### PR TITLE
Remove reliance on current path in Views access check

### DIFF
--- a/og_context/includes/views/handlers/og_context_plugin_access_og_perm.inc
+++ b/og_context/includes/views/handlers/og_context_plugin_access_og_perm.inc
@@ -59,7 +59,7 @@ class og_context_plugin_access_og_perm extends views_plugin_access {
         '#title' => t('Argument position for group ID'),
         '#default_value' => $this->options['group_id_arg'],
         '#options' => array(NULL => t('None')) + range(0, 9),
-        '#description' => t('Group ID argument position with arg() function. e.g. if your dynamic path is "node/%/group/%/overview" and you are using the second "%" for group IDs you have to choose "3" like "arg(3)".'),
+        '#description' => t('The position of the Group ID argument in the view\'s path. The position is 0-based. E.g. if your dynamic path is "node/%/group/%/overview" and you are using the second "%" for group IDs, you have to choose "3".'),
       );
     }
   }
@@ -98,6 +98,16 @@ class og_context_plugin_access_og_perm extends views_plugin_access {
    * Determine the access callback and arguments.
    */
   function get_access_callback() {
-    return array('_og_context_views_page_access', array($this->options['group_type'], $this->options['perm'], $this->options['group_id_arg']));
+    $current_display = $this->view->current_display;
+    if ($this->view->display[$current_display]->handler->has_path()) {
+      // The arg number needs to be int. That way it will be replaced with the
+      // group id in the path before _og_context_views_page_access is called.
+      $group_id_arg = (int)$this->options['group_id_arg'];
+    }
+    else {
+      $group_id_arg = FALSE;
+    }
+
+    return array('_og_context_views_page_access', array($this->options['group_type'], $this->options['perm'], $group_id_arg));
   }
 }

--- a/og_context/og_context.module
+++ b/og_context/og_context.module
@@ -657,15 +657,14 @@ function _group_context_handler_entity($entity_type = 'node', $entity = NULL, $p
  *   The group type.
  * @param $perm
  *   The group permission to search for.
- * @param $group_id_arg
- *   Optional; The position in arg() where the group ID can be found.
+ * @param $gid
+ *   The group id from the path.
  *
  * @return
  *   TRUE if user is allowed access to the page.
  */
-function _og_context_views_page_access($group_type, $perm, $group_id_arg = FALSE) {
-  if ($group_id_arg !== '') {
-    $gid = arg($group_id_arg);
+function _og_context_views_page_access($group_type, $perm, $gid) {
+  if ($gid) {
     if (is_numeric($gid)) {
       return og_user_access($group_type, $gid, $perm);
     }


### PR DESCRIPTION
The access callback of the Views access plugin directly calls arg() to get the group id from the path. This makes the access check inaccurate when access is checked on any page other than the view's actual path. Such checks may occur when:
- The view is embedded on another page
- Any page needs to print a link to the view and checks access (e.g. using drupal_valid_path()) before doing so

This PR updates the access callback so that one of the arguments passed to _og_context_views_page_access () will be a path component number, which will be replaced with the View's argument at run time. This allows _og_context_views_page_access() to receive the View's argument instead of the path position number entered by the user.
