### PR TITLE
Issue #34: Trimmed version of menu_get_path() as comparison.

### DIFF
--- a/og_context/og_context.module
+++ b/og_context/og_context.module
@@ -386,9 +386,7 @@ function og_context_determine_context($group_type, $item = NULL, $check_access =
 
   $providers = og_context_negotiation_info();
   if (empty($item)) {
-    if (!$item = _og_context_menu_get_untranslated_item(current_path())) {
-      return;
-    }
+    $item = _og_context_menu_get_untranslated_item(current_path());
   }
 
   foreach ($enabled_providers as $name => $ignore) {

--- a/og_context/og_context.module
+++ b/og_context/og_context.module
@@ -200,24 +200,42 @@ function og_context($group_type = 'node', $group = NULL, $account = NULL, $check
   // User account is sent.
   $account = $account ? $account : user_load($user->uid);
 
-  $context = &drupal_static(__FUNCTION__, FALSE);
+  $id = FALSE;
+  if ($group) {
+    list($id) = entity_extract_ids($group_type, $group);
+  }
 
-  if (empty($group) && $context !== FALSE) {
+  $cache_keys = array(
+    $group_type,
+    $id,
+    $account->uid,
+    $check_access,
+  );
+  $cache_key = implode(':', $cache_keys);
+
+  $context = &drupal_static(__FUNCTION__, array());
+
+  if (!array_key_exists($cache_key, $context)) {
+    // Mark that this context hasn't been checked yet.
+    $context[$cache_key] = FALSE;
+  }
+
+  if (empty($group) && $context[$cache_key] !== FALSE) {
     // Determine if we can return cached values.
-    if (empty($context)) {
+    if (empty($context[$cache_key])) {
       // We already tried to find a context, but couldn't.
       return FALSE;
     }
 
-    if ($context['group_type'] == $group_type) {
+    if ($context[$cache_key]['group_type'] == $group_type) {
       // Return the cached values.
-      return $context;
+      return $context[$cache_key];
     }
   }
 
   // Set the context to array, so we can know this function has been already
   // executed.
-  $context = array();
+  $context[$cache_key] = array();
 
   if (!empty($group)) {
     if (!og_is_group($group_type, $group)) {
@@ -231,18 +249,18 @@ function og_context($group_type = 'node', $group = NULL, $account = NULL, $check
     }
 
     list($id) = entity_extract_ids($group_type, $group);
-    $context = array('group_type' => $group_type, 'gid' => $id);
+    $context[$cache_key] = array('group_type' => $group_type, 'gid' => $id);
   }
   // Get context from context handlers.
   elseif ($gid = og_context_determine_context($group_type, NULL, $check_access)) {
-    $context = array('group_type' => $group_type, 'gid' => $gid);
+    $context[$cache_key] = array('group_type' => $group_type, 'gid' => $gid);
     if ($user->uid) {
       // Save the group ID in the authenticated user's session.
       $_SESSION['og_context'] = array('group_type' => $group_type, 'gid' => $gid);
     }
   }
 
-  return $context;
+  return $context[$cache_key];
 }
 
 /**
@@ -407,7 +425,7 @@ function og_context_determine_context($group_type, $item = NULL, $check_access =
 
       // Check if user has access to the group.
       $group = entity_load_single($group_type, $check_gid);
-      if (entity_access('view', $group_type, $group)) {
+      if (!$check_access || entity_access('view', $group_type, $group)) {
         // We found an accessible context, so we can break.
         $gid = $check_gid;
         break;

--- a/og_context/og_context.module
+++ b/og_context/og_context.module
@@ -367,6 +367,23 @@ function og_context_determine_context($group_type, $item = NULL, $check_access =
   }
 
   $providers = og_context_negotiation_info();
+
+  // Don't call menu_get_item() directly here as it may result in a nested call
+  // to og_context() due to access check and dynamic loading. Instead, only use
+  // the parts of menu_get_item() that gets the router item and use it for
+  // comparison.
+  $current_path = current_path();
+  $original_map = arg(NULL, $current_path);
+  $parts = array_slice($original_map, 0, MENU_MAX_PARTS);
+  $ancestors = menu_get_ancestors($parts);
+  $router_item = db_query_range('SELECT * FROM {menu_router} WHERE path IN (:ancestors) ORDER BY fit DESC', 0, 1, array(':ancestors' => $ancestors))->fetchAssoc();
+  if ($router_item) {
+    drupal_alter('menu_get_item', $router_item, $current_path, $original_map);
+  }
+  else {
+    return;
+  }
+
   foreach ($enabled_providers as $name => $ignore) {
     if (empty($providers[$name])) {
       continue;
@@ -375,7 +392,7 @@ function og_context_determine_context($group_type, $item = NULL, $check_access =
     $invoke = FALSE;
     if (!empty($provider['menu path'])) {
       foreach ($provider['menu path'] as $path) {
-        if (strpos(current_path(), $path) === 0) {
+        if (strpos($router_item['path'], $path) === 0) {
           $invoke = TRUE;
           // Path matches, so we can break.
           break;

--- a/og_context/og_context.module
+++ b/og_context/og_context.module
@@ -370,7 +370,7 @@ function og_context_provider_weight($provider) {
  *   The entity type of the group. For example, "node" or "user".
  * @param $item
  *   Optional; A menu item that context should be extracted from. If empty
- *   defaults to the current menu item by using menu_get_item().
+ *   defaults to the untranslated menu item matching the current path.
  * @param bool $check_access
  *   Determines if access to the group should be done. Defaults to TRUE.
  *
@@ -385,8 +385,10 @@ function og_context_determine_context($group_type, $item = NULL, $check_access =
   }
 
   $providers = og_context_negotiation_info();
-  if (!$router_item = _og_context_menu_get_untranslated_item(current_path())) {
-    return;
+  if (empty($item)) {
+    if (!$item = _og_context_menu_get_untranslated_item(current_path())) {
+      return;
+    }
   }
 
   foreach ($enabled_providers as $name => $ignore) {
@@ -397,7 +399,7 @@ function og_context_determine_context($group_type, $item = NULL, $check_access =
     $invoke = FALSE;
     if (!empty($provider['menu path'])) {
       foreach ($provider['menu path'] as $path) {
-        if (strpos($router_item['path'], $path) === 0) {
+        if (strpos($item['path'], $path) === 0) {
           $invoke = TRUE;
           // Path matches, so we can break.
           break;

--- a/og_context/og_context.module
+++ b/og_context/og_context.module
@@ -384,10 +384,6 @@ function og_context_determine_context($group_type, $item = NULL, $check_access =
     return;
   }
 
-  if (empty($item)) {
-    $item = menu_get_item();
-  }
-
   $providers = og_context_negotiation_info();
   if (!$router_item = _og_context_menu_get_untranslated_item(current_path())) {
     return;

--- a/og_context/og_context.module
+++ b/og_context/og_context.module
@@ -367,7 +367,7 @@ function og_context_determine_context($group_type, $item = NULL, $check_access =
   }
 
   $providers = og_context_negotiation_info();
-  if (!$router_item = _og_context_get_menu_router_item(current_path())) {
+  if (!$router_item = _og_context_menu_get_untranslated_item(current_path())) {
     return;
   }
 
@@ -643,13 +643,18 @@ function _og_context_views_page_access($group_type, $perm, $group_id_arg = FALSE
  * @return array
  *   The matching menu router item.
  */
-function _og_context_get_menu_router_item($path) {
-  $original_map = arg(NULL, $path);
-  $parts = array_slice($original_map, 0, MENU_MAX_PARTS);
-  $ancestors = menu_get_ancestors($parts);
-  $router_item = db_query_range('SELECT * FROM {menu_router} WHERE path IN (:ancestors) ORDER BY fit DESC', 0, 1, array(':ancestors' => $ancestors))->fetchAssoc();
-  if ($router_item) {
-    drupal_alter('menu_get_item', $router_item, $path, $original_map);
+function _og_context_menu_get_untranslated_item($path) {
+  $router_items = &drupal_static(__FUNCTION__);
+
+  if (!isset($router_items[$path])) {
+    $original_map = arg(NULL, $path);
+    $parts = array_slice($original_map, 0, MENU_MAX_PARTS);
+    $ancestors = menu_get_ancestors($parts);
+    $router_item = db_query_range('SELECT * FROM {menu_router} WHERE path IN (:ancestors) ORDER BY fit DESC', 0, 1, array(':ancestors' => $ancestors))->fetchAssoc();
+    if ($router_item) {
+      drupal_alter('menu_get_item', $router_item, $path, $original_map);
+    }
+    $router_items[$path] = $router_item;
   }
-  return $router_item;
+  return $router_items[$path];
 }

--- a/og_context/og_context.module
+++ b/og_context/og_context.module
@@ -366,6 +366,10 @@ function og_context_determine_context($group_type, $item = NULL, $check_access =
     return;
   }
 
+  if (empty($item)) {
+    $item = menu_get_item();
+  }
+
   $providers = og_context_negotiation_info();
   foreach ($enabled_providers as $name => $ignore) {
     if (empty($providers[$name])) {
@@ -375,7 +379,7 @@ function og_context_determine_context($group_type, $item = NULL, $check_access =
     $invoke = FALSE;
     if (!empty($provider['menu path'])) {
       foreach ($provider['menu path'] as $path) {
-        if (strpos(current_path(), $path) === 0) {
+        if (strpos($item['path'], $path) === 0) {
           $invoke = TRUE;
           // Path matches, so we can break.
           break;

--- a/og_context/og_context.module
+++ b/og_context/og_context.module
@@ -389,6 +389,23 @@ function og_context_determine_context($group_type, $item = NULL, $check_access =
   }
 
   $providers = og_context_negotiation_info();
+
+  // Don't call menu_get_item() directly here as it may result in a nested call
+  // to og_context() due to access check and dynamic loading. Instead, only use
+  // the parts of menu_get_item() that gets the router item and use it for
+  // comparison.
+  $current_path = current_path();
+  $original_map = arg(NULL, $current_path);
+  $parts = array_slice($original_map, 0, MENU_MAX_PARTS);
+  $ancestors = menu_get_ancestors($parts);
+  $router_item = db_query_range('SELECT * FROM {menu_router} WHERE path IN (:ancestors) ORDER BY fit DESC', 0, 1, array(':ancestors' => $ancestors))->fetchAssoc();
+  if ($router_item) {
+    drupal_alter('menu_get_item', $router_item, $current_path, $original_map);
+  }
+  else {
+    return;
+  }
+
   foreach ($enabled_providers as $name => $ignore) {
     if (empty($providers[$name])) {
       continue;
@@ -397,7 +414,7 @@ function og_context_determine_context($group_type, $item = NULL, $check_access =
     $invoke = FALSE;
     if (!empty($provider['menu path'])) {
       foreach ($provider['menu path'] as $path) {
-        if (strpos($item['path'], $path) === 0) {
+        if (strpos($router_item['path'], $path) === 0) {
           $invoke = TRUE;
           // Path matches, so we can break.
           break;

--- a/og_context/og_context.module
+++ b/og_context/og_context.module
@@ -389,20 +389,7 @@ function og_context_determine_context($group_type, $item = NULL, $check_access =
   }
 
   $providers = og_context_negotiation_info();
-
-  // Don't call menu_get_item() directly here as it may result in a nested call
-  // to og_context() due to access check and dynamic loading. Instead, only use
-  // the parts of menu_get_item() that gets the router item and use it for
-  // comparison.
-  $current_path = current_path();
-  $original_map = arg(NULL, $current_path);
-  $parts = array_slice($original_map, 0, MENU_MAX_PARTS);
-  $ancestors = menu_get_ancestors($parts);
-  $router_item = db_query_range('SELECT * FROM {menu_router} WHERE path IN (:ancestors) ORDER BY fit DESC', 0, 1, array(':ancestors' => $ancestors))->fetchAssoc();
-  if ($router_item) {
-    drupal_alter('menu_get_item', $router_item, $current_path, $original_map);
-  }
-  else {
+  if (!$router_item = _og_context_get_menu_router_item(current_path())) {
     return;
   }
 
@@ -664,4 +651,27 @@ function _og_context_views_page_access($group_type, $perm, $group_id_arg = FALSE
     // Try to get context.
     return og_user_access($group_type, $group['gid'], $perm);
   }
+}
+
+/**
+ * Helper function to get the raw menu router for current path.
+ *
+ * This truncated version of menu_get_item() stops processing the matching
+ * router item prior to dynamic path translation and access control.
+ *
+ * @param string $path
+ *   Fully expanded drupal path, e.g. 'node/5'.
+ *
+ * @return array
+ *   The matching menu router item.
+ */
+function _og_context_get_menu_router_item($path) {
+  $original_map = arg(NULL, $path);
+  $parts = array_slice($original_map, 0, MENU_MAX_PARTS);
+  $ancestors = menu_get_ancestors($parts);
+  $router_item = db_query_range('SELECT * FROM {menu_router} WHERE path IN (:ancestors) ORDER BY fit DESC', 0, 1, array(':ancestors' => $ancestors))->fetchAssoc();
+  if ($router_item) {
+    drupal_alter('menu_get_item', $router_item, $path, $original_map);
+  }
+  return $router_item;
 }

--- a/og_context/og_context.module
+++ b/og_context/og_context.module
@@ -367,20 +367,7 @@ function og_context_determine_context($group_type, $item = NULL, $check_access =
   }
 
   $providers = og_context_negotiation_info();
-
-  // Don't call menu_get_item() directly here as it may result in a nested call
-  // to og_context() due to access check and dynamic loading. Instead, only use
-  // the parts of menu_get_item() that gets the router item and use it for
-  // comparison.
-  $current_path = current_path();
-  $original_map = arg(NULL, $current_path);
-  $parts = array_slice($original_map, 0, MENU_MAX_PARTS);
-  $ancestors = menu_get_ancestors($parts);
-  $router_item = db_query_range('SELECT * FROM {menu_router} WHERE path IN (:ancestors) ORDER BY fit DESC', 0, 1, array(':ancestors' => $ancestors))->fetchAssoc();
-  if ($router_item) {
-    drupal_alter('menu_get_item', $router_item, $current_path, $original_map);
-  }
-  else {
+  if (!$router_item = _og_context_get_menu_router_item(current_path())) {
     return;
   }
 
@@ -642,4 +629,27 @@ function _og_context_views_page_access($group_type, $perm, $group_id_arg = FALSE
     // Try to get context.
     return og_user_access($group_type, $group['gid'], $perm);
   }
+}
+
+/**
+ * Helper function to get the raw menu router for current path.
+ *
+ * This truncated version of menu_get_item() stops processing the matching
+ * router item prior to dynamic path translation and access control.
+ *
+ * @param string $path
+ *   Fully expanded drupal path, e.g. 'node/5'.
+ *
+ * @return array
+ *   The matching menu router item.
+ */
+function _og_context_get_menu_router_item($path) {
+  $original_map = arg(NULL, $path);
+  $parts = array_slice($original_map, 0, MENU_MAX_PARTS);
+  $ancestors = menu_get_ancestors($parts);
+  $router_item = db_query_range('SELECT * FROM {menu_router} WHERE path IN (:ancestors) ORDER BY fit DESC', 0, 1, array(':ancestors' => $ancestors))->fetchAssoc();
+  if ($router_item) {
+    drupal_alter('menu_get_item', $router_item, $path, $original_map);
+  }
+  return $router_item;
 }

--- a/og_context/og_context.module
+++ b/og_context/og_context.module
@@ -389,7 +389,7 @@ function og_context_determine_context($group_type, $item = NULL, $check_access =
   }
 
   $providers = og_context_negotiation_info();
-  if (!$router_item = _og_context_get_menu_router_item(current_path())) {
+  if (!$router_item = _og_context_menu_get_untranslated_item(current_path())) {
     return;
   }
 
@@ -665,13 +665,18 @@ function _og_context_views_page_access($group_type, $perm, $group_id_arg = FALSE
  * @return array
  *   The matching menu router item.
  */
-function _og_context_get_menu_router_item($path) {
-  $original_map = arg(NULL, $path);
-  $parts = array_slice($original_map, 0, MENU_MAX_PARTS);
-  $ancestors = menu_get_ancestors($parts);
-  $router_item = db_query_range('SELECT * FROM {menu_router} WHERE path IN (:ancestors) ORDER BY fit DESC', 0, 1, array(':ancestors' => $ancestors))->fetchAssoc();
-  if ($router_item) {
-    drupal_alter('menu_get_item', $router_item, $path, $original_map);
+function _og_context_menu_get_untranslated_item($path) {
+  $router_items = &drupal_static(__FUNCTION__);
+
+  if (!isset($router_items[$path])) {
+    $original_map = arg(NULL, $path);
+    $parts = array_slice($original_map, 0, MENU_MAX_PARTS);
+    $ancestors = menu_get_ancestors($parts);
+    $router_item = db_query_range('SELECT * FROM {menu_router} WHERE path IN (:ancestors) ORDER BY fit DESC', 0, 1, array(':ancestors' => $ancestors))->fetchAssoc();
+    if ($router_item) {
+      drupal_alter('menu_get_item', $router_item, $path, $original_map);
+    }
+    $router_items[$path] = $router_item;
   }
-  return $router_item;
+  return $router_items[$path];
 }

--- a/og_context/og_context.module
+++ b/og_context/og_context.module
@@ -384,11 +384,11 @@ function og_context_determine_context($group_type, $item = NULL, $check_access =
     return;
   }
 
-  $providers = og_context_negotiation_info();
   if (empty($item)) {
     $item = _og_context_menu_get_untranslated_item(current_path());
   }
 
+  $providers = og_context_negotiation_info();
   foreach ($enabled_providers as $name => $ignore) {
     if (empty($providers[$name])) {
       continue;

--- a/og_context/og_context.test
+++ b/og_context/og_context.test
@@ -58,5 +58,7 @@ class OgContextTestCase extends DrupalWebTestCase {
 
     // Other user should not get the group context
     $this->assertFalse(og_context('node', $this->group_node, $this->user2));
+    // Anybody should get existing context if checking access is FALSE.
+    $this->assertTrue(og_context('node', $this->group_node, $this->user2, FALSE));
   }
 }

--- a/og_ui/og_ui.module
+++ b/og_ui/og_ui.module
@@ -1116,6 +1116,16 @@ function og_ui_get_group_admin($entity_type, $etid) {
   if (!ctype_digit($etid)) {
     return array();
   }
+  // ensure we are invoking this on something worth doing it on
+  $entity = entity_load_single($entity_type, $etid);
+  $entity_info = entity_get_info($entity_type);
+  // if this isn't a group type, skip invoking admin modules
+  if (empty($entity_info['entity keys']['bundle']) || !og_is_group_type($entity_type, $entity->{$entity_info['entity keys']['bundle']})) {
+    $cache["$entity_type:$etid"] = FALSE;
+    return FALSE;
+  }
+  
+
   $data = module_invoke_all('og_ui_get_group_admin', $entity_type, $etid);
 
   // Allow other modules to alter the menu items.


### PR DESCRIPTION
This has the same functionality as pre #28, only using a really basic version of menu_get_item.
### Remaining tasks
- Tests needed (I'm not the guy here)
- ~~Maybe extract this code to an internal function.~~
- ~~Add static cache of found menu router items?~~
- ~~Rename function to `_og_context_menu_get_(unprocessed|untranslated|raw)_item()`~~ (Went for `_og_context_menu_get_untranslated_item()` to better match the fact that `_menu_translate` isn't called).
