### PR TITLE
Fixed issue with entity metadata wrapper not returning correct group value in og_is_group().

### DIFF
--- a/og.module
+++ b/og.module
@@ -1818,7 +1818,8 @@ function og_is_group($entity_type, $entity) {
   if (!field_info_instance($entity_type, OG_GROUP_FIELD, $bundle)) {
     return variable_get("og_is_group__{$entity_type}__{$bundle}", FALSE);
   }
-  return !empty($wrapper->{OG_GROUP_FIELD}) && $wrapper->{OG_GROUP_FIELD}->value();
+  $entity = $wrapper->value();
+  return !empty($entity->{OG_GROUP_FIELD}) && $entity->{OG_GROUP_FIELD}[$entity->language][0]['value'];
 }
 
 


### PR DESCRIPTION
This is a strange issue, and I'm not sure if it's actually an issue with the entity API. When I am saving a new node and select it to be in a certain group (the group is a node), then it says "The referenced group (node: 4) is invalid." and doesn't save the node. If I get "$wrapper->value()" and inspect the entity object, the group value is set to 1 (which it should be). However, "$wrapper->{OG_GROUP_FIELD}->value()" returns blank.
