### PR TITLE
Fix edit link so that destination query parameter is formatted and encoded properly

### DIFF
--- a/includes/views/handlers/og_handler_field_og_membership_link_edit.inc
+++ b/includes/views/handlers/og_handler_field_og_membership_link_edit.inc
@@ -65,12 +65,6 @@ class og_handler_field_og_membership_link_edit extends views_handler_field_entit
     $text = !empty($this->options['text']) ? $this->options['text'] : t('edit');
     unset($this->options['alter']['fragment']);
 
-    if (!empty($this->options['destination'])) {
-      $this->options['alter']['query'] = drupal_get_destination();
-    }
-
-    $this->options['alter']['path'] = "group/" . $group_type . "/" . $gid  . "/admin/people/edit-membership/" . $og_membership->id;
-
-    return $text;
+    return l($text, "group/" . $group_type . "/" . $gid  . "/admin/people/edit-membership/" . $og_membership->id, array('query' => drupal_get_destination()));
   }
 }


### PR DESCRIPTION
When selecting a filter for the State field on the Edit Membership page, the edit link does not set the destination query string parameter correctly.

For example, currently the URL is:

group/node/114456/admin/people/edit-membership/85346?destination=group/node/114456/admin/people/edit-membership%3Fstate%3D11144566uid%3D

It should be

group/node/114456/admin/people/edit-membership/85346?destination=group/node/114456/admin/people/edit-membership%3Fstate%3D1%26uid%3D
