### PR TITLE
Streamline testing on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,20 @@ language: php
 sudo: false
 
 php:
-  - 5.5
   - 5.6
   - 7.0
 
 env:
-  - DRUPAL_CORE=8.1.x
-  - DRUPAL_CORE=8.2.x
+  - TEST_SUITE=8.1.x
+  - TEST_SUITE=8.2.x
+  - TEST_SUITE=8.3.x
+  - TEST_SUITE=PHP_CodeSniffer
+
+# Only run the coding standards check once.
+matrix:
+  exclude:
+    - php: 5.6
+      env: TEST_SUITE=PHP_CodeSniffer
 
 mysql:
   database: og
@@ -21,8 +28,14 @@ before_script:
   # We also don't care if that file exists or not on PHP 7.
   - phpenv config-rm xdebug.ini || true
 
+  # Make sure Composer is up to date.
+  - composer self-update
+
   # Remember the current directory for later use in the Drupal installation.
-  - TESTDIR=$(pwd)
+  - MODULE_DIR=$(pwd)
+
+  # Install Composer dependencies for OG.
+  - composer install
 
   # Navigate out of module directory to prevent blown stack by recursive module
   # lookup.
@@ -31,45 +44,25 @@ before_script:
   # Create database.
   - mysql -e 'create database og'
 
-  # Export database variable for kernel tests.
-  - export SIMPLETEST_DB=mysql://root:@127.0.0.1/og
+  # Download Drupal 8 core. Skip this for the coding standards test.
+  - test ${TEST_SUITE} == "PHP_CodeSniffer" || travis_retry git clone --branch $TEST_SUITE --depth 1 https://git.drupal.org/project/drupal.git
 
-  # Composer.
-  - sed -i '1i export PATH="$HOME/.composer/vendor/bin:$PATH"' $HOME/.bashrc
-  - source $HOME/.bashrc
+  # Remember the Drupal installation path.
+  - DRUPAL_DIR=$(pwd)/drupal
 
-  # Install Composer dependencies.
-  - composer self-update
-
-  # Install code sniffer.
-  - composer global require squizlabs/php_codesniffer
-
-  # Coder.
-  - composer global require drupal/coder:8.2.8
-  - ln -s ~/.composer/vendor/drupal/coder/coder_sniffer/Drupal ~/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/
-  - phpenv rehash
-
-  # Check if there any bad coding standarts
-  - phpcs --standard=Drupal -p --colors $TESTDIR
-
-
-  # Download Drupal 8 core.
-  - travis_retry git clone --branch $DRUPAL_CORE --depth 1 https://git.drupal.org/project/drupal.git
-  - cd drupal
-  - composer install
-
-  # Reference OG in the Drupal site.
-  - ln -s $TESTDIR modules/og
+  # Install Composer dependencies for core. Skip this for the coding standards test.
+  - test ${TEST_SUITE} == "PHP_CodeSniffer" || composer install --working-dir=$DRUPAL_DIR
 
   # Start a web server on port 8888 in the background.
-  - nohup php -S localhost:8888 > /dev/null 2>&1 &
+  - test ${TEST_SUITE} == "PHP_CodeSniffer" || nohup php -S localhost:8888 --docroot $DRUPAL_DIR > /dev/null 2>&1 &
 
   # Wait until the web server is responding.
-  - until curl -s localhost:8888; do true; done > /dev/null
+  - test ${TEST_SUITE} == "PHP_CodeSniffer" || until curl -s localhost:8888; do true; done > /dev/null
 
   # Export web server URL for browser tests.
   - export SIMPLETEST_BASE_URL=http://localhost:8888
 
-script:
-  # Run the PHPUnit tests which also include the kernel tests.
-  - ./vendor/phpunit/phpunit/phpunit -c ./core/phpunit.xml.dist ./modules/og
+  # Export database variable for kernel tests.
+  - export SIMPLETEST_DB=mysql://root:@127.0.0.1/og
+
+script: DRUPAL_DIR=$DRUPAL_DIR MODULE_DIR=$MODULE_DIR $MODULE_DIR/scripts/travis-ci/run-test.sh $TEST_SUITE

--- a/composer.json
+++ b/composer.json
@@ -9,5 +9,7 @@
         "irc": "irc://irc.freenode.org/drupal-og",
         "source": "https://cgit.drupalcode.org/og"
     },
-    "minimum-stability": "dev"
+    "require-dev": {
+        "drupal/coder": "^8.2"
+    }
 }

--- a/og.module
+++ b/og.module
@@ -5,22 +5,16 @@
  * Enable users to create and manage groups with roles and permissions.
  */
 
-use Drupal\Core\Form\FormStateInterface;
-use Drupal\og\GroupTypeManager;
-use Drupal\user\UserInterface;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
-use Drupal\Core\Field\FieldDefinitionInterface;
-use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Session\AccountInterface;
-use Drupal\og\Entity\OgMembership;
 use Drupal\og\Og;
 use Drupal\og\OgGroupAudienceHelper;
-use Drupal\og\OgMembershipInterface;
 use Drupal\user\EntityOwnerInterface;
+use Drupal\user\UserInterface;
 
 /**
  * Group default roles and permissions field.
@@ -171,7 +165,6 @@ function og_entity_create_access(AccountInterface $account, array $context, $bun
 }
 
 /**
- *
  * Implements hook_entity_bundle_field_info().
  *
  * Add a read only property to group entities as a group flag.
@@ -209,7 +202,6 @@ function og_entity_bundle_field_info_alter(&$fields, EntityTypeInterface $entity
     'type' => 'og_group_subscribe',
   ])->setDisplayConfigurable('view', TRUE);
 }
-
 
 /**
  * Implements hook_field_formatter_info_alter().

--- a/og.module
+++ b/og.module
@@ -134,13 +134,10 @@ function og_entity_create_access(AccountInterface $account, array $context, $bun
     return $access_result;
   }
 
-  if ($entity_type_id == 'node') {
-    $node_access_strict = \Drupal::config('og.settings')->get('node_access_strict');
-
-    if (!$node_access_strict && $account->hasPermission("create $bundle content")) {
-      // The user has the core permission and strict node access is not set.
-      return AccessResult::neutral();
-    }
+  $node_access_strict = \Drupal::config('og.settings')->get('node_access_strict');
+  if ($entity_type_id == 'node' && !$node_access_strict && $account->hasPermission("create $bundle content")) {
+    // The user has the core permission and strict node access is not set.
+    return AccessResult::neutral();
   }
 
   // We can't check if user has create permissions, as there is no group

--- a/og.views.inc
+++ b/og.views.inc
@@ -34,7 +34,7 @@ function og_field_views_data(FieldStorageConfigInterface $field_storage) {
   // reference item is no different really.
   switch ($field_storage->getType()) {
     case 'og_standard_reference':
-      $entity_manager = \Drupal::entityManager();
+      $entity_manager = \Drupal::entityTypeManager();
       $entity_type_id = $field_storage->getTargetEntityTypeId();
       /** @var \Drupal\Core\Entity\Sql\DefaultTableMapping $table_mapping */
       $table_mapping = $entity_manager->getStorage($entity_type_id)->getTableMapping();

--- a/og_ui/og_ui.module
+++ b/og_ui/og_ui.module
@@ -8,7 +8,6 @@
 use Drupal\Core\Config\Entity\ConfigEntityBundleBase;
 use Drupal\Core\Entity\BundleEntityFormBase;
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;

--- a/og_ui/src/Controller/OgUiController.php
+++ b/og_ui/src/Controller/OgUiController.php
@@ -75,6 +75,7 @@ class OgUiController extends ControllerBase {
     $action = $type === 'roles' ? t('Edit roles') : t('Edit permissions');
     $header = [t('Group type'), t('Operations')];
     $rows = [];
+    $build = [];
 
     foreach ($this->groupTypeManager->getAllGroupBundles() as $entity_type => $bundles) {
       $definition = $this->entityTypeManager->getDefinition($entity_type);

--- a/og_ui/src/Form/AdminSettingsForm.php
+++ b/og_ui/src/Form/AdminSettingsForm.php
@@ -66,7 +66,6 @@ class AdminSettingsForm extends ConfigFormBase {
   public function buildForm(array $form, FormStateInterface $form_state) {
     $form = parent::buildForm($form, $form_state);
     $config_og = $this->config('og.settings');
-    $config_og_ui = $this->config('og_ui.settings');
 
     $form['og_group_manager_full_access'] = [
       '#type' => 'checkbox',

--- a/og_ui/src/Form/AdminSettingsForm.php
+++ b/og_ui/src/Form/AdminSettingsForm.php
@@ -82,7 +82,6 @@ class AdminSettingsForm extends ConfigFormBase {
     ];
 
     // @todo: Port og_ui_admin_people_view.
-
     $form['og_delete_orphans'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Delete orphans'),

--- a/phpcs-ruleset.xml.dist
+++ b/phpcs-ruleset.xml.dist
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<!-- PHP_CodeSniffer standard for Drupal modules. -->
+<!-- See http://pear.php.net/manual/en/package.php.php-codesniffer.annotated-ruleset.php -->
+<ruleset name="Drupal Module">
+    <description>Drupal coding standard for contributed modules</description>
+
+    <!-- Exclude unsupported file types. -->
+    <exclude-pattern>*.gif</exclude-pattern>
+    <exclude-pattern>*.less</exclude-pattern>
+    <exclude-pattern>*.png</exclude-pattern>
+
+    <!-- Minified files don't have to comply with coding standards. -->
+    <exclude-pattern>*.min.css</exclude-pattern>
+    <exclude-pattern>*.min.js</exclude-pattern>
+
+    <rule ref="./vendor/drupal/coder/coder_sniffer/Drupal" />
+</ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="pbm_default">
+  <description>Default PHP CodeSniffer configuration for Organic Groups.</description>
+  <rule ref="phpcs-ruleset.xml.dist"/>
+  <arg name="extensions" value="php,inc,module,install,info,test,profile,theme,css,js"/>
+  <arg name="report" value="full"/>
+  <arg value="p"/>
+  <file>.</file>
+  <exclude-pattern>./vendor</exclude-pattern>
+</ruleset>

--- a/scripts/travis-ci/run-test.sh
+++ b/scripts/travis-ci/run-test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Run either PHPUnit tests or PHP_CodeSniffer tests on Travis CI, depending
+# on the passed in parameter.
+
+case "$1" in
+    PHP_CodeSniffer)
+        cd $MODULE_DIR
+        composer install
+        ./vendor/bin/phpcs
+        exit $?
+        ;;
+    *)
+        ln -s $MODULE_DIR $DRUPAL_DIR/modules/og
+        cd $DRUPAL_DIR
+        ./vendor/bin/phpunit -c ./core/phpunit.xml.dist $MODULE_DIR/tests
+        exit $?
+esac

--- a/src/Entity/OgMembership.php
+++ b/src/Entity/OgMembership.php
@@ -192,7 +192,9 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
    */
   public function getRoles() {
     // Add the member role.
-    $roles[] = OgRole::getRole($this->getGroupEntityType(), $this->getGroup()->bundle(), OgRoleInterface::AUTHENTICATED);
+    $roles = [
+      OgRole::getRole($this->getGroupEntityType(), $this->getGroup()->bundle(), OgRoleInterface::AUTHENTICATED),
+    ];
     $roles = array_merge($roles, $this->get('roles')->referencedEntities());
     return $roles;
   }
@@ -228,7 +230,7 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
       return FALSE;
     }
 
-    return array_filter($this->getRoles(), function (OgRole $role) use ($permission) {
+    return (bool) array_filter($this->getRoles(), function (OgRole $role) use ($permission) {
       return $role->hasPermission($permission);
     });
   }

--- a/src/Entity/OgRole.php
+++ b/src/Entity/OgRole.php
@@ -38,6 +38,13 @@ use Drupal\user\Entity\Role;
 class OgRole extends Role implements OgRoleInterface {
 
   /**
+   * The role name.
+   *
+   * @var string
+   */
+  protected $name;
+
+  /**
    * Constructs an OgRole object.
    *
    * @param array $values

--- a/src/GroupTypeManager.php
+++ b/src/GroupTypeManager.php
@@ -92,9 +92,7 @@ class GroupTypeManager {
    * Do not access this property directly, use $this->getGroupRelationMap()
    * instead.
    *
-   * @var array $groupRelationMap
-   *   An associative array representing group and group content relations, in
-   *   the following format:
+   * This mapping is in the following format:
    * @code
    *   [
    *     'group_entity_type_id' => [
@@ -106,6 +104,9 @@ class GroupTypeManager {
    *     ],
    *   ]
    * @endcode
+   *
+   * @var array $groupRelationMap
+   *   An associative array representing group and group content relations.
    */
   protected $groupRelationMap = [];
 

--- a/src/Og.php
+++ b/src/Og.php
@@ -362,11 +362,12 @@ class Og {
    * @param string $plugin_id
    *   The plugin ID, which is also the default field name.
    *
-   * @throws \Exception
-   *
    * @return OgFieldBase|bool
    *   An array with the field storage config and field config definitions, or
    *   FALSE if none found.
+   *
+   * @throws \Exception
+   *   Thrown when the requested plugin is not valid.
    */
   protected static function getFieldBaseDefinition($plugin_id) {
     /** @var OgFieldsPluginManager $plugin_manager */
@@ -390,6 +391,8 @@ class Og {
    *   Returns the OG selection handler.
    *
    * @throws \Exception
+   *   Thrown when the passed in field definition is not of a group audience
+   *   field.
    */
   public static function getSelectionHandler(FieldDefinitionInterface $field_definition, array $options = []) {
     if (!OgGroupAudienceHelper::isGroupAudienceField($field_definition)) {

--- a/src/OgAccess.php
+++ b/src/OgAccess.php
@@ -118,7 +118,7 @@ class OgAccess implements OgAccessInterface {
     // As Og::isGroup depends on this config, we retrieve it here and set it as
     // the minimal caching data.
     $config = $this->configFactory->get('og.settings');
-    $cacheable_metadata = (new CacheableMetadata)
+    $cacheable_metadata = (new CacheableMetadata())
         ->addCacheableDependency($config);
 
     if (!$this->groupTypeManager->isGroup($group_type_id, $bundle)) {

--- a/src/OgDeleteOrphansBase.php
+++ b/src/OgDeleteOrphansBase.php
@@ -149,7 +149,7 @@ abstract class OgDeleteOrphansBase extends PluginBase implements OgDeleteOrphans
   /**
    * {@inheritdoc}
    */
-  public function configurationForm($form, FormStateInterface $form_state) {
+  public function configurationForm(array $form, FormStateInterface $form_state) {
     return [];
   }
 

--- a/src/OgDeleteOrphansInterface.php
+++ b/src/OgDeleteOrphansInterface.php
@@ -46,6 +46,6 @@ interface OgDeleteOrphansInterface {
    * @return array $form
    *   The renderable form array representing the entire configuration form.
    */
-  public function configurationForm($form, FormStateInterface $form_state);
+  public function configurationForm(array $form, FormStateInterface $form_state);
 
 }

--- a/src/OgFieldBase.php
+++ b/src/OgFieldBase.php
@@ -60,7 +60,6 @@ abstract class OgFieldBase extends PluginBase implements OgFieldsInterface {
     $field_storage = $this->getFieldStorageBaseDefinition();
 
     if (!empty($field_storage['entity']) && !in_array($entity_type, $field_storage['entity'])) {
-
       $plugin_id = $this->getPluginId();
       $entities = implode(', ', $field_storage['entity']);
 
@@ -69,7 +68,6 @@ abstract class OgFieldBase extends PluginBase implements OgFieldsInterface {
       }
 
       throw new \Exception("The Organic Groups field with plugin ID $plugin_id cannot be attached to the entity type. It can only be attached to the following entities: $entities.");
-
     }
 
     $this->entityType = $entity_type;

--- a/src/OgFieldBase.php
+++ b/src/OgFieldBase.php
@@ -65,7 +65,6 @@ abstract class OgFieldBase extends PluginBase implements OgFieldsInterface {
       $entities = implode(', ', $field_storage['entity']);
 
       if ($field_name = $this->getFieldName()) {
-        $params['@field_name'] = $field_name;
         throw new \Exception("The Organic Groups field with plugin ID $plugin_id with the name $field_name cannot be attached to the entity type. It can only be attached to the following entities: $entities.");
       }
 

--- a/src/Plugin/EntityReferenceSelection/OgSelection.php
+++ b/src/Plugin/EntityReferenceSelection/OgSelection.php
@@ -65,9 +65,9 @@ class OgSelection extends DefaultSelection {
     // bundle defined as group.
     $query = $this->getSelectionHandler()->buildEntityQuery($match, $match_operator);
     $target_type = $this->configuration['target_type'];
-    $entityDefinition = \Drupal::entityTypeManager()->getDefinition($target_type);
+    $definition = \Drupal::entityTypeManager()->getDefinition($target_type);
 
-    if ($bundle_key = $entityDefinition->getKey('bundle')) {
+    if ($bundle_key = $definition->getKey('bundle')) {
       $bundles = Og::groupTypeManager()->getAllGroupBundles($target_type);
 
       if (!$bundles) {
@@ -82,7 +82,7 @@ class OgSelection extends DefaultSelection {
       return $query;
     }
 
-    $identifier_key = $entityDefinition->getKey('id');
+    $identifier_key = $definition->getKey('id');
 
     $ids = [];
     if (!empty($this->configuration['handler_settings']['field_mode']) && $this->configuration['handler_settings']['field_mode'] == 'admin') {

--- a/src/Plugin/OgDeleteOrphans/Batch.php
+++ b/src/Plugin/OgDeleteOrphans/Batch.php
@@ -30,7 +30,7 @@ class Batch extends OgDeleteOrphansBase {
   /**
    * {@inheritdoc}
    */
-  public function configurationForm($form, FormStateInterface $form_state) {
+  public function configurationForm(array $form, FormStateInterface $form_state) {
     $count = $this->getQueue()->numberOfItems();
     return [
       '#type' => 'fieldset',


### PR DESCRIPTION
This is a followup and cleanup of my experiment with using Scrutinizer CI for coding standards checks in https://github.com/amitaibu/og/pull/301

I was unhappy about a number of things with our current implementation of testing on Travis:
- Test dependencies were being installed in hard coded `before_script` instructions, instead of declaring our dev dependencies in `composer.json` and leveraging that.
- Some magic was done by downloading Coder and symlinking its coding standards inside PHP_CodeSniffer before executing the coding standards checks. The standard way of doing this is to declare our coding standards in a ruleset, and configurating PHP_CodeSniffer with a `phpcs.xml` file. This can then also be used by developers working on the module by simply running `./vendor/bin/phpcs` from the module folder.
- The coding standards checks were running before the "real" tests, delaying the important results.  Also having a coding standards violation would fail every test. These should run in a separate instance.
- The coding standards checks were running for all different PHP versions and all different versions of core, this is overkill, we only need to check it once.

I have experimented by splitting the work between Travis CI and Scrutinizer CI. Scrutinizer CI is dedicated to static analysis, and it returns some useful suggestions, but mainly a whole bunch of false positives. The things it finds are quite minor, and this does not weigh up against the difficulty of setting it up, and the burden of having to maintain a long list of false positives. I have abandoned this idea, but I have made a commit with the improvements that were suggested by the service, so this work is not lost.

I also tried out the ContinuousPHP service. This was very easy to set up, I had the coding standards checks set up and running in 5 minutes, but this service unfortunately requires to set up pipelines manually through a web UI. It does not yet support a `.continuousphp.yml` configuration file (it is promised for the future though).

So I finally reworked the Travis CI configuration to run the coding standards checks in a separate process. I have also done some major cleanup to the config file. I have removed the deprecated PHP 5.5 version, and have added Drupal 8.3.x which is now open for development.

I have added a small script to run the Travis CI tests. I am personally not a big fan of using shell scripts for CI, but this is recommended by Travis: the exit error codes of the test scripts are piped through and fail or pass the build. If the bash script is unwanted I can work this functionality in the main Travis configuration file.
