### PR TITLE
Fix notice when trying to access a membership that was just deleted.

### DIFF
--- a/og.module
+++ b/og.module
@@ -3556,7 +3556,9 @@ function og_get_groups_by_user($account = NULL, $group_type = NULL) {
   }
 
   foreach ($og_memberships as $og_membership) {
-    $gids[$og_membership->group_type][$og_membership->gid] = $og_membership->gid;
+    if (!empty($og_membership)) {
+      $gids[$og_membership->group_type][$og_membership->gid] = $og_membership->gid;
+    }
   }
 
   if (empty($group_type)) {


### PR DESCRIPTION
I'm getting the following notice when I delete an OG Membership and then call `og_get_groups_by_user()` passing in a user that was referencing the membership that was just deleted:

> Notice: Trying to get property of non-object in sites/all/modules/contrib/og/og.module line 3552

`og_get_groups_by_user()` assumes that the array of memberships that is returned from the entity metadata wrapper always contains valid entities but this is not the case. If an OG Membership entity is deleted, in `EntityAPIController::delete()` the entity is unset from the static entity cache from `DrupalDefaultEntityController`. Other entities that are statically cached and reference this entity will now reference NULL instead.

This is the code in question from `og_get_groups_by_user()`:

```
  // Get the wrapper for a user object that was referencing the OG Membership entity
  // that was removed. The user object is also statically cached.
  $wrapper = entity_metadata_wrapper('user', $account->uid);
  $og_memberships = $wrapper->{'og_membership__' . OG_STATE_ACTIVE}->value();
  // This check fails to detect that the reference is now empty, since the array contains
  // array(0 => NULL) which evaluates to TRUE.
  if (!$og_memberships) {
    return;
  }

  // This loop assumes that the memberships are valid, but $og_membership is now NULL.
  foreach ($og_memberships as $og_membership) {
      $gids[$og_membership->group_type][$og_membership->gid] = $og_membership->gid;
  }
```
