### PR TITLE
Provide a Views default argument plugin that gets the group from OgContext

### DIFF
--- a/src/Plugin/views/argument_default/Group.php
+++ b/src/Plugin/views/argument_default/Group.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Drupal\og\Plugin\views\argument_default;
+
+use Drupal\Core\Cache\Cache;
+use Drupal\Core\Cache\CacheableDependencyInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Plugin\Context\ContextProviderInterface;
+use Drupal\views\Plugin\views\argument_default\ArgumentDefaultPluginBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Default argument plugin to provide the group from the current context.
+ *
+ * @ViewsArgumentDefault(
+ *   id = "og_group_context",
+ *   title = @Translation("Group ID from OG context")
+ * )
+ */
+class Group extends ArgumentDefaultPluginBase implements CacheableDependencyInterface {
+
+  /**
+   * The OG context provider.
+   *
+   * @var \Drupal\Core\Plugin\Context\ContextProviderInterface
+   */
+  protected $ogContext;
+
+  /**
+   * Constructs a new User instance.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   *
+   * @param \Drupal\Core\Plugin\Context\ContextProviderInterface $og_context
+   *   The OG context provider.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ContextProviderInterface $og_context) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+
+    $this->ogContext = $og_context;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('og.context')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function defineOptions() {
+    $options = parent::defineOptions();
+    $options['og_group_context'] = ['default' => ''];
+
+    return $options;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildOptionsForm(&$form, FormStateInterface $form_state) {
+    $form['og_group_context'] = [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getArgument() {
+    $contexts = $this->ogContext->getRuntimeContexts(['og']);
+    if (!empty($contexts['og']) && $group = $contexts['og']->getContextValue()) {
+      if ($group instanceof ContentEntityInterface) {
+        return $group->id();
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheMaxAge() {
+    return Cache::PERMANENT;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheContexts() {
+    // @todo This should return the active group cache context as soon as we
+    //   have it.
+    return [];
+  }
+
+}
+

--- a/src/Plugin/views/argument_default/Group.php
+++ b/src/Plugin/views/argument_default/Group.php
@@ -36,7 +36,6 @@ class Group extends ArgumentDefaultPluginBase implements CacheableDependencyInte
    *   The plugin_id for the plugin instance.
    * @param mixed $plugin_definition
    *   The plugin implementation definition.
-   *
    * @param \Drupal\Core\Plugin\Context\ContextProviderInterface $og_context
    *   The OG context provider.
    */
@@ -79,11 +78,9 @@ class Group extends ArgumentDefaultPluginBase implements CacheableDependencyInte
    * {@inheritdoc}
    */
   public function getArgument() {
-    $contexts = $this->ogContext->getRuntimeContexts(['og']);
-    if (!empty($contexts['og']) && $group = $contexts['og']->getContextValue()) {
-      if ($group instanceof ContentEntityInterface) {
-        return $group->id();
-      }
+    $group = $this->getGroup();
+    if ($group instanceof ContentEntityInterface) {
+      return $group->id();
     }
   }
 
@@ -103,5 +100,31 @@ class Group extends ArgumentDefaultPluginBase implements CacheableDependencyInte
     return [];
   }
 
-}
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheTags() {
+    $group = $this->getGroup();
+    if ($group instanceof ContentEntityInterface) {
+      $tag = $group->getEntityTypeId() . ':' . $group->id();
+      return Cache::buildTags('og-group-content', [$tag]);
+    }
+    return [];
+  }
 
+  /**
+   * Returns the group that is relevant in the current context.
+   *
+   * @return \Drupal\Core\Entity\ContentEntityInterface|null
+   *   The group, or NULL if no group is found.
+   */
+  protected function getGroup() {
+    $contexts = $this->ogContext->getRuntimeContexts(['og']);
+    if (!empty($contexts['og']) && $group = $contexts['og']->getContextValue()) {
+      if ($group instanceof ContentEntityInterface) {
+        return $group;
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
I was trying to create a "Recent group content" view as part of my work on #216 but I had to abandon this idea because of my inadequate level of Views-fu. I still would like to contribute the default argument plugin I wrote as part of this work. It will get the active group from OgContext and supply it as a default argument.

How to test:

1. Set up a group that has group content of type `node`.
1. Create a new view named "Recent group content" that shows "Content" of type "All" sorted by "Newest first". Enable the "Create a block" checkbox and set it to display an "Unformatted list" of "titles (linked)".
1. Add a contextual filter to the view for the group audience field of your group content type.
1. Configure the contextual filter. Set the option "Provide default value" for "When the filter value is not available". From the dropdown select "Group ID from OG context".
1. Save the view.
1. In the block configuration, enable the "Recent group content" block.

You will now see a list of recent group content on your group pages.