### PR TITLE
"OG: user role in group" access plugin

### DIFF
--- a/og.module
+++ b/og.module
@@ -2637,6 +2637,49 @@ function og_role_permissions($roles = array()) {
 }
 
 /**
+ * Returns an array of all roles.
+ *
+ * @param $include_all
+ *   (optional) If TRUE then the anonymous and authenticated default roles will
+ *   be included.
+ *
+ * @return array
+ *   An associative array with the role id as the key and the role name as
+ *   value.
+ */
+function og_get_all_roles($include_all = TRUE) {
+
+  $query = db_select('og_role', 'ogr')
+      ->fields('ogr', array('rid', 'group_type', 'group_bundle', 'name'))
+      ->orderBy('rid', 'ASC');
+
+  if (!$include_all) {
+    $query->condition('name', array(OG_ANONYMOUS_ROLE, OG_AUTHENTICATED_ROLE), 'NOT IN');
+  }
+  $og_roles = $query
+    ->execute()
+    ->fetchAll();
+
+  $node_types = node_type_get_types();
+  $group_entities = og_get_all_group_entity();
+  $group_bundles = og_get_all_group_bundle();
+
+  $roles = array();
+  foreach ($og_roles as $role) {
+
+    $role_name_parts = array(
+      $group_entities[$role->group_type],
+      $group_bundles[$role->group_type][$role->group_bundle],
+      $role->name,
+    );
+
+    $roles[$role->rid] = implode(':', $role_name_parts);
+  }
+
+  return $roles;
+}
+
+/**
  * Retrieve an array of roles matching specified conditions.
  *
  * @param $group_type

--- a/og_role.inc
+++ b/og_role.inc
@@ -1,0 +1,111 @@
+<?php
+
+
+/**
+ * @file
+ * Plugin to provide access control based on user roles in a group.
+ */
+
+$plugin = array(
+  'title' => t('OG: user role in group'),
+  'description' => t('Control access by group role. This applies only to node type groups.'),
+  'callback' => 'og_role_ctools_access_check',
+  'default' => array(
+    'og_rids' => array(),
+  ),
+  'settings form' => 'og_role_ctools_access_settings',
+  'settings form submit' => 'og_role_ctools_access_settings_submit',
+  'summary' => 'og_role_ctools_access_summary',
+  'required context' => array(
+    new ctools_context_required(t('User'), 'user'),
+    new ctools_context_optional(t('Node'), 'node'),
+  ),
+);
+
+/**
+ * Settings form for the 'by role' access plugin
+ */
+function og_role_ctools_access_settings($form, &$form_state, $conf) {
+  $form['settings']['og_rids'] = array(
+    '#type' => 'checkboxes',
+    '#title' => t('Group roles'),
+    '#default_value' => $conf['og_rids'],
+    '#options' => og_get_all_roles(FALSE),
+    '#description' => t('Only the checked roles will be granted access.'),
+    '#required' => TRUE,
+  );
+  return $form;
+}
+
+/**
+ * Compress the roles allowed to the minimum.
+ */
+function og_role_ctools_access_settings_submit($form, &$form_state) {
+  $form_state['values']['settings']['og_rids'] = array_keys(array_filter($form_state['values']['settings']['og_rids']));
+}
+
+/**
+ * Check for access.
+ */
+function og_role_ctools_access_check($conf, $context) {
+  list($user_context, $node_context) = $context;
+  if (empty($user_context->data)) {
+    return FALSE;
+  }
+  $account = $user_context->data;
+
+  if (!empty($node_context->data)) {
+    $node = $node_context->data;
+    $user_og_roles = og_get_user_roles('node', $node->nid, $account->uid, FALSE);
+    return array_intersect($conf['og_rids'], array_keys($user_og_roles));
+  }
+  else {
+    $user_groups = og_get_groups_by_user($account);
+    if (empty($user_groups)) {
+      return FALSE;
+    }
+    else {
+      $user_og_roles = array();
+      foreach($user_groups as $group_type => $groups) {
+        foreach ($groups as $group_id) {
+          $user_og_roles += og_get_user_roles($group_type, $group_id, $account->uid, FALSE);
+        }
+      }
+      return array_intersect($conf['og_rids'], array_keys($user_og_roles));
+    }
+  }
+}
+
+/**
+ * Provide a summary description based upon the checked role.
+ */
+function og_role_ctools_access_summary($conf, $context) {
+  list($user_context, $node_context) = $context;
+  if (!isset($conf['og_rids'])) {
+    $conf['og_rids'] = array();
+  }
+  $roles = og_get_all_roles(FALSE);
+  $names = array();
+  foreach (array_filter($conf['og_rids']) as $rid) {
+    $names[] = check_plain($roles[$rid]);
+  }
+
+  $summary_args = array(
+    '@identifier' => $user_context->identifier,
+  );
+
+  if (empty($names)) {
+    $summary_string = '@identifier has "any role"';
+  }
+  else {
+    $summary_string = '@identifier has "@role"';
+    $summary_args['@role'] = implode(', ', $names);
+  }
+
+  if (!empty($node_context->data)) {
+    $summary_string .= ' in "@group" group';
+    $summary_args['@group'] = $node_context->identifier;
+  }
+
+  return t($summary_string, $summary_args);
+}


### PR DESCRIPTION
A follow up for:

https://github.com/Gizra/og/pull/49

I did the changes mentioned by amitaibu plus made some other changes. 

I wanted to use it in a custom page made by page manager (panels), which didn't have context, so now node_context is optional.

My use case is that I wanted to create something like a "dashboard" for all "Group admins" in which each admin will be able to see whatever he needs to see from his own group.

Any feedback is welcomed :)
