### PR TITLE
Filter OgRoleInterface::AUTHENTICATED on setRoles

### DIFF
--- a/src/Entity/OgMembership.php
+++ b/src/Entity/OgMembership.php
@@ -203,6 +203,9 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
    * {@inheritdoc}
    */
   public function setRoles(array $roles = []) {
+    $roles = array_filter($roles, function (OgRole $role) {
+      return !($role->getName() == OgRoleInterface::AUTHENTICATED);
+    });
     $role_ids = array_map(function (OgRole $role) {
       return $role->id();
     }, $roles);


### PR DESCRIPTION
I use hook_og_membership_presave to add an additional role to the membership entity. hook_og_membership_presave is fired after OgMembership::preSave which revokes OgRoleInterface::AUTHENTICATED. But OgMembership::addRole calls ::getRole and this adds  the authenticated role again. ::setRoles should filter authenticated role automatically.