### PR TITLE
Fix typo in OgRoleManagerInterface

### DIFF
--- a/src/OgRoleManager.php
+++ b/src/OgRoleManager.php
@@ -117,7 +117,7 @@ class OgRoleManager implements OgRoleManagerInterface {
   /**
    * {@inheritdoc}
    */
-  public function getRolesByBunlde($entity_type_id, $bundle) {
+  public function getRolesByBundle($entity_type_id, $bundle) {
     $properties = [
       'group_type' => $entity_type_id,
       'group_bundle' => $bundle,

--- a/src/OgRoleManagerInterface.php
+++ b/src/OgRoleManagerInterface.php
@@ -56,7 +56,7 @@ interface OgRoleManagerInterface {
    * @return \Drupal\og\OgRoleInterface[]
    *   An array of roles indexed by their ids.
    */
-  public function getRolesByBunlde($entity_type_id, $bundle);
+  public function getRolesByBundle($entity_type_id, $bundle);
 
   /**
    * Deletes the roles associated with a group type.

--- a/tests/src/Kernel/OgRoleManagerTest.php
+++ b/tests/src/Kernel/OgRoleManagerTest.php
@@ -90,7 +90,7 @@ class OgRoleManagerTest extends KernelTestBase {
     ];
 
     $role_manager = $this->container->get('og.role_manager');
-    $roles = $role_manager->getRolesByBunlde('node', $this->bundle);
+    $roles = $role_manager->getRolesByBundle('node', $this->bundle);
     $role_ids = array_keys($roles);
     $this->assertEquals($expected_role_ids, $role_ids);
   }


### PR DESCRIPTION
Fix typo OgRoleManagerInterface::getRolesByBunlde => OgRoleManagerInterface::getRolesByBundle
