### PR TITLE
Allow users with specific group permissions to modify og_membership entities

### DIFF
--- a/og.module
+++ b/og.module
@@ -1798,7 +1798,11 @@ function og_membership_label($og_membership) {
  * Access callback for the group membership entity.
  */
 function og_membership_access($op, $entity, $account = NULL, $entity_type = 'og_membership') {
-  // No-end user needs access to this entity, so restrict it to admins.
+  // If the group id exists, we check whether the user has administration permissions over the
+  // specific group. Otherwise we default to checking the global 'administer group' permission.
+  if (!empty($entity->gid)) {
+    return og_user_access($entity->group_type, $entity->gid, 'administer group', $account);
+  }
   return user_access('administer group');
 }
 


### PR DESCRIPTION
Currently only users with the global 'administer groups' can create/modify/delete og_membership entities. The code comments suggest this is because 'no end user needs to access this entity'.

However, we have front end user interfaces that use views_bulk_operations to modify og_memberships (for example, to set users from Pending to Active). These changes are (silently) failing even though the user is a administrator of the specific group to which the membership belongs.

Expected behaviour: users should be able to modify og_membership entities that are associated with groups for which they are administrators.

This pull request changes this behaviour, and attempts to `og_user_access()` first, before falling back to `user_access()`.
