### PR TITLE
Getting referencable entities only works for nodes.

### DIFF
--- a/plugins/entityreference/selection/OgSelectionHandler.class.php
+++ b/plugins/entityreference/selection/OgSelectionHandler.class.php
@@ -125,7 +125,7 @@ class OgSelectionHandler extends EntityReference_SelectionHandler_Generic {
           }
           elseif (!empty($node->nid) && (og_user_access($group_type, $gid, "update any $node_type content") || ($user->uid == $node->uid && og_user_access($group_type, $gid, "update own $node_type content")))) {
             $node_groups = isset($node_groups) ? $node_groups : og_get_entity_groups('node', $node->nid);
-            if (in_array($gid, $node_groups['node'])) {
+            if (in_array($gid, $node_groups[$group_type])) {
               $ids[] = $gid;
             }
           }


### PR DESCRIPTION
When checking the user's edit permisssion in buildEntityFieldQuery, things break when using non-node groups. Use $group_type instead.
