### PR TITLE
og_ui reduce memory footprint on every page in the system!

### DIFF
--- a/og_ui/og_ui.module
+++ b/og_ui/og_ui.module
@@ -1116,6 +1116,15 @@ function og_ui_get_group_admin($entity_type, $etid) {
   if (!ctype_digit($etid)) {
     return array();
   }
+  // ensure we are invoking this on something worth doing it on
+  $entity = entity_load_single($entity_type, $etid);
+  $entity_info = entity_get_info($entity_type);
+  // if this isn't a group type, skip invoking admin modules
+  if (!og_is_group_type($entity_type, $entity->{$entity_info['entity keys']['bundle']})) {
+    $cache["$entity_type:$etid"] = FALSE;
+    return FALSE;
+  }
+
   $data = module_invoke_all('og_ui_get_group_admin', $entity_type, $etid);
 
   // Allow other modules to alter the menu items.

--- a/og_ui/og_ui.module
+++ b/og_ui/og_ui.module
@@ -1120,10 +1120,11 @@ function og_ui_get_group_admin($entity_type, $etid) {
   $entity = entity_load_single($entity_type, $etid);
   $entity_info = entity_get_info($entity_type);
   // if this isn't a group type, skip invoking admin modules
-  if (!og_is_group_type($entity_type, $entity->{$entity_info['entity keys']['bundle']})) {
+  if (empty($entity_info['entity keys']['bundle']) || !og_is_group_type($entity_type, $entity->{$entity_info['entity keys']['bundle']})) {
     $cache["$entity_type:$etid"] = FALSE;
     return FALSE;
   }
+  
 
   $data = module_invoke_all('og_ui_get_group_admin', $entity_type, $etid);
 


### PR DESCRIPTION
In this blog post I did for memory profiling https://drupal.psu.edu/content/memory-profiling-hooks I went through and found the memory used by every hook in my drupal site. From there I found that when og_ui is enabled, it's access callback is being fired on every node even if its NOT a group type -- og_ui_get_group_admin doesn't check to see if the bundle of the current entity is one that is actually a group_type.

This PR should reduce the memory footprint of og_ui on every page load and in my own testing it reduced the memory required to generate the page by 314.48 KB (because of all the hook invoking this does otherwise).
