### PR TITLE
Convert OgGroupAudienceHelper to an injectable service

### DIFF
--- a/og.module
+++ b/og.module
@@ -12,7 +12,7 @@ use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\og\Og;
-use Drupal\og\OgGroupAudienceHelper;
+use Drupal\og\OgGroupAudienceHelperInterface;
 use Drupal\user\EntityOwnerInterface;
 use Drupal\user\UserInterface;
 
@@ -145,7 +145,7 @@ function og_entity_create_access(AccountInterface $account, array $context, $bun
   $field_definitions = \Drupal::service('entity_field.manager')->getFieldDefinitions($entity_type_id, $bundle);
   foreach ($field_definitions as $field_name => $field_definition) {
     /** @var \Drupal\Core\Field\FieldDefinitionInterface $field_definition */
-    if (!OgGroupAudienceHelper::isGroupAudienceField($field_definition)) {
+    if (!\Drupal::service('og.group_audience_helper')->isGroupAudienceField($field_definition)) {
       continue;
     }
 
@@ -215,7 +215,7 @@ function og_field_formatter_info_alter(array &$info) {
       continue;
     }
 
-    $info[$key]['field_types'][] = OgGroupAudienceHelper::GROUP_REFERENCE;
+    $info[$key]['field_types'][] = OgGroupAudienceHelperInterface::GROUP_REFERENCE;
   }
 }
 
@@ -223,7 +223,7 @@ function og_field_formatter_info_alter(array &$info) {
  * Implements hook_field_widget_info_alter().
  */
 function og_field_widget_info_alter(array &$info) {
-  $info['options_buttons']['field_types'][] = OgGroupAudienceHelper::GROUP_REFERENCE;
+  $info['options_buttons']['field_types'][] = OgGroupAudienceHelperInterface::GROUP_REFERENCE;
 }
 
 /**

--- a/og.services.yml
+++ b/og.services.yml
@@ -11,18 +11,21 @@ services:
       - { name: 'cache.context'}
   og.access:
     class: Drupal\og\OgAccess
-    arguments: ['@config.factory', '@current_user', '@module_handler', '@og.group_type_manager', '@og.permission_manager', '@og.membership_manager']
+    arguments: ['@config.factory', '@current_user', '@module_handler', '@og.group_type_manager', '@og.permission_manager', '@og.membership_manager', '@og.group_audience_helper']
   og.membership_manager:
     class: Drupal\og\MembershipManager
-    arguments: ['@entity_type.manager']
+    arguments: ['@entity_type.manager', '@og.group_audience_helper']
   og.event_subscriber:
     class: Drupal\og\EventSubscriber\OgEventSubscriber
     arguments: ['@og.permission_manager', '@entity_type.manager', '@entity_type.bundle.info']
     tags:
       - { name: 'event_subscriber' }
+  og.group_audience_helper:
+    class: Drupal\og\OgGroupAudienceHelper
+    arguments: ['@entity_type.manager', '@entity_field.manager']
   og.group_type_manager:
     class: Drupal\og\GroupTypeManager
-    arguments: ['@config.factory', '@entity_type.manager', '@entity_type.bundle.info', '@event_dispatcher', '@state', '@og.permission_manager', '@og.role_manager', '@router.builder']
+    arguments: ['@config.factory', '@entity_type.manager', '@entity_type.bundle.info', '@event_dispatcher', '@state', '@og.permission_manager', '@og.role_manager', '@router.builder', '@og.group_audience_helper']
   og.permissions:
     class: Drupal\og\OgPermissionHandler
     arguments: ['@module_handler', '@string_translation', '@controller_resolver']

--- a/og_ui/og_ui.module
+++ b/og_ui/og_ui.module
@@ -12,7 +12,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\og\Og;
-use Drupal\og\OgGroupAudienceHelper;
+use Drupal\og\OgGroupAudienceHelperInterface;
 use Drupal\og_ui\BundleFormAlter;
 
 /**
@@ -69,16 +69,16 @@ function og_ui_entity_type_save(EntityInterface $entity) {
   $is_group_content = Og::isGroupContent($entity_type_id, $bundle);
   if ($entity->og_group_content_bundle != $is_group_content) {
     if ($entity->og_group_content_bundle) {
-      Og::createField(OgGroupAudienceHelper::DEFAULT_FIELD, $entity_type_id, $bundle);
+      Og::createField(OgGroupAudienceHelperInterface::DEFAULT_FIELD, $entity_type_id, $bundle);
     }
-    elseif ($field = FieldConfig::loadByName($entity_type_id, $bundle, OgGroupAudienceHelper::DEFAULT_FIELD)) {
+    elseif ($field = FieldConfig::loadByName($entity_type_id, $bundle, OgGroupAudienceHelperInterface::DEFAULT_FIELD)) {
       $field->delete();
       return;
     }
   }
 
   // Change the field target type and bundle.
-  if ($field_storage = FieldStorageConfig::loadByName($entity_type_id, OgGroupAudienceHelper::DEFAULT_FIELD)) {
+  if ($field_storage = FieldStorageConfig::loadByName($entity_type_id, OgGroupAudienceHelperInterface::DEFAULT_FIELD)) {
     $target_type = $field_storage->getSetting('target_type');
     if (!empty($entity->og_target_type) && $entity->og_target_type !== $target_type) {
       // @todo It's probably not possible to change the field storage after the
@@ -87,7 +87,7 @@ function og_ui_entity_type_save(EntityInterface $entity) {
       $field_storage->save();
     }
   }
-  if ($field = FieldConfig::loadByName($entity_type_id, $bundle, OgGroupAudienceHelper::DEFAULT_FIELD)) {
+  if ($field = FieldConfig::loadByName($entity_type_id, $bundle, OgGroupAudienceHelperInterface::DEFAULT_FIELD)) {
     $handler_settings = $field->getSetting('handler_settings');
     if (!isset($handler_settings['target_bundles']) || $entity->og_target_bundles != $handler_settings['target_bundles']) {
       $handler_settings['target_bundles'] = $entity->og_target_bundles;

--- a/og_ui/src/BundleFormAlter.php
+++ b/og_ui/src/BundleFormAlter.php
@@ -7,7 +7,7 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\og\Og;
-use Drupal\og\OgGroupAudienceHelper;
+use Drupal\og\OgGroupAudienceHelperInterface;
 
 /**
  * Helper for og_ui_form_alter().
@@ -131,7 +131,7 @@ class BundleFormAlter {
    */
   protected function addGroupContent(array &$form, FormStateInterface $form_state) {
     // Get the stored config from the default group audience field if it exists.
-    $field = FieldConfig::loadByName($this->entityTypeId, $this->bundle, OgGroupAudienceHelper::DEFAULT_FIELD);
+    $field = FieldConfig::loadByName($this->entityTypeId, $this->bundle, OgGroupAudienceHelperInterface::DEFAULT_FIELD);
     $handler_settings = $field ? $field->getSetting('handler_settings') : [];
 
     // Compile a list of group entity types and bundles.

--- a/src/GroupTypeManager.php
+++ b/src/GroupTypeManager.php
@@ -132,6 +132,13 @@ class GroupTypeManager {
   protected $routeBuilder;
 
   /**
+   * The OG group audience helper.
+   *
+   * @var \Drupal\og\OgGroupAudienceHelperInterface
+   */
+  protected $groupAudienceHelper;
+
+  /**
    * Constructs a GroupTypeManager object.
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
@@ -150,8 +157,10 @@ class GroupTypeManager {
    *   The OG role manager.
    * @param \Drupal\Core\Routing\RouteBuilderInterface $route_builder
    *   The route builder service.
+   * @param \Drupal\og\OgGroupAudienceHelperInterface $group_audience_helper
+   *   The OG group audience helper.
    */
-  public function __construct(ConfigFactoryInterface $config_factory, EntityTypeManagerInterface $entity_type_manager, EntityTypeBundleInfoInterface $entity_type_bundle_info, EventDispatcherInterface $event_dispatcher, StateInterface $state, PermissionManagerInterface $permission_manager, OgRoleManagerInterface $og_role_manager, RouteBuilderInterface $route_builder) {
+  public function __construct(ConfigFactoryInterface $config_factory, EntityTypeManagerInterface $entity_type_manager, EntityTypeBundleInfoInterface $entity_type_bundle_info, EventDispatcherInterface $event_dispatcher, StateInterface $state, PermissionManagerInterface $permission_manager, OgRoleManagerInterface $og_role_manager, RouteBuilderInterface $route_builder, OgGroupAudienceHelperInterface $group_audience_helper) {
     $this->configFactory = $config_factory;
     $this->ogRoleStorage = $entity_type_manager->getStorage('og_role');
     $this->entityTypeBundleInfo = $entity_type_bundle_info;
@@ -160,6 +169,7 @@ class GroupTypeManager {
     $this->permissionManager = $permission_manager;
     $this->ogRoleManager = $og_role_manager;
     $this->routeBuilder = $route_builder;
+    $this->groupAudienceHelper = $group_audience_helper;
   }
 
   /**
@@ -220,7 +230,7 @@ class GroupTypeManager {
   public function getGroupBundleIdsByGroupContentBundle($group_content_entity_type_id, $group_content_bundle_id) {
     $bundles = [];
 
-    foreach (OgGroupAudienceHelper::getAllGroupAudienceFields($group_content_entity_type_id, $group_content_bundle_id) as $field) {
+    foreach ($this->groupAudienceHelper->getAllGroupAudienceFields($group_content_entity_type_id, $group_content_bundle_id) as $field) {
       $group_entity_type_id = $field->getSetting('target_type');
       $handler_settings = $field->getSetting('handler_settings');
       $group_bundle_ids = !empty($handler_settings['target_bundles']) ? $handler_settings['target_bundles'] : [];

--- a/src/GroupTypeManager.php
+++ b/src/GroupTypeManager.php
@@ -189,6 +189,24 @@ class GroupTypeManager {
   }
 
   /**
+   * Checks if the given entity bundle is group content.
+   *
+   * This is provided as a convenient sister method to ::isGroup(). It is a
+   * simple wrapper for OgGroupAudienceHelperInterface::hasGroupAudienceField().
+   *
+   * @param string $entity_type_id
+   *   The entity type ID.
+   * @param string $bundle
+   *   The bundle name.
+   *
+   * @return bool
+   *   TRUE if the entity bundle is group content.
+   */
+  public function isGroupContent($entity_type_id, $bundle) {
+    return $this->groupAudienceHelper->hasGroupAudienceField($entity_type_id, $bundle);
+  }
+
+  /**
    * Returns the group of an entity type.
    *
    * @param string $entity_type_id

--- a/src/MembershipManager.php
+++ b/src/MembershipManager.php
@@ -30,13 +30,23 @@ class MembershipManager implements MembershipManagerInterface {
   protected $entityTypeManager;
 
   /**
+   * The OG group audience helper.
+   *
+   * @var \Drupal\og\OgGroupAudienceHelperInterface
+   */
+  protected $groupAudienceHelper;
+
+  /**
    * Constructs a MembershipManager object.
    *
    * @param \Drupal\core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
+   * @param \Drupal\og\OgGroupAudienceHelperInterface $group_audience_helper
+   *   The OG group audience helper.
    */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, OgGroupAudienceHelperInterface $group_audience_helper) {
     $this->entityTypeManager = $entity_type_manager;
+    $this->groupAudienceHelper = $group_audience_helper;
   }
 
   /**
@@ -158,7 +168,7 @@ class MembershipManager implements MembershipManagerInterface {
 
     $group_ids = [];
 
-    $fields = OgGroupAudienceHelper::getAllGroupAudienceFields($entity->getEntityTypeId(), $entity->bundle(), $group_type_id, $group_bundle);
+    $fields = $this->groupAudienceHelper->getAllGroupAudienceFields($entity->getEntityTypeId(), $entity->bundle(), $group_type_id, $group_bundle);
     foreach ($fields as $field) {
       $target_type = $field->getFieldStorageDefinition()->getSetting('target_type');
 
@@ -242,7 +252,7 @@ class MembershipManager implements MembershipManagerInterface {
     $query = $this->entityTypeManager
       ->getStorage('field_storage_config')
       ->getQuery()
-      ->condition('type', OgGroupAudienceHelper::GROUP_REFERENCE);
+      ->condition('type', OgGroupAudienceHelperInterface::GROUP_REFERENCE);
 
     // Optionally filter group content entity types.
     if ($entity_types) {

--- a/src/Og.php
+++ b/src/Og.php
@@ -255,7 +255,7 @@ class Og {
   /**
    * Check if the given entity type and bundle is a group content.
    *
-   * This is just a convenience wrapper around Og::getAllGroupAudienceFields().
+   * This works by checking if the bundle has one or more group audience fields.
    *
    * @param string $entity_type_id
    *   The entity type.
@@ -266,7 +266,7 @@ class Og {
    *   True or false if the given entity is group content.
    */
   public static function isGroupContent($entity_type_id, $bundle_id) {
-    return (bool) OgGroupAudienceHelper::getAllGroupAudienceFields($entity_type_id, $bundle_id);
+    return \Drupal::service('og.group_audience_helper')->hasGroupAudienceField($entity_type_id, $bundle_id);
   }
 
   /**
@@ -395,7 +395,7 @@ class Og {
    *   field.
    */
   public static function getSelectionHandler(FieldDefinitionInterface $field_definition, array $options = []) {
-    if (!OgGroupAudienceHelper::isGroupAudienceField($field_definition)) {
+    if (!\Drupal::service('og.group_audience_helper')->isGroupAudienceField($field_definition)) {
       $field_name = $field_definition->getName();
       throw new \Exception("The field $field_name is not an audience field.");
     }

--- a/src/OgGroupAudienceHelperInterface.php
+++ b/src/OgGroupAudienceHelperInterface.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Drupal\og;
+
+use Drupal\Core\Field\FieldDefinitionInterface;
+
+/**
+ * Interface for a service that deals with group audience fields.
+ */
+interface OgGroupAudienceHelperInterface {
+  /**
+   * The name of the field type that references non-user entities to groups.
+   */
+  const GROUP_REFERENCE = 'og_standard_reference';
+  /**
+   * The default OG audience field name.
+   */
+  const DEFAULT_FIELD = 'og_audience';
+
+  /**
+   * Returns whether the given entity bundle has a group audience field.
+   *
+   * This can be used to determine whether the bundle is group content.
+   *
+   * @param string $entity_type_id
+   *   The entity type ID to check for the presence of group audience fields.
+   * @param string $bundle_id
+   *   The bundle name to check for the presence of group audience fields.
+   *
+   * @return bool
+   *   TRUE if the field is a group audience type, FALSE otherwise.
+   */
+  public function hasGroupAudienceField($entity_type_id, $bundle_id);
+
+  /**
+   * Returns TRUE if field is a group audience type.
+   *
+   * @param \Drupal\Core\Field\FieldDefinitionInterface $field_definition
+   *   The field definition object.
+   *
+   * @return bool
+   *   TRUE if the field is a group audience type, FALSE otherwise.
+   */
+  public static function isGroupAudienceField(FieldDefinitionInterface $field_definition);
+
+  /**
+   * Returns all the group audience fields of a certain bundle.
+   *
+   * @param string $group_content_entity_type_id
+   *   The entity type ID of the group content for which to return audience
+   *   fields.
+   * @param string $group_content_bundle_id
+   *   The bundle name of the group content for which to return audience fields.
+   * @param string $group_entity_type_id
+   *   Filter list to only include fields referencing a specific group type. If
+   *   omitted, all fields will be returned.
+   * @param string $group_bundle_id
+   *   Filter list to only include fields referencing a specific group bundle.
+   *   Fields that do not specify any bundle restrictions at all are also
+   *   included. If omitted, the results will not be filtered by group bundle.
+   *
+   * @return \Drupal\Core\Field\FieldDefinitionInterface[]
+   *   An array of field definitions, keyed by field name; Or an empty array if
+   *   none found.
+   */
+  public function getAllGroupAudienceFields($group_content_entity_type_id, $group_content_bundle_id, $group_entity_type_id = NULL, $group_bundle_id = NULL);
+
+}

--- a/src/Plugin/OgFields/AudienceField.php
+++ b/src/Plugin/OgFields/AudienceField.php
@@ -5,7 +5,7 @@ namespace Drupal\og\Plugin\OgFields;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\og\OgFieldBase;
 use Drupal\og\OgFieldsInterface;
-use Drupal\og\OgGroupAudienceHelper;
+use Drupal\og\OgGroupAudienceHelperInterface;
 
 /**
  * Determine to which groups this group content is assigned to.
@@ -31,7 +31,7 @@ class AudienceField extends OgFieldBase implements OgFieldsInterface {
       'settings' => [
         'target_type' => $this->getEntityType(),
       ],
-      'type' => OgGroupAudienceHelper::GROUP_REFERENCE,
+      'type' => OgGroupAudienceHelperInterface::GROUP_REFERENCE,
     ];
 
     return parent::getFieldStorageBaseDefinition($values);

--- a/tests/src/Functional/GroupSubscribeFormatterTest.php
+++ b/tests/src/Functional/GroupSubscribeFormatterTest.php
@@ -105,7 +105,6 @@ class GroupSubscribeFormatterTest extends BrowserTestBase {
     $this->drupalLogin($this->user2);
     $this->drupalGet('node/' . $this->group->id());
     $this->clickLink('Subscribe to group');
-
   }
 
 }

--- a/tests/src/Functional/OgComplexWidgetTest.php
+++ b/tests/src/Functional/OgComplexWidgetTest.php
@@ -6,7 +6,7 @@ use Drupal\block_content\Entity\BlockContent;
 use Drupal\block_content\Entity\BlockContentType;
 use Drupal\node\Entity\Node;
 use Drupal\og\Og;
-use Drupal\og\OgGroupAudienceHelper;
+use Drupal\og\OgGroupAudienceHelperInterface;
 use Drupal\simpletest\BrowserTestBase;
 use Drupal\simpletest\ContentTypeCreationTrait;
 use Drupal\simpletest\NodeCreationTrait;
@@ -48,7 +48,7 @@ class OgComplexWidgetTest extends BrowserTestBase {
         ],
       ],
     ];
-    Og::createField(OgGroupAudienceHelper::DEFAULT_FIELD, 'node', 'post', $settings);
+    Og::createField(OgGroupAudienceHelperInterface::DEFAULT_FIELD, 'node', 'post', $settings);
   }
 
   /**
@@ -102,7 +102,7 @@ class OgComplexWidgetTest extends BrowserTestBase {
 
     // Check that the post references the group correctly.
     /** @var OgMembershipReferenceItemList $reference_list */
-    $reference_list = $post->get(OgGroupAudienceHelper::DEFAULT_FIELD);
+    $reference_list = $post->get(OgGroupAudienceHelperInterface::DEFAULT_FIELD);
     $this->assertEquals(1, $reference_list->count(), "There is 1 reference after adding a group to the '$field' field.");
     $this->assertEquals($group->id(), $reference_list->first()->getValue()['target_id'], "The '$field' field references the correct group.");
   }

--- a/tests/src/Kernel/Access/AccessByOgMembershipTest.php
+++ b/tests/src/Kernel/Access/AccessByOgMembershipTest.php
@@ -10,7 +10,7 @@ use Drupal\node\Entity\NodeType;
 use Drupal\og\Entity\OgMembership;
 use Drupal\og\Entity\OgRole;
 use Drupal\og\Og;
-use Drupal\og\OgGroupAudienceHelper;
+use Drupal\og\OgGroupAudienceHelperInterface;
 use Drupal\og\OgMembershipInterface;
 use Drupal\og\OgRoleInterface;
 use Drupal\simpletest\ContentTypeCreationTrait;
@@ -126,7 +126,7 @@ class AccessByOgMembershipTest extends KernelTestBase {
         ],
       ],
     ];
-    Og::createField(OgGroupAudienceHelper::DEFAULT_FIELD, 'node', 'group_content', $settings);
+    Og::createField(OgGroupAudienceHelperInterface::DEFAULT_FIELD, 'node', 'group_content', $settings);
 
     // Grant both members and non-members permission to edit any group content.
     foreach ([OgRoleInterface::AUTHENTICATED, OgRoleInterface::ANONYMOUS] as $role_name) {
@@ -160,7 +160,7 @@ class AccessByOgMembershipTest extends KernelTestBase {
         'title' => $this->randomString(),
         'type' => 'group_content',
         'uid' => $this->users[$membership_type]->id(),
-        OgGroupAudienceHelper::DEFAULT_FIELD => [['target_id' => $this->group->id()]],
+        OgGroupAudienceHelperInterface::DEFAULT_FIELD => [['target_id' => $this->group->id()]],
       ]);
       $this->groupContent[$membership_type]->save();
     }

--- a/tests/src/Kernel/Access/OgAccessHookTest.php
+++ b/tests/src/Kernel/Access/OgAccessHookTest.php
@@ -9,7 +9,7 @@ use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
 use Drupal\og\Entity\OgMembership;
 use Drupal\og\Og;
-use Drupal\og\OgGroupAudienceHelper;
+use Drupal\og\OgGroupAudienceHelperInterface;
 use Drupal\og\OgMembershipInterface;
 use Drupal\user\Entity\Role;
 use Drupal\user\Entity\User;
@@ -142,7 +142,7 @@ class OgAccessHookTest extends KernelTestBase {
         ],
       ],
     ];
-    Og::createField(OgGroupAudienceHelper::DEFAULT_FIELD, 'node', 'group_content', $settings);
+    Og::createField(OgGroupAudienceHelperInterface::DEFAULT_FIELD, 'node', 'group_content', $settings);
 
     // Grant members permission to edit their own content.
     /** @var \Drupal\og\Entity\OgRole $role */
@@ -172,7 +172,7 @@ class OgAccessHookTest extends KernelTestBase {
         'title' => $this->randomString(),
         'type' => 'group_content',
         'uid' => $this->users[$membership_type]->id(),
-        OgGroupAudienceHelper::DEFAULT_FIELD => [['target_id' => $this->group->id()]],
+        OgGroupAudienceHelperInterface::DEFAULT_FIELD => [['target_id' => $this->group->id()]],
       ]);
       $this->groupContent[$membership_type]->save();
     }

--- a/tests/src/Kernel/Access/OgGroupContentOperationAccessTest.php
+++ b/tests/src/Kernel/Access/OgGroupContentOperationAccessTest.php
@@ -10,7 +10,7 @@ use Drupal\node\Entity\NodeType;
 use Drupal\og\Entity\OgMembership;
 use Drupal\og\Entity\OgRole;
 use Drupal\og\Og;
-use Drupal\og\OgGroupAudienceHelper;
+use Drupal\og\OgGroupAudienceHelperInterface;
 use Drupal\og\OgMembershipInterface;
 use Drupal\og\OgRoleInterface;
 use Drupal\user\Entity\User;
@@ -209,14 +209,14 @@ class OgGroupContentOperationAccessTest extends KernelTestBase {
         ],
       ],
     ];
-    Og::createField(OgGroupAudienceHelper::DEFAULT_FIELD, 'comment', 'newsletter', $settings);
+    Og::createField(OgGroupAudienceHelperInterface::DEFAULT_FIELD, 'comment', 'newsletter', $settings);
 
     // Create an 'article' group content type.
     NodeType::create([
       'type' => 'article',
       'name' => 'Article',
     ])->save();
-    Og::createField(OgGroupAudienceHelper::DEFAULT_FIELD, 'node', 'article', $settings);
+    Og::createField(OgGroupAudienceHelperInterface::DEFAULT_FIELD, 'node', 'article', $settings);
 
     // Create a group content entity owned by each test user, for both the
     // 'newsletter' and 'article' bundles.
@@ -237,7 +237,7 @@ class OgGroupContentOperationAccessTest extends KernelTestBase {
             $values = [
               'title' => $this->randomString(),
               'type' => $bundle_id,
-              OgGroupAudienceHelper::DEFAULT_FIELD => [['target_id' => $this->group->id()]],
+              OgGroupAudienceHelperInterface::DEFAULT_FIELD => [['target_id' => $this->group->id()]],
             ];
             break;
 
@@ -247,7 +247,7 @@ class OgGroupContentOperationAccessTest extends KernelTestBase {
               'comment_type' => $bundle_id,
               'entity_id' => $this->group->id(),
               'entity_type' => 'entity_test',
-              OgGroupAudienceHelper::DEFAULT_FIELD => [['target_id' => $this->group->id()]],
+              OgGroupAudienceHelperInterface::DEFAULT_FIELD => [['target_id' => $this->group->id()]],
             ];
             break;
         }

--- a/tests/src/Kernel/Entity/EntityCreateAccessTest.php
+++ b/tests/src/Kernel/Entity/EntityCreateAccessTest.php
@@ -6,7 +6,7 @@ use Drupal\KernelTests\KernelTestBase;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
 use Drupal\og\Og;
-use Drupal\og\OgGroupAudienceHelper;
+use Drupal\og\OgGroupAudienceHelperInterface;
 use Drupal\simpletest\ContentTypeCreationTrait;
 use Drupal\simpletest\NodeCreationTrait;
 use Drupal\user\Entity\Role;
@@ -76,7 +76,7 @@ class EntityCreateAccessTest extends KernelTestBase {
       'name' => $this->randomString(),
     ]);
     $this->groupContentType->save();
-    Og::createField(OgGroupAudienceHelper::DEFAULT_FIELD, 'node', 'post');
+    Og::createField(OgGroupAudienceHelperInterface::DEFAULT_FIELD, 'node', 'post');
   }
 
   /**

--- a/tests/src/Kernel/Entity/FieldCreateTest.php
+++ b/tests/src/Kernel/Entity/FieldCreateTest.php
@@ -7,7 +7,7 @@ use Drupal\field\Entity\FieldConfig;
 use Drupal\node\Entity\NodeType;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\og\Og;
-use Drupal\og\OgGroupAudienceHelper;
+use Drupal\og\OgGroupAudienceHelperInterface;
 
 /**
  * Testing field definition overrides.
@@ -67,7 +67,7 @@ class FieldCreateTest extends KernelTestBase {
   public function testValidFields() {
     // Simple create, for all the fields defined by OG core.
     $field_names = array(
-      OgGroupAudienceHelper::DEFAULT_FIELD,
+      OgGroupAudienceHelperInterface::DEFAULT_FIELD,
       OG_DEFAULT_ACCESS_FIELD,
     );
 
@@ -79,12 +79,12 @@ class FieldCreateTest extends KernelTestBase {
 
     // Override the field config.
     $bundle = $this->bundles[1];
-    Og::CreateField(OgGroupAudienceHelper::DEFAULT_FIELD, 'node', $bundle, ['field_config' => ['label' => 'Other groups dummy']]);
-    $this->assertEquals(FieldConfig::loadByName('node', $bundle, OgGroupAudienceHelper::DEFAULT_FIELD)->label(), 'Other groups dummy');
+    Og::CreateField(OgGroupAudienceHelperInterface::DEFAULT_FIELD, 'node', $bundle, ['field_config' => ['label' => 'Other groups dummy']]);
+    $this->assertEquals(FieldConfig::loadByName('node', $bundle, OgGroupAudienceHelperInterface::DEFAULT_FIELD)->label(), 'Other groups dummy');
 
     // Override the field storage config.
     $bundle = $this->bundles[2];
-    Og::CreateField(OgGroupAudienceHelper::DEFAULT_FIELD, 'node', $bundle, ['field_name' => 'override_name']);
+    Og::CreateField(OgGroupAudienceHelperInterface::DEFAULT_FIELD, 'node', $bundle, ['field_name' => 'override_name']);
     $this->assertNotNull(FieldConfig::loadByName('node', $bundle, 'override_name')->id());
 
     // Field that can be added only to certain entities.

--- a/tests/src/Kernel/Entity/GetBundleByBundleTest.php
+++ b/tests/src/Kernel/Entity/GetBundleByBundleTest.php
@@ -6,7 +6,7 @@ use Drupal\KernelTests\KernelTestBase;
 use Drupal\block_content\Entity\BlockContentType;
 use Drupal\node\Entity\NodeType;
 use Drupal\og\Og;
-use Drupal\og\OgGroupAudienceHelper;
+use Drupal\og\OgGroupAudienceHelperInterface;
 
 /**
  * Tests retrieving group content bundles by group bundles and vice versa.
@@ -142,7 +142,7 @@ class GetBundleByBundleTest extends KernelTestBase {
                 ],
               ];
             }
-            Og::createField(OgGroupAudienceHelper::DEFAULT_FIELD, $group_content_entity_type_id, $group_content_bundle_id, $settings);
+            Og::createField(OgGroupAudienceHelperInterface::DEFAULT_FIELD, $group_content_entity_type_id, $group_content_bundle_id, $settings);
           }
         }
       }

--- a/tests/src/Kernel/Entity/GetGroupContentTest.php
+++ b/tests/src/Kernel/Entity/GetGroupContentTest.php
@@ -8,7 +8,7 @@ use Drupal\entity_test\Entity\EntityTest;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
 use Drupal\og\Og;
-use Drupal\og\OgGroupAudienceHelper;
+use Drupal\og\OgGroupAudienceHelperInterface;
 use Drupal\user\Entity\User;
 
 /**
@@ -132,7 +132,7 @@ class GetGroupContentTest extends KernelTestBase {
             ],
           ],
         ];
-        Og::createField(OgGroupAudienceHelper::DEFAULT_FIELD, $entity_type, $bundle, $settings);
+        Og::createField(OgGroupAudienceHelperInterface::DEFAULT_FIELD, $entity_type, $bundle, $settings);
 
         // Create the group content entity.
         $label_field = $entity_type === 'node' ? 'title' : 'name';
@@ -200,13 +200,13 @@ class GetGroupContentTest extends KernelTestBase {
         ],
       ],
     ];
-    Og::createField(OgGroupAudienceHelper::DEFAULT_FIELD, 'entity_test', $bundle, $settings);
+    Og::createField(OgGroupAudienceHelperInterface::DEFAULT_FIELD, 'entity_test', $bundle, $settings);
 
     // Create a group content entity that references both groups.
     $group_content = $this->entityTypeManager->getStorage('entity_test')->create([
       'name' => $this->randomString(),
       'type' => $bundle,
-      OgGroupAudienceHelper::DEFAULT_FIELD => [
+      OgGroupAudienceHelperInterface::DEFAULT_FIELD => [
         ['target_id' => $groups[0]->id()],
         ['target_id' => $groups[1]->id()],
       ],
@@ -270,7 +270,7 @@ class GetGroupContentTest extends KernelTestBase {
           ],
         ],
       ];
-      Og::createField(OgGroupAudienceHelper::DEFAULT_FIELD, 'entity_test', $bundle, $settings);
+      Og::createField(OgGroupAudienceHelperInterface::DEFAULT_FIELD, 'entity_test', $bundle, $settings);
     }
 
     // Create a group content entity that references both groups.

--- a/tests/src/Kernel/Entity/GroupAudienceTest.php
+++ b/tests/src/Kernel/Entity/GroupAudienceTest.php
@@ -6,7 +6,7 @@ use Drupal\Component\Utility\Unicode;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\entity_test\Entity\EntityTest;
 use Drupal\og\Og;
-use Drupal\og\OgGroupAudienceHelper;
+use Drupal\og\OgGroupAudienceHelperInterface;
 
 /**
  * Tests the group audience field.
@@ -14,6 +14,13 @@ use Drupal\og\OgGroupAudienceHelper;
  * @group og
  */
 class GroupAudienceTest extends KernelTestBase {
+
+  /**
+   * The OG group audience helper.
+   *
+   * @var \Drupal\og\OgGroupAudienceHelperInterface
+   */
+  protected $groupAudienceHelper;
 
   /**
    * {@inheritdoc}
@@ -46,6 +53,8 @@ class GroupAudienceTest extends KernelTestBase {
     $this->installEntitySchema('og_membership');
     $this->installEntitySchema('user');
 
+    $this->groupAudienceHelper = $this->container->get('og.group_audience_helper');
+
     // Create several bundles.
     for ($i = 0; $i <= 4; $i++) {
       $bundle = EntityTest::create([
@@ -69,20 +78,20 @@ class GroupAudienceTest extends KernelTestBase {
     $bundle = $this->bundles[2];
 
     // Test no values returned for a non-group content.
-    $this->assertEmpty(OgGroupAudienceHelper::getAllGroupAudienceFields('entity_test', $bundle));
+    $this->assertEmpty($this->groupAudienceHelper->getAllGroupAudienceFields('entity_test', $bundle));
 
     // Set bundles as group content.
     $field_name1 = Unicode::strtolower($this->randomMachineName());
     $field_name2 = Unicode::strtolower($this->randomMachineName());
 
-    Og::createField(OgGroupAudienceHelper::DEFAULT_FIELD, 'entity_test', $bundle, ['field_name' => $field_name1]);
-    Og::createField(OgGroupAudienceHelper::DEFAULT_FIELD, 'entity_test', $bundle, ['field_name' => $field_name2]);
+    Og::createField(OgGroupAudienceHelperInterface::DEFAULT_FIELD, 'entity_test', $bundle, ['field_name' => $field_name1]);
+    Og::createField(OgGroupAudienceHelperInterface::DEFAULT_FIELD, 'entity_test', $bundle, ['field_name' => $field_name2]);
 
-    $field_names = OgGroupAudienceHelper::getAllGroupAudienceFields('entity_test', $bundle);
+    $field_names = $this->groupAudienceHelper->getAllGroupAudienceFields('entity_test', $bundle);
     $this->assertEquals([$field_name1, $field_name2], array_keys($field_names));
 
     // Test Og::isGroupContent method, which is just a wrapper around
-    // OgGroupAudienceHelper::getAllGroupAudienceFields.
+    // OgGroupAudienceHelper::hasGroupAudienceFields().
     $this->assertTrue(Og::isGroupContent('entity_test', $bundle));
 
     $bundle = $this->bundles[3];
@@ -109,12 +118,12 @@ class GroupAudienceTest extends KernelTestBase {
         ],
       ],
     ];
-    Og::createField(OgGroupAudienceHelper::DEFAULT_FIELD, 'entity_test', $bundle, $overrides);
+    Og::createField(OgGroupAudienceHelperInterface::DEFAULT_FIELD, 'entity_test', $bundle, $overrides);
 
     // Add a default field, which will use the "entity_test" as target type.
-    Og::createField(OgGroupAudienceHelper::DEFAULT_FIELD, 'entity_test', $bundle, ['field_name' => $field_name2]);
+    Og::createField(OgGroupAudienceHelperInterface::DEFAULT_FIELD, 'entity_test', $bundle, ['field_name' => $field_name2]);
 
-    $field_names = OgGroupAudienceHelper::getAllGroupAudienceFields('entity_test', $bundle, 'entity_test');
+    $field_names = $this->groupAudienceHelper->getAllGroupAudienceFields('entity_test', $bundle, 'entity_test');
     $this->assertEquals([$field_name2], array_keys($field_names));
   }
 
@@ -146,13 +155,13 @@ class GroupAudienceTest extends KernelTestBase {
         ],
       ],
     ];
-    Og::createField(OgGroupAudienceHelper::DEFAULT_FIELD, 'entity_test', $bundle, $overrides);
+    Og::createField(OgGroupAudienceHelperInterface::DEFAULT_FIELD, 'entity_test', $bundle, $overrides);
 
     $overrides['field_name'] = $field_name2;
     $overrides['field_config']['settings']['handler_settings']['target_bundles'] = [$group_bundle2 => $group_bundle2];
-    Og::createField(OgGroupAudienceHelper::DEFAULT_FIELD, 'entity_test', $bundle, $overrides);
+    Og::createField(OgGroupAudienceHelperInterface::DEFAULT_FIELD, 'entity_test', $bundle, $overrides);
 
-    $field_names = OgGroupAudienceHelper::getAllGroupAudienceFields('entity_test', $bundle, 'entity_test', $group_bundle1);
+    $field_names = $this->groupAudienceHelper->getAllGroupAudienceFields('entity_test', $bundle, 'entity_test', $group_bundle1);
     $this->assertEquals([$field_name1], array_keys($field_names));
   }
 

--- a/tests/src/Kernel/Entity/GroupMembershipManagerTest.php
+++ b/tests/src/Kernel/Entity/GroupMembershipManagerTest.php
@@ -8,7 +8,7 @@ use Drupal\entity_test\Entity\EntityTest;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
 use Drupal\og\Og;
-use Drupal\og\OgGroupAudienceHelper;
+use Drupal\og\OgGroupAudienceHelperInterface;
 use Drupal\user\Entity\User;
 
 /**
@@ -116,7 +116,7 @@ class GroupMembershipManagerTest extends KernelTestBase {
           ],
         ],
       ];
-      Og::createField(OgGroupAudienceHelper::DEFAULT_FIELD, 'entity_test', $bundle, $settings);
+      Og::createField(OgGroupAudienceHelperInterface::DEFAULT_FIELD, 'entity_test', $bundle, $settings);
     }
 
     // Create a group content entity that references all four groups.

--- a/tests/src/Kernel/Entity/OgNodePermissionsTest.php
+++ b/tests/src/Kernel/Entity/OgNodePermissionsTest.php
@@ -6,7 +6,7 @@ use Drupal\Component\Utility\Unicode;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\node\Entity\NodeType;
 use Drupal\og\Og;
-use Drupal\og\OgGroupAudienceHelper;
+use Drupal\og\OgGroupAudienceHelperInterface;
 
 /**
  * Test OG permissions for node entities.
@@ -37,7 +37,7 @@ class OgNodePermissionsTest extends KernelTestBase {
     ]);
 
     $bundle->save();
-    Og::CreateField(OgGroupAudienceHelper::DEFAULT_FIELD, 'node', $bundle->id());
+    Og::CreateField(OgGroupAudienceHelperInterface::DEFAULT_FIELD, 'node', $bundle->id());
 
     $name = $bundle->id();
     $expected = [

--- a/tests/src/Kernel/Entity/OgStandardReferenceItemTest.php
+++ b/tests/src/Kernel/Entity/OgStandardReferenceItemTest.php
@@ -6,7 +6,7 @@ use Drupal\Component\Utility\Unicode;
 use Drupal\entity_test\Entity\EntityTest;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\og\Og;
-use Drupal\og\OgGroupAudienceHelper;
+use Drupal\og\OgGroupAudienceHelperInterface;
 
 /**
  * Tests OgStandardReferenceItem class.
@@ -57,7 +57,7 @@ class OgStandardReferenceItemTest extends KernelTestBase {
     }
     $this->fieldName = strtolower($this->randomMachineName());
 
-    Og::CreateField(OgGroupAudienceHelper::DEFAULT_FIELD, 'entity_test', $this->bundles[2], ['field_name' => $this->fieldName]);
+    Og::CreateField(OgGroupAudienceHelperInterface::DEFAULT_FIELD, 'entity_test', $this->bundles[2], ['field_name' => $this->fieldName]);
   }
 
   /**

--- a/tests/src/Kernel/Entity/ReferenceStringIdTest.php
+++ b/tests/src/Kernel/Entity/ReferenceStringIdTest.php
@@ -6,7 +6,7 @@ use Drupal\Component\Utility\Unicode;
 use Drupal\entity_test\Entity\EntityTestStringId;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\og\Og;
-use Drupal\og\OgGroupAudienceHelper;
+use Drupal\og\OgGroupAudienceHelperInterface;
 
 /**
  * Checks that groups with string IDs can be referenced.
@@ -79,7 +79,7 @@ class ReferenceStringIdTest extends KernelTestBase {
     // Add a group audience field to the second bundle, this will turn it into a
     // group content type.
     $this->fieldName = strtolower($this->randomMachineName());
-    Og::CreateField(OgGroupAudienceHelper::DEFAULT_FIELD, 'entity_test_string_id', $this->bundles[1], [
+    Og::CreateField(OgGroupAudienceHelperInterface::DEFAULT_FIELD, 'entity_test_string_id', $this->bundles[1], [
       'field_name' => $this->fieldName,
     ]);
   }

--- a/tests/src/Kernel/Entity/SelectionHandlerTest.php
+++ b/tests/src/Kernel/Entity/SelectionHandlerTest.php
@@ -8,7 +8,7 @@ use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\og\Og;
-use Drupal\og\OgGroupAudienceHelper;
+use Drupal\og\OgGroupAudienceHelperInterface;
 use Drupal\user\Entity\User;
 
 /**
@@ -105,7 +105,7 @@ class SelectionHandlerTest extends KernelTestBase {
     Og::groupTypeManager()->addGroup('node', $this->groupBundle);
 
     // Add og audience field to group content.
-    $this->fieldDefinition = Og::createField(OgGroupAudienceHelper::DEFAULT_FIELD, 'node', $this->groupContentBundle);
+    $this->fieldDefinition = Og::createField(OgGroupAudienceHelperInterface::DEFAULT_FIELD, 'node', $this->groupContentBundle);
 
     // Get the storage of the field.
     $this->selectionHandler = Og::getSelectionHandler($this->fieldDefinition, ['handler_settings' => ['field_mode' => 'default']]);

--- a/tests/src/Kernel/EntityReference/Views/OgStandardReferenceRelationshipTest.php
+++ b/tests/src/Kernel/EntityReference/Views/OgStandardReferenceRelationshipTest.php
@@ -5,7 +5,7 @@ namespace Drupal\Tests\og\Kernel\EntityReference\Views;
 use Drupal\entity_test\Entity\EntityTest;
 use Drupal\entity_test\Entity\EntityTestMul;
 use Drupal\og\Og;
-use Drupal\og\OgGroupAudienceHelper;
+use Drupal\og\OgGroupAudienceHelperInterface;
 use Drupal\Tests\views\Kernel\ViewsKernelTestBase;
 use Drupal\views\Tests\ViewTestData;
 use Drupal\views\Views;
@@ -63,10 +63,10 @@ class OgStandardReferenceRelationshipTest extends ViewsKernelTestBase {
     $this->installEntitySchema('entity_test_mul');
 
     // Create reference from entity_test to entity_test_mul.
-    Og::createField(OgGroupAudienceHelper::DEFAULT_FIELD, 'entity_test', 'entity_test', ['field_name' => 'field_test_data', 'field_storage_config' => ['settings' => ['target_type' => 'entity_test_mul']]]);
+    Og::createField(OgGroupAudienceHelperInterface::DEFAULT_FIELD, 'entity_test', 'entity_test', ['field_name' => 'field_test_data', 'field_storage_config' => ['settings' => ['target_type' => 'entity_test_mul']]]);
 
     // Create reference from entity_test_mul to entity_test.
-    Og::createField(OgGroupAudienceHelper::DEFAULT_FIELD, 'entity_test_mul', 'entity_test_mul', ['field_name' => 'field_data_test', 'field_storage_config' => ['settings' => ['target_type' => 'entity_test']]]);
+    Og::createField(OgGroupAudienceHelperInterface::DEFAULT_FIELD, 'entity_test_mul', 'entity_test_mul', ['field_name' => 'field_data_test', 'field_storage_config' => ['settings' => ['target_type' => 'entity_test']]]);
 
     ViewTestData::createTestViews(get_class($this), ['og_standard_reference_test_views']);
   }

--- a/tests/src/Kernel/Field/AudienceFieldFormatterTest.php
+++ b/tests/src/Kernel/Field/AudienceFieldFormatterTest.php
@@ -3,7 +3,7 @@
 namespace Drupal\Tests\og\Kernel\Field;
 
 use Drupal\KernelTests\KernelTestBase;
-use Drupal\og\OgGroupAudienceHelper;
+use Drupal\og\OgGroupAudienceHelperInterface;
 
 /**
  * Test that formatters for entity reference can be applied to audience fields.
@@ -30,7 +30,7 @@ class AudienceFieldFormatterTest extends KernelTestBase {
       'entity_reference_label',
     ];
 
-    $actual = array_keys($formatter_manager->getOptions(OgGroupAudienceHelper::GROUP_REFERENCE));
+    $actual = array_keys($formatter_manager->getOptions(OgGroupAudienceHelperInterface::GROUP_REFERENCE));
     sort($actual);
     $this->assertEquals($expected, $actual);
   }

--- a/tests/src/Kernel/OgDeleteOrphansTest.php
+++ b/tests/src/Kernel/OgDeleteOrphansTest.php
@@ -7,7 +7,7 @@ use Drupal\KernelTests\KernelTestBase;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
 use Drupal\og\Og;
-use Drupal\og\OgGroupAudienceHelper;
+use Drupal\og\OgGroupAudienceHelperInterface;
 use Drupal\user\Entity\User;
 
 /**
@@ -75,7 +75,7 @@ class OgDeleteOrphansTest extends KernelTestBase {
       'type' => $group_content_bundle,
       'name' => $this->randomString(),
     ])->save();
-    Og::createField(OgGroupAudienceHelper::DEFAULT_FIELD, 'node', $group_content_bundle);
+    Og::createField(OgGroupAudienceHelperInterface::DEFAULT_FIELD, 'node', $group_content_bundle);
 
     // Create group admin user.
     $group_admin = User::create(['name' => $this->randomString()]);
@@ -93,7 +93,7 @@ class OgDeleteOrphansTest extends KernelTestBase {
     $group_content = Node::create([
       'title' => $this->randomString(),
       'type' => $group_content_bundle,
-      OgGroupAudienceHelper::DEFAULT_FIELD => [['target_id' => $this->group->id()]],
+      OgGroupAudienceHelperInterface::DEFAULT_FIELD => [['target_id' => $this->group->id()]],
     ]);
     $group_content->save();
   }

--- a/tests/src/Unit/CreateMembershipTest.php
+++ b/tests/src/Unit/CreateMembershipTest.php
@@ -9,6 +9,7 @@ use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\og\MembershipManager;
+use Drupal\og\OgGroupAudienceHelperInterface;
 use Drupal\og\OgMembershipInterface;
 use Drupal\Tests\UnitTestCase;
 use Prophecy\Argument;
@@ -34,6 +35,13 @@ class CreateMembershipTest extends UnitTestCase {
    * @var \Drupal\Core\Entity\EntityTypeManagerInterface|\Prophecy\Prophecy\ObjectProphecy
    */
   protected $entityTypeManager;
+
+  /**
+   * The OG group audience helper.
+   *
+   * @var \Drupal\og\OgGroupAudienceHelperInterface|\Prophecy\Prophecy\ObjectProphecy
+   */
+  protected $groupAudienceHelper;
 
   /**
    * The entity storage prophecy used in the test.
@@ -89,6 +97,7 @@ class CreateMembershipTest extends UnitTestCase {
     $this->entityStorage = $this->prophesize(EntityStorageInterface::class);
     $this->entityManager = $this->prophesize(EntityManagerInterface::class);
     $this->entityTypeManager = $this->prophesize(EntityTypeManagerInterface::class);
+    $this->groupAudienceHelper = $this->prophesize(OgGroupAudienceHelperInterface::class);
 
     $this->entityManager->getStorage('og_membership')
       ->willReturn($this->entityStorage->reveal());
@@ -128,7 +137,7 @@ class CreateMembershipTest extends UnitTestCase {
    * @covers ::createMembership
    */
   public function testNewGroup() {
-    $membership_manager = new MembershipManager($this->entityTypeManager->reveal());
+    $membership_manager = new MembershipManager($this->entityTypeManager->reveal(), $this->groupAudienceHelper->reveal());
     $membership = $membership_manager->createMembership($this->group->reveal(), $this->user->reveal());
     $this->assertInstanceOf(OgMembershipInterface::class, $membership);
   }

--- a/tests/src/Unit/GroupManagerTest.php
+++ b/tests/src/Unit/GroupManagerTest.php
@@ -12,6 +12,7 @@ use Drupal\Core\State\StateInterface;
 use Drupal\og\Event\GroupCreationEvent;
 use Drupal\og\Event\GroupCreationEventInterface;
 use Drupal\og\GroupTypeManager;
+use Drupal\og\OgGroupAudienceHelperInterface;
 use Drupal\og\PermissionManagerInterface;
 use Drupal\og\OgRoleManagerInterface;
 use Drupal\Tests\UnitTestCase;
@@ -113,6 +114,13 @@ class GroupManagerTest extends UnitTestCase {
   protected $routeBuilder;
 
   /**
+   * The OG group audience helper.
+   *
+   * @var \Drupal\og\OgGroupAudienceHelperInterface|\Prophecy\Prophecy\ObjectProphecy
+   */
+  protected $groupAudienceHelper;
+
+  /**
    * {@inheritdoc}
    */
   public function setUp() {
@@ -128,6 +136,7 @@ class GroupManagerTest extends UnitTestCase {
     $this->permissionManager = $this->prophesize(PermissionManagerInterface::class);
     $this->state = $this->prophesize(StateInterface::class);
     $this->routeBuilder = $this->prophesize(RouteBuilderInterface::class);
+    $this->groupAudienceHelper = $this->prophesize(OgGroupAudienceHelperInterface::class);
   }
 
   /**
@@ -331,7 +340,8 @@ class GroupManagerTest extends UnitTestCase {
       $this->state->reveal(),
       $this->permissionManager->reveal(),
       $this->ogRoleManager->reveal(),
-      $this->routeBuilder->reveal()
+      $this->routeBuilder->reveal(),
+      $this->groupAudienceHelper->reveal()
     );
   }
 

--- a/tests/src/Unit/OgAccessEntityTestBase.php
+++ b/tests/src/Unit/OgAccessEntityTestBase.php
@@ -10,7 +10,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
-use Drupal\og\OgGroupAudienceHelper;
+use Drupal\og\OgGroupAudienceHelperInterface;
 
 /**
  * OG access entity base class.
@@ -50,6 +50,11 @@ class OgAccessEntityTestBase extends OgAccessTestBase {
     $this->groupContentEntity->getEntityTypeId()->willReturn($entity_type_id);
     $this->addCache($this->groupContentEntity);
 
+    // If the group audience helper is asked if the group content entity has any
+    // group audience fields, it is expected that this will return TRUE.
+    $this->groupAudienceHelper->hasGroupAudienceField($entity_type_id, $bundle)
+      ->willReturn(TRUE);
+
     // It is expected that a list of entity operation permissions is retrieved
     // from the permission manager so that the passed in permission can be
     // checked against this list. Our permissions are not in the list, so it is
@@ -62,7 +67,7 @@ class OgAccessEntityTestBase extends OgAccessTestBase {
 
     // Mock retrieval of field definitions.
     $field_definition = $this->prophesize(FieldDefinitionInterface::class);
-    $field_definition->getType()->willReturn(OgGroupAudienceHelper::GROUP_REFERENCE);
+    $field_definition->getType()->willReturn(OgGroupAudienceHelperInterface::GROUP_REFERENCE);
     $field_definition->getFieldStorageDefinition()
       ->willReturn($this->prophesize(FieldStorageDefinitionInterface::class)->reveal());
     $field_definition->getSetting('handler_settings')->willReturn([]);

--- a/tests/src/Unit/OgAccessTestBase.php
+++ b/tests/src/Unit/OgAccessTestBase.php
@@ -13,6 +13,7 @@ use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\og\MembershipManagerInterface;
+use Drupal\og\OgGroupAudienceHelperInterface;
 use Drupal\og\OgMembershipInterface;
 use Drupal\Tests\UnitTestCase;
 use Drupal\og\GroupTypeManager;
@@ -98,6 +99,13 @@ class OgAccessTestBase extends UnitTestCase {
   protected $membershipManager;
 
   /**
+   * The OG group audience helper.
+   *
+   * @var \Drupal\og\OgGroupAudienceHelperInterface
+   */
+  protected $groupAudienceHelper;
+
+  /**
    * The entity manager service.
    *
    * @var \Drupal\Core\Entity\EntityManagerInterface|\Prophecy\Prophecy\ObjectProphecy
@@ -164,8 +172,11 @@ class OgAccessTestBase extends UnitTestCase {
     $this->group = $this->groupEntity()->reveal();
 
     $this->membershipManager = $this->prophesize(MembershipManagerInterface::class);
+    $this->membershipManager->getMembership($this->group, $this->user->reveal())->willReturn($this->membership->reveal());
     $this->membershipManager->getMembership($this->group, $this->user->reveal(), [OgMembershipInterface::STATE_ACTIVE])->willReturn($this->membership->reveal());
     $this->membership->getRoles()->willReturn([$this->ogRole->reveal()]);
+
+    $this->groupAudienceHelper = $this->prophesize(OgGroupAudienceHelperInterface::class);
 
     // @todo: Move to test.
     $this->ogRole->isAdmin()->willReturn(FALSE);
@@ -183,7 +194,8 @@ class OgAccessTestBase extends UnitTestCase {
       $module_handler->reveal(),
       $this->groupTypeManager->reveal(),
       $this->permissionManager->reveal(),
-      $this->membershipManager->reveal()
+      $this->membershipManager->reveal(),
+      $this->groupAudienceHelper->reveal()
     );
 
     $container = new ContainerBuilder();
@@ -193,6 +205,7 @@ class OgAccessTestBase extends UnitTestCase {
     $container->set('module_handler', $this->prophesize(ModuleHandlerInterface::class)->reveal());
     $container->set('og.group_type_manager', $this->groupTypeManager->reveal());
     $container->set('og.membership_manager', $this->membershipManager->reveal());
+    $container->set('og.group_audience_helper', $this->groupAudienceHelper->reveal());
 
     // This is for caching purposes only.
     $container->set('current_user', $this->user->reveal());


### PR DESCRIPTION
`OgGroupAudienceHelper` is one of the last bastions of procedural code in OG. Let's convert it into a service so we can inject it into whatever OO code that needs it. This will make it unit testable and will make it possible to swap it out for a customized implementation if this is needed for some reason.
