### PR TITLE
Use theme('username') for usernames in the admin interface.

### DIFF
--- a/og_ui/og_ui.admin.inc
+++ b/og_ui/og_ui.admin.inc
@@ -296,7 +296,7 @@ function og_ui_edit_membership($form, &$form_state, $group_type, $gid, $og_membe
   $form['og_user']['name'] = array(
     '#type' => 'markup',
     '#title' => t('User name'),
-    '#markup' => $account->name,
+    '#markup' => theme('username', array('account' => $account)),
   );
   $form['og_user']['state'] = array(
     '#type' => 'select',
@@ -399,7 +399,7 @@ function og_ui_delete_membership($form, &$form_state, $group_type, $gid, $og_mem
   return confirm_form($form,
     t('Remove membership in group @group', array('@group' => $label)),
     'group/' . $group_type . '/' . $gid . '/admin/people',
-    t('Are you sure you would like to remove the membership for the user @user?', array('@user' => $account->name)),
+    t('Are you sure you would like to remove the membership for the user !user?', array('!user' => theme('username', array('account' => $account)))),
     t('Remove'),
     t('Cancel')
   );


### PR DESCRIPTION
Using the $account->name as the value on the screen limits the possibility to format the username using the theming layer.

Replacing it by 

```
theme('username', array('account' => $account));
```

This gives modules, site builders and themers the power to replace the name with another value (eg. Full name specified in the user profile).
