### PR TITLE
Clear static caches after a group or group content entity is deleted

### DIFF
--- a/og.module
+++ b/og.module
@@ -71,6 +71,16 @@ function og_entity_predelete(EntityInterface $entity) {
 }
 
 /**
+ * Implements hook_entity_delete().
+ */
+function og_entity_delete(EntityInterface $entity) {
+  // Clear static caches after a group or group content entity is deleted.
+  if (Og::isGroup($entity->getEntityTypeId(), $entity->bundle()) || Og::isGroupContent($entity->getEntityTypeId(), $entity->bundle())) {
+    Og::invalidateCache();
+  }
+}
+
+/**
  * Implements hook_entity_access().
  */
 function og_entity_access(EntityInterface $entity, $operation, AccountInterface $account) {


### PR DESCRIPTION
In one of our tests we were getting a failure due to static caches not being cleared when a group is deleted:

```
PHP Fatal error:  Call to a member function bundle() on null in web/modules/contrib/og/src/Entity/OgMembership.php on line 196
```

Here is the backtrace, it happens when we are cleaning up groups created during Behat tests. Whenever a group is deleted, we have notifications being sent out to group administrators, but this still finds statically cached memberships from groups that were previously removed.

```
PHP  28. SolutionSubContext->cleanSolutions() vendor/behat/behat/src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php:104 
PHP  29. Drupal\Core\Entity\Entity->delete() web/modules/custom/solution/solution.behat.inc:413 
PHP  30. Drupal\Core\Entity\EntityStorageBase->delete() web/core/lib/Drupal/Core/Entity/Entity.php:372 
PHP  31. Drupal\Core\Entity\ContentEntityStorageBase->invokeHook() web/core/lib/Drupal/Core/Entity/EntityStorageBase.php:359 
PHP  32. Drupal\Core\Entity\EntityStorageBase->invokeHook() web/core/lib/Drupal/Core/Entity/ContentEntityStorageBase.php:418 
PHP  33. Drupal\Core\Extension\ModuleHandler->invokeAll() web/core/lib/Drupal/Core/Entity/EntityStorageBase.php:169 
PHP  34. call_user_func_array:{web/core/lib/Drupal/Core/Extension/ModuleHandler.php:402}() web/core/lib/Drupal/Core/Extension/ModuleHandler.php:402 
PHP  35. joinup_notification_entity_predelete() web/core/lib/Drupal/Core/Extension/ModuleHandler.php:402 
PHP  36. Drupal\joinup_notification\NotificationSenderService->send() web/modules/custom/joinup_notification/joinup_notification.module:52 
PHP  37. array_filter() web/modules/custom/joinup_notification/src/NotificationSenderService.php:80 
PHP  38. Drupal\joinup_notification\NotificationSenderService->Drupal\joinup_notification\{closure}() web/modules/custom/joinup_notification/src/NotificationSenderService.php:80 
PHP  39. Drupal\og\Entity\OgMembership->getRoles() web/modules/custom/joinup_notification/src/NotificationSenderService.php:78 
```

This PR just clears the entire OG static cache when a group or group content entity is deleted. I think for our use case it is probably enough to only clear the `MembershipManager` cache, but it seems logical to me to clear the entire cache when a group or group content is deleted.

At the moment this is a bit drastic since `Og::invalidateCache()` currently oversteps its responsibilities and also clears caches of the `EntityTypeManager` and `EntityFieldManager`, but that is a separate issue I think.

Reference material:
* The full build output of the failing build in which I discovered this bug: https://continuousphp.com/git-hub/ec-europa/joinup-dev/build/7cbd7346-96e0-412f-9f5e-18f1454086cb/output
* The PR containing the full code base in case you want to get a clear picture of what happens in the backtrace: https://github.com/ec-europa/joinup-dev/pull/274