### PR TITLE
OgMembership static cache are not cleared on membership save

### DIFF
--- a/src/Entity/OgMembership.php
+++ b/src/Entity/OgMembership.php
@@ -369,6 +369,9 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
     Og::reset();
     \Drupal::service('og.access')->reset();
 
+    // Invalidate the group membership manager.
+    \Drupal::service('og.membership_manager')->reset();
+
     return $result;
   }
 

--- a/tests/src/Kernel/Entity/OgMembershipTest.php
+++ b/tests/src/Kernel/Entity/OgMembershipTest.php
@@ -107,6 +107,31 @@ class OgMembershipTest extends KernelTestBase {
   }
 
   /**
+   * Tests getting an ogMembership from the static cache.
+   */
+  public function testMembershipStaticCache() {
+    // Create a second bundle and add as a group.
+    $another_group = EntityTest::create([
+      'type' => Unicode::strtolower($this->randomMachineName()),
+      'name' => $this->randomString(),
+    ]);
+    $another_group->save();
+    Og::groupTypeManager()->addGroup('entity_test', $another_group->bundle());
+
+    $membership = Og::createMembership($this->group, $this->user);
+    $membership->save();
+    // Load the membership to instantiate the membership static cache.
+    $membership = Og::getMembership($this->group, $this->user);
+    $this->assertInstanceOf(OgMembership::class, $membership);
+
+    // Create another membership for the given user on the same request.
+    $membership = Og::createMembership($another_group, $this->user);
+    $membership->save();
+    $membership = Og::getMembership($another_group, $this->user);
+    $this->assertInstanceOf(OgMembership::class, $membership);
+  }
+
+  /**
    * Tests exceptions are thrown when trying to save a membership with no user.
    *
    * @covers ::preSave


### PR DESCRIPTION
I ran across a bug when I was trying to create a test using multiple users and groups which ends up being an issue in OgMembership static cache.

I am going to provide a failing test first and then a small fix but the main idea is (Steps to reproduce):

- An OgMembership is being created and saved.
- The OgMembership above is loaded. The static cache is being populated by the membership and user tag.
- A new OgMembership is being created for the same user in another group. The static cache is not being cleared.
- The new OgMembership is attempted to be loaded. No membership is found because the static cache only has the first value.

This happens because the static cache identifier tag is in the form of <code>\<OgMembership class>:\<user id>:\<state type></code>. When the second one is being loaded, the user does not change, so the static cache returns the first result only which was already cached.