### PR TITLE
Allow hook_og_ui_get_group_admin_alter() to change the sort order of group admin items

### DIFF
--- a/og_ui/og_ui.module
+++ b/og_ui/og_ui.module
@@ -1128,15 +1128,15 @@ function og_ui_get_group_admin($entity_type, $etid) {
 
   $data = module_invoke_all('og_ui_get_group_admin', $entity_type, $etid);
 
+  // Sort the results.
+  uasort($data, 'drupal_sort_title');
+
   // Allow other modules to alter the menu items.
   $context = array(
     'entity_type' => $entity_type,
     'etid' => $etid,
   );
   drupal_alter('og_ui_get_group_admin', $data, $context);
-
-  // Sort the results.
-  uasort($data, 'drupal_sort_title');
 
   $cache["$entity_type:$etid"] = $data;
   return $data;


### PR DESCRIPTION
The current code prevents doing that, but I don't see any good reason that it should.
