### PR TITLE
Fix og_field_access 1.x to 2.x migration

### DIFF
--- a/includes/migrate/7200/og_roles.migrate.inc
+++ b/includes/migrate/7200/og_roles.migrate.inc
@@ -13,6 +13,8 @@ class OgMigrateRoles extends OgEntityMigration {
 
   public $tableName = 'og_role';
 
+  protected $dependencies = array('OgMigrateMembership');
+
   public $keyName = 'rid';
 
   /**


### PR DESCRIPTION
During an upgrade from OG 1.x to 2.x if you used to use OG Field Access submodule, your custom permissions are lost because OgMigrateRoles::preImport() is run while the new audience fields are not set on the group content bundles yet.
This change just declare OgMigrateMembership as dependency of OgMigrateRoles to ensure that these fields have been added to the bundles before we try to check them.
As OgMigrateMembership does not rely on OG user roles or permissions to run, that fix might not introduce any side effect.
