### PR TITLE
Checking user access for og_get_groups_by_user() and og_get_entity_groups().

### DIFF
--- a/og.module
+++ b/og.module
@@ -2294,9 +2294,9 @@ function og_user_access_entity($perm, $entity_type, $entity, $account = NULL) {
  */
 function og_get_entity_groups($entity_type = 'user', $entity = NULL, $states = array(OG_STATE_ACTIVE), $field_name = NULL, $access_check = FALSE) {
   $cache = &drupal_static(__FUNCTION__, array());
+  global $user;
 
   if ($entity_type == 'user' && empty($entity)) {
-    global $user;
     $entity = clone $user;
   }
   if (is_object($entity)) {
@@ -2349,15 +2349,14 @@ function og_get_entity_groups($entity_type = 'user', $entity = NULL, $states = a
     ->execute()
     ->fetchAll();
 
-  $account = user_load($id);
+  $account = $entity_type == 'user' ? user_load($id) : NULL;
   foreach ($result as $row) {
-    foreach (entity_load($row->group_type, array($row->gid)) as $group) {
-      if ($access_check && !entity_access('view', $row->group_type, $group, $account)) {
-        // User doesn't have access to the group.
-        continue;
-      }
-      $cache[$identifier][$row->group_type][$row->id] = $row->gid;
+    $group = entity_load_single($row->group_type, $row->gid);
+    if ($access_check && $account && !entity_access('view', $row->group_type, $group, $account)) {
+      // User doesn't have access to the group.
+      continue;
     }
+    $cache[$identifier][$row->group_type][$row->id] = $row->gid;
   }
 
   return $cache[$identifier];

--- a/og.module
+++ b/og.module
@@ -2349,12 +2349,15 @@ function og_get_entity_groups($entity_type = 'user', $entity = NULL, $states = a
     ->execute()
     ->fetchAll();
 
+  $account = user_load($id);
   foreach ($result as $row) {
-    if ($access_check && !entity_access('view', $row->group_type, entity_load_single($row->group_type, $row->gid), user_load($id))) {
-      // User doesn't have access to the group.
-      continue;
+    foreach (entity_load($row->group_type, array($row->gid)) as $group) {
+      if ($access_check && !entity_access('view', $row->group_type, $group, $account)) {
+        // User doesn't have access to the group.
+        continue;
+      }
+      $cache[$identifier][$row->group_type][$row->id] = $row->gid;
     }
-    $cache[$identifier][$row->group_type][$row->id] = $row->gid;
   }
 
   return $cache[$identifier];

--- a/og.module
+++ b/og.module
@@ -2351,12 +2351,19 @@ function og_get_entity_groups($entity_type = 'user', $entity = NULL, $states = a
 
   $account = $entity_type == 'user' ? user_load($id) : NULL;
   foreach ($result as $row) {
-    $group = entity_load_single($row->group_type, $row->gid);
-    if ($access_check && $account && !entity_access('view', $row->group_type, $group, $account)) {
-      // User doesn't have access to the group.
+
+    $groups = entity_load($row->group_type, array($row->gid));
+    if (empty($groups)) {
+      $cache[$identifier][$row->group_type][$row->id] = $row->gid;
       continue;
     }
-    $cache[$identifier][$row->group_type][$row->id] = $row->gid;
+    foreach ($groups as $group) {
+      if (!empty($group) && $access_check && $account && !entity_access('view', $row->group_type, $group, $account)) {
+        // User doesn't have access to the group.
+        continue;
+      }
+      $cache[$identifier][$row->group_type][$row->id] = $row->gid;
+    }
   }
 
   return $cache[$identifier];

--- a/og.module
+++ b/og.module
@@ -2285,14 +2285,14 @@ function og_user_access_entity($perm, $entity_type, $entity, $account = NULL) {
  *   (optional) The field name associated with the group.
  * @param $access_check
  *   (optional) When TRUE check if user has permissions to view the group.
- *   When FALSE do not check user permissions. Default to TRUE.
+ *   When FALSE do not check user permissions. Default to FALSE.
  *
  * @return
  *  An array with the group's entity type as the key, and array - keyed by
  *  the OG membership ID and the group ID as the value. If nothing found,
  *  then an empty array.
  */
-function og_get_entity_groups($entity_type = 'user', $entity = NULL, $states = array(OG_STATE_ACTIVE), $field_name = NULL, $access_check = TRUE) {
+function og_get_entity_groups($entity_type = 'user', $entity = NULL, $states = array(OG_STATE_ACTIVE), $field_name = NULL, $access_check = FALSE) {
   $cache = &drupal_static(__FUNCTION__, array());
 
   if ($entity_type == 'user' && empty($entity)) {
@@ -2350,7 +2350,7 @@ function og_get_entity_groups($entity_type = 'user', $entity = NULL, $states = a
     ->fetchAll();
 
   foreach ($result as $row) {
-    if ($access_check && !entity_access('view', $row->group_type, entity_load_single($row->group_type, $row->id))) {
+    if ($access_check && !entity_access('view', $row->group_type, entity_load_single($row->group_type, $row->gid), user_load($id))) {
       // User doesn't have access to the group.
       continue;
     }
@@ -2358,8 +2358,6 @@ function og_get_entity_groups($entity_type = 'user', $entity = NULL, $states = a
   }
 
   return $cache[$identifier];
-
-  //This is test comment.
 }
 
 /**
@@ -3542,12 +3540,12 @@ function og_node_create_links($group_type, $gid, $field_name, $destination = NUL
  *   types will be fetched.
  * @param $access_check
  *   (optional) When TRUE check if user has permissions to view the group.
- *   When FALSE do not check user permissions. Default to TRUE.
+ *   When FALSE do not check user permissions. Default to FALSE.
  *
  * @return
  *   An array with the group IDs or an empty array.
  */
-function og_get_groups_by_user($account = NULL, $group_type = NULL, $access_check = TRUE) {
+function og_get_groups_by_user($account = NULL, $group_type = NULL, $access_check = FALSE) {
   if (empty($account)) {
     global $user;
     $account = $user;
@@ -3578,7 +3576,7 @@ function og_get_groups_by_user($account = NULL, $group_type = NULL, $access_chec
 
   foreach ($groups as $entity_type => $ids) {
     foreach (entity_load($entity_type, $ids) as $entity) {
-      if ($access_check && !entity_access('view', $entity_type, $entity)) {
+      if ($access_check && !entity_access('view', $entity_type, $entity, $account)) {
         // User doesn't have access to the group.
         continue;
       }

--- a/og.module
+++ b/og.module
@@ -2283,13 +2283,16 @@ function og_user_access_entity($perm, $entity_type, $entity, $account = NULL) {
  *   (optional) Array with the state to return. Defaults to active.
  * @param $field_name
  *   (optional) The field name associated with the group.
+ * @param $access_check
+ *   (optional) When TRUE check if user has permissions to view the group.
+ *   When FALSE do not check user permissions. Default to TRUE.
  *
  * @return
  *  An array with the group's entity type as the key, and array - keyed by
  *  the OG membership ID and the group ID as the value. If nothing found,
  *  then an empty array.
  */
-function og_get_entity_groups($entity_type = 'user', $entity = NULL, $states = array(OG_STATE_ACTIVE), $field_name = NULL) {
+function og_get_entity_groups($entity_type = 'user', $entity = NULL, $states = array(OG_STATE_ACTIVE), $field_name = NULL, $access_check = TRUE) {
   $cache = &drupal_static(__FUNCTION__, array());
 
   if ($entity_type == 'user' && empty($entity)) {
@@ -2347,6 +2350,10 @@ function og_get_entity_groups($entity_type = 'user', $entity = NULL, $states = a
     ->fetchAll();
 
   foreach ($result as $row) {
+    if ($access_check && !entity_access('view', $row->group_type, entity_load_single($row->group_type, $row->id))) {
+      // User doesn't have access to the group.
+      continue;
+    }
     $cache[$identifier][$row->group_type][$row->id] = $row->gid;
   }
 
@@ -3531,11 +3538,14 @@ function og_node_create_links($group_type, $gid, $field_name, $destination = NUL
  * @param $group_type
  *   (optional) The entity type of the groups to fetch. By default all group
  *   types will be fetched.
+ * @param $access_check
+ *   (optional) When TRUE check if user has permissions to view the group.
+ *   When FALSE do not check user permissions. Default to TRUE.
  *
  * @return
  *   An array with the group IDs or an empty array.
  */
-function og_get_groups_by_user($account = NULL, $group_type = NULL) {
+function og_get_groups_by_user($account = NULL, $group_type = NULL, $access_check = TRUE) {
   if (empty($account)) {
     global $user;
     $account = $user;
@@ -3555,9 +3565,23 @@ function og_get_groups_by_user($account = NULL, $group_type = NULL) {
     return;
   }
 
+  $groups = array();
   foreach ($og_memberships as $og_membership) {
-    if (!empty($og_membership)) {
-      $gids[$og_membership->group_type][$og_membership->gid] = $og_membership->gid;
+    if (empty($og_membership)) {
+      // OG membership might have been just deleted.
+      continue;
+    }
+    $groups[$og_membership->group_type][] = $og_membership->gid;
+  }
+
+  foreach ($groups as $entity_type => $ids) {
+    foreach (entity_load($entity_type, $ids) as $entity) {
+      if ($access_check && !entity_access('view', $entity_type, $entity)) {
+        // User doesn't have access to the group.
+        continue;
+      }
+      list($id) = entity_extract_ids($entity_type, $entity);
+      $gids[$entity_type][$id] = $id;
     }
   }
 

--- a/og.module
+++ b/og.module
@@ -2358,6 +2358,8 @@ function og_get_entity_groups($entity_type = 'user', $entity = NULL, $states = a
   }
 
   return $cache[$identifier];
+
+  //This is test comment.
 }
 
 /**

--- a/og.test
+++ b/og.test
@@ -338,6 +338,58 @@ class OgNodeAccess extends DrupalWebTestCase {
     $this->assertFalse(in_array($this->group2->nid, $entity_groups['node']), 'Content retains original groups after saving node form.');
   }
 
+  /**
+   * Test user access to unpublished group node.
+   */
+  function testUnpublishedGroupAccess() {
+    $user1 = $this->group_manager;
+    $user2 = $this->editor_user;
+    $this->drupalLogin($user1);
+
+    // Create a group node and set as private.
+    $settings = array();
+    $settings['type'] = 'page';
+    $settings[OG_GROUP_FIELD][LANGUAGE_NONE][0]['value'] = 1;
+    $settings[OG_ACCESS_FIELD][LANGUAGE_NONE][0]['value'] = 1;
+    $group_node = $this->drupalCreateNode($settings);
+
+    // Add another user to group.
+    og_group('node', $group_node->nid, array('entity' => $user2));
+    drupal_static_reset('node_access');
+
+    $this->assertTrue(entity_access('view', 'node', $group_node, $user2), 'Group member can view published group.');
+
+    // Get user's groups they have access to using og_get_entity_groups().
+    $groups1 = og_get_entity_groups('user', $user2, array(OG_STATE_ACTIVE), NULL, TRUE);
+    // Get user's groups they have access to using og_get_groups_by_user().
+    $groups2 = og_get_groups_by_user($user2, 'node', TRUE);
+
+    $group1 = !empty($groups1['node']) ? in_array($group_node->nid, $groups1['node']) : FALSE;
+    $group2 = !empty($groups2) ? in_array($group_node->nid, $groups2) : FALSE;
+
+    $this->assertTrue($group1, 'Group member is getting published group from og_get_entity_groups().');
+    $this->assertTrue($group2, 'Group member is getting published group from og_get_groups_by_user().');
+
+    $group_node->status = NODE_NOT_PUBLISHED;
+    node_save($group_node);
+    drupal_static_reset('node_access');
+
+    $this->assertFalse(entity_access('view', 'node', $group_node, $user2), "Group member can't view unpublished group.");
+
+    // Clear the cache because permissions were changed.
+    drupal_static_reset('og_get_entity_groups');
+
+    // Get user's groups they have access to using og_get_entity_groups().
+    $groups1 = og_get_entity_groups('user', $user2, array(OG_STATE_ACTIVE), NULL, TRUE);
+    // Get user's groups they have access to using og_get_groups_by_user().
+    $groups2 = og_get_groups_by_user($user2, 'node', TRUE);
+
+    $group1 = !empty($groups1['node']) ? in_array($group_node->nid, $groups1['node']) : FALSE;
+    $group2 = !empty($groups2) ? in_array($group_node->nid, $groups2) : FALSE;
+
+    $this->assertFalse($group1, 'Group member is not getting unpublished group from og_get_entity_groups().');
+    $this->assertFalse($group2, 'Group member is not getting unpublished group from og_get_groups_by_user().');
+  }
 }
 
 /**

--- a/og.test
+++ b/og.test
@@ -1938,7 +1938,7 @@ class OgDeleteOrphansTestCase extends DrupalWebTestCase {
     // Add OG audience field to the audience content type.
     $og_field = og_fields_info(OG_AUDIENCE_FIELD);
     $og_field['field']['settings']['target_type'] = 'node';
-    og_create_field(OG_AUDIENCE_FIELD, 'node', $type->type, $og_field);
+    og_create_field(OG_AUDIENCE_FIELD, 'node', $this->node_type, $og_field);
 
     // Set the setting for delete a group content when deleting group.
     variable_set('og_orphans_delete', TRUE);
@@ -1976,7 +1976,7 @@ class OgDeleteOrphansTestCase extends DrupalWebTestCase {
     $second_node = node_load($second_node->nid);
 
     // Verify the none orphan node wasn't deleted.
-    $this->assertTrue($first_node, "The second node is realted to another group and deleted.");
+    $this->assertTrue($first_node, "The second node is related to another group and deleted.");
     // Verify the orphan node deleted.
     $this->assertFalse($second_node, "The orphan node deleted.");
   }

--- a/og_access/og_access.test
+++ b/og_access/og_access.test
@@ -336,7 +336,7 @@ class OgAccessTestCase extends DrupalWebTestCase {
 
     // Add another user to group.
     og_group('node', $group_node1->nid, array('entity' => $user2));
-
+    drupal_static_reset('node_access');
     $this->assertTrue(node_access('view', $node, $user2), 'Group member can view published node.');
 
     $node->status = NODE_NOT_PUBLISHED;
@@ -344,6 +344,32 @@ class OgAccessTestCase extends DrupalWebTestCase {
     drupal_static_reset('node_access');
 
     $this->assertFalse(node_access('view', $node, $user2), 'Group member can not view unpublished node.');
+
+    $groups1 = og_get_entity_groups('user', $user2, array(OG_STATE_ACTIVE), NULL, TRUE);
+    $groups2 = og_get_groups_by_user($user2, 'node', TRUE);
+    $groups1 = $groups1 ? $groups1 : array('node' => array());
+    $groups2 = $groups2 ? $groups2 : array();
+
+
+    $this->assertTrue(node_access('view', $group_node1, $user2), 'Group member can view published group.');
+    $this->assertTrue(entity_access('view', 'node', $group_node1, $user2), 'Group member can view published group.');
+    $this->assertTrue(in_array($group_node1->nid, $groups1['node']), 'Group member can view published group.');
+    $this->assertTrue(in_array($group_node1->nid, $groups2), 'Group member can view published group.');
+
+    $group_node1->status = NODE_NOT_PUBLISHED;
+    node_save($group_node1);
+    drupal_static_reset('node_access');
+    drupal_static_reset('og_get_entity_groups');
+
+    $groups1 = og_get_entity_groups('user', $user2, array(OG_STATE_ACTIVE), NULL, TRUE);
+    $groups2 = og_get_groups_by_user($user2, 'node', TRUE);
+    $groups1 = $groups1 ? $groups1 : array('node' => array());
+    $groups2 = $groups2 ? $groups2 : array();
+
+    $this->assertFalse(node_access('view', $group_node1, $user2), 'Group member can\'t view unpublished node.');
+    $this->assertFalse(entity_access('view', 'node', $group_node1, $user2), 'Group member can\'t view unpublished node.');
+    $this->assertFalse(in_array($group_node1->nid, $groups1['node']), 'Group member can\'t view unpublished group.');
+    $this->assertFalse(in_array($group_node1->nid, $groups2), 'Group member can\'t view unpublished group.');
   }
 }
 

--- a/og_access/og_access.test
+++ b/og_access/og_access.test
@@ -345,59 +345,6 @@ class OgAccessTestCase extends DrupalWebTestCase {
 
     $this->assertFalse(node_access('view', $node, $user2), 'Group member can not view unpublished node.');
   }
-
-  /**
-   * Test unpublished node.
-   */
-  function testUnpublishedGroupAccess() {
-    $user1 = $this->user1;
-    $user2 = $this->user2;
-    $this->drupalLogin($user1);
-
-    // Create a group node and set as private.
-    $settings = array();
-    $settings['type'] = $this->group_type;
-    $settings[OG_GROUP_FIELD][LANGUAGE_NONE][0]['value'] = 1;
-    $settings[OG_ACCESS_FIELD][LANGUAGE_NONE][0]['value'] = 1;
-    $group_node = $this->drupalCreateNode($settings);
-
-    // Add another user to group.
-    og_group('node', $group_node->nid, array('entity' => $user2));
-    drupal_static_reset('node_access');
-
-    $this->assertTrue(entity_access('view', 'node', $group_node, $user2), 'Group member can view published group.');
-
-    // Get user's groups he has access to using og_get_entity_groups().
-    $groups1 = og_get_entity_groups('user', $user2, array(OG_STATE_ACTIVE), NULL, TRUE);
-    // Get user's groups he has access to using og_get_groups_by_user().
-    $groups2 = og_get_groups_by_user($user2, 'node', TRUE);
-
-    $group1 = !empty($groups1['node']) ? in_array($group_node->nid, $groups1['node']) : FALSE;
-    $group2 = !empty($groups2) ? in_array($group_node->nid, $groups2) : FALSE;
-
-    $this->assertTrue($group1, 'Group member is getting published group from og_get_entity_groups().');
-    $this->assertTrue($group2, 'Group member is getting published group from og_get_groups_by_user().');
-
-    $group_node->status = NODE_NOT_PUBLISHED;
-    node_save($group_node);
-    drupal_static_reset('node_access');
-
-    $this->assertFalse(entity_access('view', 'node', $group_node, $user2), "Group member can't view unpublished group.");
-
-    // Clear the cache because permissions were changed.
-    drupal_static_reset('og_get_entity_groups');
-
-    // Get user's groups he has access to using og_get_entity_groups().
-    $groups1 = og_get_entity_groups('user', $user2, array(OG_STATE_ACTIVE), NULL, TRUE);
-    // Get user's groups he has access to using og_get_groups_by_user().
-    $groups2 = og_get_groups_by_user($user2, 'node', TRUE);
-
-    $group1 = !empty($groups1['node']) ? in_array($group_node->nid, $groups1['node']) : FALSE;
-    $group2 = !empty($groups2) ? in_array($group_node->nid, $groups2) : FALSE;
-
-    $this->assertFalse($group1, 'Group member is not getting unpublished group from og_get_entity_groups().');
-    $this->assertFalse($group2, 'Group member is not getting unpublished group from og_get_groups_by_user().');
-  }
 }
 
 

--- a/og_access/og_access.test
+++ b/og_access/og_access.test
@@ -344,32 +344,59 @@ class OgAccessTestCase extends DrupalWebTestCase {
     drupal_static_reset('node_access');
 
     $this->assertFalse(node_access('view', $node, $user2), 'Group member can not view unpublished node.');
+  }
 
-    $groups1 = og_get_entity_groups('user', $user2, array(OG_STATE_ACTIVE), NULL, TRUE);
-    $groups2 = og_get_groups_by_user($user2, 'node', TRUE);
-    $groups1 = $groups1 ? $groups1 : array('node' => array());
-    $groups2 = $groups2 ? $groups2 : array();
+  /**
+   * Test unpublished node.
+   */
+  function testUnpublishedGroupAccess() {
+    $user1 = $this->user1;
+    $user2 = $this->user2;
+    $this->drupalLogin($user1);
 
+    // Create a group node and set as private.
+    $settings = array();
+    $settings['type'] = $this->group_type;
+    $settings[OG_GROUP_FIELD][LANGUAGE_NONE][0]['value'] = 1;
+    $settings[OG_ACCESS_FIELD][LANGUAGE_NONE][0]['value'] = 1;
+    $group_node = $this->drupalCreateNode($settings);
 
-    $this->assertTrue(node_access('view', $group_node1, $user2), 'Group member can view published group.');
-    $this->assertTrue(entity_access('view', 'node', $group_node1, $user2), 'Group member can view published group.');
-    $this->assertTrue(in_array($group_node1->nid, $groups1['node']), 'Group member can view published group.');
-    $this->assertTrue(in_array($group_node1->nid, $groups2), 'Group member can view published group.');
-
-    $group_node1->status = NODE_NOT_PUBLISHED;
-    node_save($group_node1);
+    // Add another user to group.
+    og_group('node', $group_node->nid, array('entity' => $user2));
     drupal_static_reset('node_access');
+
+    $this->assertTrue(entity_access('view', 'node', $group_node, $user2), 'Group member can view published group.');
+
+    // Get user's groups he has access to using og_get_entity_groups().
+    $groups1 = og_get_entity_groups('user', $user2, array(OG_STATE_ACTIVE), NULL, TRUE);
+    // Get user's groups he has access to using og_get_groups_by_user().
+    $groups2 = og_get_groups_by_user($user2, 'node', TRUE);
+
+    $group1 = !empty($groups1['node']) ? in_array($group_node->nid, $groups1['node']) : FALSE;
+    $group2 = !empty($groups2) ? in_array($group_node->nid, $groups2) : FALSE;
+
+    $this->assertTrue($group1, 'Group member is getting published group from og_get_entity_groups().');
+    $this->assertTrue($group2, 'Group member is getting published group from og_get_groups_by_user().');
+
+    $group_node->status = NODE_NOT_PUBLISHED;
+    node_save($group_node);
+    drupal_static_reset('node_access');
+
+    $this->assertFalse(entity_access('view', 'node', $group_node, $user2), "Group member can't view unpublished group.");
+
+    // Clear the cache because permissions were changed.
     drupal_static_reset('og_get_entity_groups');
 
+    // Get user's groups he has access to using og_get_entity_groups().
     $groups1 = og_get_entity_groups('user', $user2, array(OG_STATE_ACTIVE), NULL, TRUE);
+    // Get user's groups he has access to using og_get_groups_by_user().
     $groups2 = og_get_groups_by_user($user2, 'node', TRUE);
-    $groups1 = $groups1 ? $groups1 : array('node' => array());
-    $groups2 = $groups2 ? $groups2 : array();
 
-    $this->assertFalse(node_access('view', $group_node1, $user2), 'Group member can\'t view unpublished node.');
-    $this->assertFalse(entity_access('view', 'node', $group_node1, $user2), 'Group member can\'t view unpublished node.');
-    $this->assertFalse(in_array($group_node1->nid, $groups1['node']), 'Group member can\'t view unpublished group.');
-    $this->assertFalse(in_array($group_node1->nid, $groups2), 'Group member can\'t view unpublished group.');
+    $group1 = !empty($groups1['node']) ? in_array($group_node->nid, $groups1['node']) : FALSE;
+    $group2 = !empty($groups2) ? in_array($group_node->nid, $groups2) : FALSE;
+
+    $this->assertFalse($group1, 'Group member is not getting unpublished group from og_get_entity_groups().');
+    $this->assertFalse($group2, 'Group member is not getting unpublished group from og_get_groups_by_user().');
   }
 }
 


### PR DESCRIPTION
Using functions og_get_groups_by_user() and og_get_entity_groups() the user could get groups he doesn't have access to, e.g. unpublished ones.
So I added the check_access parameter to have an opportunity to get only groups user has access to.
