### PR TITLE
Ensure we don't override a group membership.

### DIFF
--- a/og_ui/og_ui.module
+++ b/og_ui/og_ui.module
@@ -763,9 +763,8 @@ function og_ui_field_formatter_view($entity_type, $entity, $field, $instance, $l
         }
       }
       if ($private) {
-        $count = count($element);
-        $delta = $count == 0 ? 0 : $count + 1;
-        $element[$delta] = array('#markup' => '- ' . t('Private group') . ' -');
+        $element = array_values($element);
+        $element[] = array('#markup' => '- ' . t('Private group') . ' -');
       }
 
       return $element;


### PR DESCRIPTION
Reset the keys on the display, so that "- Private group -" doesn't override a value in the array.

Currently, since private groups are pulled out, the key for the elements will not be in order, so the count is giving a number within the array. This will override any groups that should be displayed with the "- Private group -" text. 
