### PR TITLE
Do not load menu item just before determining context handler to prevent...

### DIFF
--- a/og_context/og_context.module
+++ b/og_context/og_context.module
@@ -366,10 +366,6 @@ function og_context_determine_context($group_type, $item = NULL, $check_access =
     return;
   }
 
-  if (empty($item)) {
-    $item = menu_get_item();
-  }
-
   $providers = og_context_negotiation_info();
   foreach ($enabled_providers as $name => $ignore) {
     if (empty($providers[$name])) {
@@ -379,7 +375,7 @@ function og_context_determine_context($group_type, $item = NULL, $check_access =
     $invoke = FALSE;
     if (!empty($provider['menu path'])) {
       foreach ($provider['menu path'] as $path) {
-        if (strpos($item['path'], $path) === 0) {
+        if (strpos(current_path(), $path) === 0) {
           $invoke = TRUE;
           // Path matches, so we can break.
           break;


### PR DESCRIPTION
... premature access denial due to empty og context.
