### PR TITLE
Fix checking whether user has access to the group in og_context()

### DIFF
--- a/og_context/og_context.module
+++ b/og_context/og_context.module
@@ -215,9 +215,8 @@ function og_context($group_type = 'node', $group = NULL, $account = NULL, $check
 
   $context = &drupal_static(__FUNCTION__, array());
 
-  if (empty($context[$cache_key])) {
+  if (!array_key_exists($cache_key, $context)) {
     // Mark that this context hasn't been checked yet.
-
     $context[$cache_key] = FALSE;
   }
 

--- a/og_context/og_context.module
+++ b/og_context/og_context.module
@@ -199,19 +199,21 @@ function og_context($group_type = 'node', $group = NULL, $account = NULL, $check
   global $user;
   // User account is sent.
   $account = $account ? $account : user_load($user->uid);
+  if (!$check_access) {
+    // Check if we already have context only if we don't have to check user's
+    // permissions to access the current group.
+    $context = &drupal_static(__FUNCTION__, FALSE);
+    if (empty($group) && $context !== FALSE) {
+      // Determine if we can return cached values.
+      if (empty($context)) {
+        // We already tried to find a context, but couldn't.
+        return FALSE;
+      }
 
-  $context = &drupal_static(__FUNCTION__, FALSE);
-
-  if (empty($group) && $context !== FALSE) {
-    // Determine if we can return cached values.
-    if (empty($context)) {
-      // We already tried to find a context, but couldn't.
-      return FALSE;
-    }
-
-    if ($context['group_type'] == $group_type) {
-      // Return the cached values.
-      return $context;
+      if ($context['group_type'] == $group_type) {
+        // Return the cached values.
+        return $context;
+      }
     }
   }
 
@@ -407,7 +409,7 @@ function og_context_determine_context($group_type, $item = NULL, $check_access =
 
       // Check if user has access to the group.
       $group = entity_load_single($group_type, $check_gid);
-      if (entity_access('view', $group_type, $group)) {
+      if (!$check_access || entity_access('view', $group_type, $group)) {
         // We found an accessible context, so we can break.
         $gid = $check_gid;
         break;

--- a/og_context/og_context.module
+++ b/og_context/og_context.module
@@ -199,27 +199,44 @@ function og_context($group_type = 'node', $group = NULL, $account = NULL, $check
   global $user;
   // User account is sent.
   $account = $account ? $account : user_load($user->uid);
-  if (!$check_access) {
-    // Check if we already have context only if we don't have to check user's
-    // permissions to access the current group.
-    $context = &drupal_static(__FUNCTION__, FALSE);
-    if (empty($group) && $context !== FALSE) {
-      // Determine if we can return cached values.
-      if (empty($context)) {
-        // We already tried to find a context, but couldn't.
-        return FALSE;
-      }
 
-      if ($context['group_type'] == $group_type) {
-        // Return the cached values.
-        return $context;
-      }
+  $id = FALSE;
+  if ($group) {
+    list($id) = entity_extract_ids($group_type, $group);
+  }
+
+  $cache_keys = array(
+    $group_type,
+    $id,
+    $account->uid,
+    $check_access,
+  );
+  $cache_key = implode(':', $cache_keys);
+
+  $context = &drupal_static(__FUNCTION__, array());
+
+  if (empty($context[$cache_key]) && $context[$cache_key] !== FALSE) {
+    // Mark that this context hasn't been checked yet.
+
+    $context[$cache_key] = FALSE;
+  }
+
+  if (empty($group) && $context[$cache_key] !== FALSE) {
+    // Determine if we can return cached values.
+    if (empty($context[$cache_key])) {
+      // We already tried to find a context, but couldn't.
+      return FALSE;
+    }
+
+    if ($context[$cache_key]['group_type'] == $group_type) {
+      // Return the cached values.
+      return $context[$cache_key];
     }
   }
 
   // Set the context to array, so we can know this function has been already
   // executed.
-  $context = array();
+  $context[$cache_key] = array();
 
   if (!empty($group)) {
     if (!og_is_group($group_type, $group)) {
@@ -233,18 +250,18 @@ function og_context($group_type = 'node', $group = NULL, $account = NULL, $check
     }
 
     list($id) = entity_extract_ids($group_type, $group);
-    $context = array('group_type' => $group_type, 'gid' => $id);
+    $context[$cache_key] = array('group_type' => $group_type, 'gid' => $id);
   }
   // Get context from context handlers.
   elseif ($gid = og_context_determine_context($group_type, NULL, $check_access)) {
-    $context = array('group_type' => $group_type, 'gid' => $gid);
+    $context[$cache_key] = array('group_type' => $group_type, 'gid' => $gid);
     if ($user->uid) {
       // Save the group ID in the authenticated user's session.
       $_SESSION['og_context'] = array('group_type' => $group_type, 'gid' => $gid);
     }
   }
 
-  return $context;
+  return $context[$cache_key];
 }
 
 /**

--- a/og_context/og_context.module
+++ b/og_context/og_context.module
@@ -215,7 +215,7 @@ function og_context($group_type = 'node', $group = NULL, $account = NULL, $check
 
   $context = &drupal_static(__FUNCTION__, array());
 
-  if (empty($context[$cache_key]) && $context[$cache_key] !== FALSE) {
+  if (empty($context[$cache_key])) {
     // Mark that this context hasn't been checked yet.
 
     $context[$cache_key] = FALSE;

--- a/og_context/og_context.test
+++ b/og_context/og_context.test
@@ -58,5 +58,7 @@ class OgContextTestCase extends DrupalWebTestCase {
 
     // Other user should not get the group context
     $this->assertFalse(og_context('node', $this->group_node, $this->user2));
+    // Anybody should get existing context if checking access is FALSE.
+    $this->assertTrue(og_context('node', $this->group_node, $this->user2, FALSE));
   }
 }


### PR DESCRIPTION
1. Check if we already have context only if we don't have to check user's permissions to access the current group.
2. Check whether user has access to the group if it's necessary.
