### PR TITLE
Group roles load

### DIFF
--- a/src/OgRoleManager.php
+++ b/src/OgRoleManager.php
@@ -117,7 +117,7 @@ class OgRoleManager implements OgRoleManagerInterface {
   /**
    * {@inheritdoc}
    */
-  public function loadRolesByBundle($entity_type_id, $bundle) {
+  public function getRolesByBunlde($entity_type_id, $bundle) {
     $properties = [
       'group_type' => $entity_type_id,
       'group_bundle' => $bundle,

--- a/src/OgRoleManager.php
+++ b/src/OgRoleManager.php
@@ -118,13 +118,12 @@ class OgRoleManager implements OgRoleManagerInterface {
   /**
    * {@inheritdoc}
    */
-  public function loadRolesByGroup(EntityInterface $group) {
+  public function loadRolesByGroup($entity_type_id, $bundle) {
     $properties = [
-      'group_type' => $group->getEntityTypeId(),
-      'group_bundle' => $group->bundle(),
+      'group_type' => $entity_type_id,
+      'group_bundle' => $bundle,
     ];
-    $role_ids = $this->ogRoleStorage->loadByProperties($properties);
-    return $this->ogRoleStorage->loadMultiple($role_ids);
+    return $this->ogRoleStorage->loadByProperties($properties);
   }
 
   /**

--- a/src/OgRoleManager.php
+++ b/src/OgRoleManager.php
@@ -117,7 +117,7 @@ class OgRoleManager implements OgRoleManagerInterface {
   /**
    * {@inheritdoc}
    */
-  public function getRolesByGroupTypeAndBundle($entity_type_id, $bundle) {
+  public function loadRolesByBundle($entity_type_id, $bundle) {
     $properties = [
       'group_type' => $entity_type_id,
       'group_bundle' => $bundle,

--- a/src/OgRoleManager.php
+++ b/src/OgRoleManager.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\og;
 
-use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\og\Event\DefaultRoleEvent;
 use Drupal\og\Event\DefaultRoleEventInterface;

--- a/src/OgRoleManager.php
+++ b/src/OgRoleManager.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\og;
 
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\og\Event\DefaultRoleEvent;
 use Drupal\og\Event\DefaultRoleEventInterface;
@@ -112,6 +113,18 @@ class OgRoleManager implements OgRoleManagerInterface {
     }
 
     return $roles;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function loadRolesByGroup(EntityInterface $group) {
+    $properties = [
+      'group_type' => $group->getEntityTypeId(),
+      'group_bundle' => $group->bundle(),
+    ];
+    $role_ids = $this->ogRoleStorage->loadByProperties($properties);
+    return $this->ogRoleStorage->loadMultiple($role_ids);
   }
 
   /**

--- a/src/OgRoleManager.php
+++ b/src/OgRoleManager.php
@@ -117,7 +117,7 @@ class OgRoleManager implements OgRoleManagerInterface {
   /**
    * {@inheritdoc}
    */
-  public function loadRolesByGroup($entity_type_id, $bundle) {
+  public function getRolesByGroupTypeAndBundle($entity_type_id, $bundle) {
     $properties = [
       'group_type' => $entity_type_id,
       'group_bundle' => $bundle,

--- a/src/OgRoleManagerInterface.php
+++ b/src/OgRoleManagerInterface.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Drupal\og;
+use Drupal\Core\Entity\EntityInterface;
 
 /**
  * Defines an interface for OG role manager.
@@ -44,6 +45,17 @@ interface OgRoleManagerInterface {
    *   role_type.
    */
   public function getRequiredDefaultRoles();
+
+  /**
+   * Returns all the roles of a provided group.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $group
+   *   The group for which to return the roles.
+   *
+   * @return \Drupal\og\OgRoleInterface[]
+   *   An array of roles indexed by their ids.
+   */
+  public function loadRolesByGroup(EntityInterface $group);
 
   /**
    * Deletes the roles associated with a group type.

--- a/src/OgRoleManagerInterface.php
+++ b/src/OgRoleManagerInterface.php
@@ -56,7 +56,7 @@ interface OgRoleManagerInterface {
    * @return \Drupal\og\OgRoleInterface[]
    *   An array of roles indexed by their ids.
    */
-  public function getRolesByGroupTypeAndBundle($entity_type_id, $bundle);
+  public function loadRolesByBundle($entity_type_id, $bundle);
 
   /**
    * Deletes the roles associated with a group type.

--- a/src/OgRoleManagerInterface.php
+++ b/src/OgRoleManagerInterface.php
@@ -49,13 +49,15 @@ interface OgRoleManagerInterface {
   /**
    * Returns all the roles of a provided group.
    *
-   * @param \Drupal\Core\Entity\EntityInterface $group
-   *   The group for which to return the roles.
+   * @param string $entity_type_id
+   *    The entity type id of the group.
+   * @param string $bundle
+   *    The bundle of the group.
    *
    * @return \Drupal\og\OgRoleInterface[]
    *   An array of roles indexed by their ids.
    */
-  public function loadRolesByGroup(EntityInterface $group);
+  public function loadRolesByGroup($entity_type_id, $bundle);
 
   /**
    * Deletes the roles associated with a group type.

--- a/src/OgRoleManagerInterface.php
+++ b/src/OgRoleManagerInterface.php
@@ -56,7 +56,7 @@ interface OgRoleManagerInterface {
    * @return \Drupal\og\OgRoleInterface[]
    *   An array of roles indexed by their ids.
    */
-  public function loadRolesByGroup($entity_type_id, $bundle);
+  public function getRolesByGroupTypeAndBundle($entity_type_id, $bundle);
 
   /**
    * Deletes the roles associated with a group type.

--- a/src/OgRoleManagerInterface.php
+++ b/src/OgRoleManagerInterface.php
@@ -56,7 +56,7 @@ interface OgRoleManagerInterface {
    * @return \Drupal\og\OgRoleInterface[]
    *   An array of roles indexed by their ids.
    */
-  public function loadRolesByBundle($entity_type_id, $bundle);
+  public function getRolesByBunlde($entity_type_id, $bundle);
 
   /**
    * Deletes the roles associated with a group type.

--- a/src/OgRoleManagerInterface.php
+++ b/src/OgRoleManagerInterface.php
@@ -1,7 +1,6 @@
 <?php
 
 namespace Drupal\og;
-use Drupal\Core\Entity\EntityInterface;
 
 /**
  * Defines an interface for OG role manager.

--- a/tests/src/Kernel/OgRoleManagerTest.php
+++ b/tests/src/Kernel/OgRoleManagerTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Drupal\Tests\og\Kernel;
+
+use Drupal\Component\Utility\Unicode;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\node\Entity\NodeType;
+use Drupal\og\Entity\OgRole;
+use Drupal\og\Og;
+
+/**
+ * Tests deletion of orphaned group content and memberships.
+ *
+ * @group og
+ */
+class OgRoleManagerTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'system',
+    'user',
+    'field',
+    'entity_reference',
+    'node',
+    'og',
+  ];
+
+  /**
+   * A test group.
+   *
+   * @var \Drupal\Core\Entity\EntityInterface
+   */
+  protected $group;
+
+  /**
+   * A test group bundle.
+   *
+   * @var string
+   */
+  protected $bundle;
+
+  /**
+   * A test Og role name.
+   *
+   * @var string
+   */
+  protected $roleName;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+
+    // Add membership and config schema.
+    $this->installConfig(['og']);
+    $this->installEntitySchema('node');
+    $this->bundle = Unicode::strtolower($this->randomMachineName());
+    $this->roleName = Unicode::strtolower($this->randomMachineName());
+
+
+    // Create a group entity type.
+    NodeType::create([
+      'type' => $this->bundle,
+      'name' => $this->randomString(),
+    ])->save();
+    Og::groupTypeManager()->addGroup('node', $this->bundle);
+
+    // Create a custom role as well to verify that the tests covers custom roles
+    // as well.
+    $og_role = OgRole::create();
+    $og_role
+      ->setName($this->roleName)
+      ->setLabel($this->randomString())
+      ->setGroupType('node')
+      ->setGroupBundle($this->bundle)
+      ->grantPermission('administer group')
+      ->save();
+  }
+
+  /**
+   * Tests that all roles are loaded for a certain group.
+   */
+  public function testLoadRolesByGroup() {
+    $expected_role_ids = [
+      'node-' . $this->bundle . '-administrator',
+      'node-' . $this->bundle . '-member',
+      'node-' . $this->bundle . '-non-member',
+      'node-' . $this->bundle . '-' . $this->roleName,
+    ];
+
+    $role_manager = $this->container->get('og.role_manager');
+    $roles = $role_manager->loadRolesByGroup('node', $this->bundle);
+    $role_ids = array_keys($roles);
+    $this->assertEquals($expected_role_ids, $role_ids);
+  }
+
+}

--- a/tests/src/Kernel/OgRoleManagerTest.php
+++ b/tests/src/Kernel/OgRoleManagerTest.php
@@ -90,7 +90,7 @@ class OgRoleManagerTest extends KernelTestBase {
     ];
 
     $role_manager = $this->container->get('og.role_manager');
-    $roles = $role_manager->getRolesByGroupTypeAndBundle('node', $this->bundle);
+    $roles = $role_manager->loadRolesByBundle('node', $this->bundle);
     $role_ids = array_keys($roles);
     $this->assertEquals($expected_role_ids, $role_ids);
   }

--- a/tests/src/Kernel/OgRoleManagerTest.php
+++ b/tests/src/Kernel/OgRoleManagerTest.php
@@ -81,7 +81,7 @@ class OgRoleManagerTest extends KernelTestBase {
   /**
    * Tests that all roles are loaded for a certain group.
    */
-  public function testLoadRolesByGroup() {
+  public function testGetRolesByBundle() {
     $expected_role_ids = [
       'node-' . $this->bundle . '-administrator',
       'node-' . $this->bundle . '-member',

--- a/tests/src/Kernel/OgRoleManagerTest.php
+++ b/tests/src/Kernel/OgRoleManagerTest.php
@@ -66,8 +66,8 @@ class OgRoleManagerTest extends KernelTestBase {
     ])->save();
     Og::groupTypeManager()->addGroup('node', $this->bundle);
 
-    // Create a custom role as well to verify that the tests covers custom roles
-    // as well.
+    // Create a custom role to verify that the tests covers custom roles as
+    // well.
     $og_role = OgRole::create();
     $og_role
       ->setName($this->roleName)

--- a/tests/src/Kernel/OgRoleManagerTest.php
+++ b/tests/src/Kernel/OgRoleManagerTest.php
@@ -22,7 +22,6 @@ class OgRoleManagerTest extends KernelTestBase {
     'system',
     'user',
     'field',
-    'entity_reference',
     'node',
     'og',
   ];
@@ -59,7 +58,6 @@ class OgRoleManagerTest extends KernelTestBase {
     $this->installEntitySchema('node');
     $this->bundle = Unicode::strtolower($this->randomMachineName());
     $this->roleName = Unicode::strtolower($this->randomMachineName());
-
 
     // Create a group entity type.
     NodeType::create([

--- a/tests/src/Kernel/OgRoleManagerTest.php
+++ b/tests/src/Kernel/OgRoleManagerTest.php
@@ -90,7 +90,7 @@ class OgRoleManagerTest extends KernelTestBase {
     ];
 
     $role_manager = $this->container->get('og.role_manager');
-    $roles = $role_manager->loadRolesByGroup('node', $this->bundle);
+    $roles = $role_manager->getRolesByGroupTypeAndBundle('node', $this->bundle);
     $role_ids = array_keys($roles);
     $this->assertEquals($expected_role_ids, $role_ids);
   }

--- a/tests/src/Kernel/OgRoleManagerTest.php
+++ b/tests/src/Kernel/OgRoleManagerTest.php
@@ -90,7 +90,7 @@ class OgRoleManagerTest extends KernelTestBase {
     ];
 
     $role_manager = $this->container->get('og.role_manager');
-    $roles = $role_manager->loadRolesByBundle('node', $this->bundle);
+    $roles = $role_manager->getRolesByBunlde('node', $this->bundle);
     $role_ids = array_keys($roles);
     $this->assertEquals($expected_role_ids, $role_ids);
   }

--- a/tests/src/Unit/OgRoleManagerTest.php
+++ b/tests/src/Unit/OgRoleManagerTest.php
@@ -159,27 +159,6 @@ class OgRoleManagerTest extends UnitTestCase {
   }
 
   /**
-   * Tests retrieval of roles from the database for a certain group.
-   *
-   * @covers ::loadRolesByGroup
-   *
-   * @dataProvider bundleRolesProvider
-   */
-  public function testLoadRolesByGroup() {
-    $properties = [
-      'group_type' => $this->entityTypeId,
-      'group_bundle' => $this->bundle,
-    ];
-    $this->ogRoleStorage->loadByProperties($properties)
-      ->willReturn([
-        $this->ogRole->reveal(),
-        $this->ogRole->reveal(),
-        $this->ogRole->reveal(),
-      ])
-      ->shouldBeCalled();
-  }
-
-  /**
    * Provides test data to test bundle roles creation.
    *
    * @return array

--- a/tests/src/Unit/OgRoleManagerTest.php
+++ b/tests/src/Unit/OgRoleManagerTest.php
@@ -159,6 +159,27 @@ class OgRoleManagerTest extends UnitTestCase {
   }
 
   /**
+   * Tests retrieval of roles from the database for a certain group.
+   *
+   * @covers ::loadRolesByGroup
+   *
+   * @dataProvider bundleRolesProvider
+   */
+  public function testLoadRolesByGroup() {
+    $properties = [
+      'group_type' => $this->entityTypeId,
+      'group_bundle' => $this->bundle,
+    ];
+    $this->ogRoleStorage->loadByProperties($properties)
+      ->willReturn([
+        $this->ogRole->reveal(),
+        $this->ogRole->reveal(),
+        $this->ogRole->reveal(),
+      ])
+      ->shouldBeCalled();
+  }
+
+  /**
    * Provides test data to test bundle roles creation.
    *
    * @return array


### PR DESCRIPTION
Given the work in progress of the UI and the use cases where we need to check roles per group, I was thinking that maybe we can have a method as part of the Role manager class that can load the roles of a group.

Currently, there is only a method to load a role given a group and a role name (in OgRole) but we do not have the sense of having all the roles of a group retrieved.

This was based on https://github.com/amitaibu/og/pull/196/files#diff-f5fb6aad0c225e8559cacebfcbf5d915R142 

Can this be valid? Is this functionality useful to be separate (since it is just a few lines of code)?
