### PR TITLE
Cannot save group reference field programmatically

### DIFF
--- a/og_context/includes/views/handlers/og_context_plugin_access_og_perm.inc
+++ b/og_context/includes/views/handlers/og_context_plugin_access_og_perm.inc
@@ -59,7 +59,7 @@ class og_context_plugin_access_og_perm extends views_plugin_access {
         '#title' => t('Argument position for group ID'),
         '#default_value' => $this->options['group_id_arg'],
         '#options' => array(NULL => t('None')) + range(0, 9),
-        '#description' => t('Group ID argument position with arg() function. e.g. if your dynamic path is "node/%/group/%/overview" and you are using the second "%" for group IDs you have to choose "3" like "arg(3)".'),
+        '#description' => t('The position of the Group ID argument in the view\'s path. The position is 0-based. E.g. if your dynamic path is "node/%/group/%/overview" and you are using the second "%" for group IDs, you have to choose "3".'),
       );
     }
   }
@@ -98,6 +98,16 @@ class og_context_plugin_access_og_perm extends views_plugin_access {
    * Determine the access callback and arguments.
    */
   function get_access_callback() {
-    return array('_og_context_views_page_access', array($this->options['group_type'], $this->options['perm'], $this->options['group_id_arg']));
+    $current_display = $this->view->current_display;
+    if ($this->view->display[$current_display]->handler->has_path()) {
+      // The arg number needs to be int. That way it will be replaced with the
+      // group id in the path before _og_context_views_page_access is called.
+      $group_id_arg = (int)$this->options['group_id_arg'];
+    }
+    else {
+      $group_id_arg = FALSE;
+    }
+
+    return array('_og_context_views_page_access', array($this->options['group_type'], $this->options['perm'], $group_id_arg));
   }
 }

--- a/og_context/og_context.module
+++ b/og_context/og_context.module
@@ -657,15 +657,14 @@ function _group_context_handler_entity($entity_type = 'node', $entity = NULL, $p
  *   The group type.
  * @param $perm
  *   The group permission to search for.
- * @param $group_id_arg
- *   Optional; The position in arg() where the group ID can be found.
+ * @param $gid
+ *   The group id from the path.
  *
  * @return
  *   TRUE if user is allowed access to the page.
  */
-function _og_context_views_page_access($group_type, $perm, $group_id_arg = FALSE) {
-  if ($group_id_arg !== '') {
-    $gid = arg($group_id_arg);
+function _og_context_views_page_access($group_type, $perm, $gid) {
+  if ($gid) {
     if (is_numeric($gid)) {
       return og_user_access($group_type, $gid, $perm);
     }

--- a/plugins/entityreference/behavior/OgBehaviorHandler.class.php
+++ b/plugins/entityreference/behavior/OgBehaviorHandler.class.php
@@ -95,10 +95,6 @@ class OgBehaviorHandler extends EntityReference_BehaviorHandler_Abstract {
    * Create, update or delete OG membership based on field values.
    */
   public function OgMembershipCrud($entity_type, $entity, $field, $instance, $langcode, &$items) {
-    if (!user_access('administer group') && !field_access('edit', $field, $entity_type, $entity)) {
-      // User has no access to field.
-      return;
-    }
     if (!$diff = $this->groupAudiencegetDiff($entity_type, $entity, $field, $instance, $langcode, $items)) {
       return;
     }


### PR DESCRIPTION
Copied from https://www.drupal.org/node/2766637

OG's entity reference handler class, OgBehaviorHandler, checks field access before it saves the group memberships, and skips saving if the currently logged in user does not have permission to edit the group reference field. As a result, if the current user does not have permission to edit the group reference field, the field is going to be ignored when the entity is saved programmatically. This can cause problems in two situations:
- The current user is irrelevant to the content being updated. E.g. during drush run
- The user may not have access to directly edit the group reference field, but custom code may want to be able to change the group memberships based on some other action taken by the user.

When content is saved programmatically, (e.g. using node_save()), the values that get saved into the database should not depend on what user is logged in. Actually, I think the entity reference handler class should not be concerned with user access when saving the group memberships. This is low level functionality, and when we get to the point where the entity needs to be saved, the field values should already have been validated.

This PR removes the access check from the membership saving logic. Please let me know if I have taken the right direction with this.
