### PR TITLE
#121 - og_context() default value set to FALSE.

### DIFF
--- a/og_context/og_context.module
+++ b/og_context/og_context.module
@@ -216,7 +216,7 @@ function og_context_is_init($called = FALSE) {
  *   Array keyed by the group type and group ID, or FALSE if no context
  *   was found.
  */
-function og_context($group_type = 'node', $group = NULL, $account = NULL, $check_access = TRUE) {
+function og_context($group_type = 'node', $group = NULL, $account = NULL, $check_access = FALSE) {
   global $user;
   // User account is sent.
   $account = $account ? $account : user_load($user->uid);


### PR DESCRIPTION
og_context() default value set to FALSE to keep the same og_context() return for all users as it was up to version 7.x-2.7
https://github.com/Gizra/og/issues/121
