### PR TITLE
Do not check twice if group access has changed

### DIFF
--- a/og_access/og_access.api.php
+++ b/og_access/og_access.api.php
@@ -58,7 +58,7 @@ function hook_og_access_invoke_node_access_acquire_grants_alter(&$result, $conte
   $og_access = $wrapper->{OG_ACCESS_FIELD}->value();
   $original_og_access = $original_wrapper->{OG_ACCESS_FIELD}->value();
   if ($og_access !== $original_og_access) {
-    $result[] = TRUE;
+    $result['my_module'] = TRUE;
   }
 }
 

--- a/og_access/og_access.api.php
+++ b/og_access/og_access.api.php
@@ -14,23 +14,23 @@
 /**
  * Allow modules to mark group privacy change.
  *
- * @param &$context
- *   Array including 3 keys:
- *   'entity' - the submitted group entity.
- *   'entity_type' - String. The type of the entity that was submitted.
- *   'change_detected' - Boolean. Marks whether the group privacy changed or not.
- *                       FALSE by default, and changeable be each hook
- *                       implementation.
+ * @param array $context
+ *   Array with the following keys:
+ *   'entity': the group entity.
+ *   'entity_type':  The group type.
  */
-function hook_og_access_invoke_node_access_acquire_grants_alter(&$context) {
+function hook_og_access_invoke_node_access_acquire_grants($context) {
   $wrapper = entity_metadata_wrapper($context['entity_type'], $context['entity']);
+  if (!isset($wrapper->OG_ACCESS_FIELD)) {
+    // Group doesn't have OG access field attached to it.
+    return;
+  }
+
   $original_wrapper = entity_metadata_wrapper($context['entity_type'], $context['entity']->original);
 
   $og_access = $wrapper->{OG_ACCESS_FIELD}->value();
-  $orig_og_access = $original_wrapper->{OG_ACCESS_FIELD}->value();
-  if ($og_access !== $orig_og_access) {
-    $context['change_detected'] = TRUE;
-  }
+  $original_og_access = $original_wrapper->{OG_ACCESS_FIELD}->value();
+  return $og_access !== $original_og_access;
 }
 
 /**

--- a/og_access/og_access.api.php
+++ b/og_access/og_access.api.php
@@ -18,6 +18,9 @@
  *   Array with the following keys:
  *   'entity': the group entity.
  *   'entity_type':  The group type.
+ *
+ * @return bool
+ *   TRUE if group privacy has been changed.
  */
 function hook_og_access_invoke_node_access_acquire_grants($context) {
   $wrapper = entity_metadata_wrapper($context['entity_type'], $context['entity']);
@@ -31,6 +34,32 @@ function hook_og_access_invoke_node_access_acquire_grants($context) {
   $og_access = $wrapper->{OG_ACCESS_FIELD}->value();
   $original_og_access = $original_wrapper->{OG_ACCESS_FIELD}->value();
   return $og_access !== $original_og_access;
+}
+
+/**
+ * Allow modules to mark group privacy change.
+ *
+ * @param $result
+ *   Array of results of the hooks called before.
+ * @param array $context
+ *   Array with the following keys:
+ *   'entity': the group entity.
+ *   'entity_type':  The group type.
+ */
+function hook_og_access_invoke_node_access_acquire_grants_alter(&$result, $context) {
+  $wrapper = entity_metadata_wrapper($context['entity_type'], $context['entity']);
+  if (!isset($wrapper->OG_ACCESS_FIELD)) {
+    // Group doesn't have OG access field attached to it.
+    return;
+  }
+
+  $original_wrapper = entity_metadata_wrapper($context['entity_type'], $context['entity']->original);
+
+  $og_access = $wrapper->{OG_ACCESS_FIELD}->value();
+  $original_og_access = $original_wrapper->{OG_ACCESS_FIELD}->value();
+  if ($og_access !== $original_og_access) {
+    $result[] = TRUE;
+  }
 }
 
 /**

--- a/og_access/og_access.module
+++ b/og_access/og_access.module
@@ -269,7 +269,7 @@ function _og_access_verify_access_field_existence($node) {
  */
 function og_access_og_access_invoke_node_access_acquire_grants($context) {
   $wrapper = entity_metadata_wrapper($context['entity_type'], $context['entity']);
-  if (!isset($wrapper->OG_ACCESS_FIELD)) {
+  if (!isset($wrapper->{OG_ACCESS_FIELD})) {
     // Group doesn't have OG access field attached to it.
     return;
   }
@@ -278,6 +278,7 @@ function og_access_og_access_invoke_node_access_acquire_grants($context) {
 
   $og_access = $wrapper->{OG_ACCESS_FIELD}->value();
   $original_og_access = $original_wrapper->{OG_ACCESS_FIELD}->value();
+
   return $og_access !== $original_og_access;
 }
 
@@ -312,6 +313,7 @@ function og_access_check_node_access_grants_is_needed($entity, $entity_type) {
     'entity_type' => $entity_type,
   );
   $result = module_invoke_all('og_access_invoke_node_access_acquire_grants', $context);
+
   drupal_alter('og_access_invoke_node_access_acquire_grants', $result, $context);
 
   return in_array(TRUE, $result);

--- a/og_access/og_access.module
+++ b/og_access/og_access.module
@@ -279,7 +279,7 @@ function og_access_og_access_invoke_node_access_acquire_grants_alter(&$context) 
 }
 
 /**
- * Check if group privacy has been changed.
+ * Check whether group privacy change batch processing is needed.
  *
  * @param $entity
  *  The group entity object.
@@ -288,25 +288,18 @@ function og_access_og_access_invoke_node_access_acquire_grants_alter(&$context) 
  *
  * @return bool
  */
-function og_access_check_group_privacy_changed($entity, $entity_type) {
+function og_access_check_batch_processing_is_needed($entity, $entity_type) {
   // Check whether group privacy change batch processing is needed.
   if (!variable_get(OG_ACCESS_PRIVACY_CHANGE_BATCH_PROCESSING, TRUE)) {
     return FALSE;
   }
 
+  // Check if entity is the group.
   if (!og_is_group($entity_type, $entity)) {
     return FALSE;
   }
 
-  $wrapper = entity_metadata_wrapper($entity_type, $entity);
-  $original_wrapper = entity_metadata_wrapper($entity_type, $entity->original);
-
-  // Access was changed from/to restricted
-  if (!empty($entity->pluggable_node_access[LANGUAGE_NONE]) || !empty($entity->original->pluggable_node_access[LANGUAGE_NONE])) {
-    return TRUE;
-  }
-
-  return $wrapper->{OG_ACCESS_FIELD}->value() != $original_wrapper->{OG_ACCESS_FIELD}->value();
+  return TRUE;
 }
 
 /**
@@ -315,7 +308,7 @@ function og_access_check_group_privacy_changed($entity, $entity_type) {
  * create batch operation to update group content.
  */
 function og_access_entity_update($entity, $entity_type) {
-  if (!og_access_check_group_privacy_changed($entity, $entity_type)) {
+  if (!og_access_check_batch_processing_is_needed($entity, $entity_type)) {
     return;
   }
 

--- a/og_access/og_access.module
+++ b/og_access/og_access.module
@@ -263,23 +263,29 @@ function _og_access_verify_access_field_existence($node) {
 }
 
 /**
- * Implements hook_og_access_invoke_node_access_acquire_grants_alter().
+ * Implements hook_og_access_invoke_node_access_acquire_grants().
  *
  * Simple check whether OG_ACCESS_FIELD values was changed.
  */
-function og_access_og_access_invoke_node_access_acquire_grants_alter(&$context) {
+function og_access_og_access_invoke_node_access_acquire_grants($context) {
   $wrapper = entity_metadata_wrapper($context['entity_type'], $context['entity']);
+  if (!isset($wrapper->OG_ACCESS_FIELD)) {
+    // Group doesn't have OG access field attached to it.
+    return;
+  }
+
   $original_wrapper = entity_metadata_wrapper($context['entity_type'], $context['entity']->original);
 
   $og_access = $wrapper->{OG_ACCESS_FIELD}->value();
-  $orig_og_access = $original_wrapper->{OG_ACCESS_FIELD}->value();
-  if ($og_access !== $orig_og_access) {
-    $context['change_detected'] = TRUE;
-  }
+  $original_og_access = $original_wrapper->{OG_ACCESS_FIELD}->value();
+  return $og_access !== $original_og_access;
 }
 
 /**
- * Check whether group privacy change batch processing is needed.
+ * Check whether group access changed that require batch processing.
+ *
+ * Note that batch processing is possible only when the event is triggered from
+ * the UI.
  *
  * @param $entity
  *  The group entity object.
@@ -287,8 +293,9 @@ function og_access_og_access_invoke_node_access_acquire_grants_alter(&$context) 
  *   The group type.
  *
  * @return bool
+ *  TRUE if content permissions of group content should be rebuilt.
  */
-function og_access_check_batch_processing_is_needed($entity, $entity_type) {
+function og_access_check_node_access_grants_is_needed($entity, $entity_type) {
   // Check whether group privacy change batch processing is needed.
   if (!variable_get(OG_ACCESS_PRIVACY_CHANGE_BATCH_PROCESSING, TRUE)) {
     return FALSE;
@@ -299,21 +306,30 @@ function og_access_check_batch_processing_is_needed($entity, $entity_type) {
     return FALSE;
   }
 
-  return TRUE;
+  // Check for access change.
+  $context = array(
+    'entity' => $entity,
+    'entity_type' => $entity_type,
+  );
+  $result = module_invoke_all('og_access_invoke_node_access_acquire_grants', $context);
+  drupal_alter('og_access_invoke_node_access_acquire_grants', $result, $context);
+
+  return in_array(TRUE, $result);
 }
 
 /**
  * Implements hook_entity_update().
+ *
  * In case the group entity was marked with group privacy change,
  * create batch operation to update group content.
  */
 function og_access_entity_update($entity, $entity_type) {
-  if (!og_access_check_batch_processing_is_needed($entity, $entity_type)) {
+  if (!og_access_check_node_access_grants_is_needed($entity, $entity_type)) {
     return;
   }
 
   // Handle group privacy change.
-  og_access_handle_group_privacy_change($entity, $entity_type);
+  og_access_handle_group_privacy_change($entity_type, $entity);
 }
 
 /**
@@ -323,30 +339,18 @@ function og_access_entity_update($entity, $entity_type) {
  * changed as well. Since a group might have big amount of content, it is being
  * handled using Batch API.
  *
- * @param $entity
- *   The group entity object.
+ *
  * @param $entity_type
  *   The group type.
+ * @param $entity
+ *   The group entity object.
  */
-function og_access_handle_group_privacy_change($entity, $entity_type) {
-
-  // Check for privacy change.
-  $context = array(
-    'change_detected' => FALSE,
-    'entity' => $entity,
-    'entity_type' => $entity_type,
-  );
-  drupal_alter('og_access_invoke_node_access_acquire_grants', $context);
-  if (!$context['change_detected']) {
-    // If no change detected there is nothing to handle.
-    return;
-  }
-
-  $wrapper = entity_metadata_wrapper($entity_type, $entity);
+function og_access_handle_group_privacy_change($entity_type, $entity) {
+  list($id) = entity_extract_ids($entity_type, $entity);
   $batch = array(
     'title' => t('Handle group privacy change'),
     'operations' => array(
-      array('og_access_invoke_node_access_acquire_grants', array($entity_type, $wrapper->getIdentifier())),
+      array('og_access_invoke_node_access_acquire_grants', array($entity_type, $id)),
     ),
   );
   batch_set($batch);


### PR DESCRIPTION
We don't need to check whether privacy was changed twice. We already checking it using drupal_alter. Just need to check if this is actually a group and that batch processing is needed. 
