### PR TITLE
Fix PHP_CodeSniffer warnings

### DIFF
--- a/src/Event/PermissionEvent.php
+++ b/src/Event/PermissionEvent.php
@@ -60,7 +60,7 @@ class PermissionEvent extends Event implements PermissionEventInterface {
    *   An array of group content bundle IDs, keyed by group content entity type
    *   ID.
    */
-  public function __construct($group_entity_type_id, $group_bundle_id, $group_content_bundle_ids) {
+  public function __construct($group_entity_type_id, $group_bundle_id, array $group_content_bundle_ids) {
     $this->groupEntityTypeId = $group_entity_type_id;
     $this->groupBundleId = $group_bundle_id;
     $this->groupContentBundleIds = $group_content_bundle_ids;

--- a/src/MembershipManager.php
+++ b/src/MembershipManager.php
@@ -292,7 +292,7 @@ class MembershipManager implements MembershipManagerInterface {
   /**
    * {@inheritdoc}
    */
-  public function isMember(EntityInterface $group, AccountInterface $user, $states = [OgMembershipInterface::STATE_ACTIVE]) {
+  public function isMember(EntityInterface $group, AccountInterface $user, array $states = [OgMembershipInterface::STATE_ACTIVE]) {
     $group_ids = $this->getUserGroupIds($user, $states);
     $entity_type_id = $group->getEntityTypeId();
     return !empty($group_ids[$entity_type_id]) && in_array($group->id(), $group_ids[$entity_type_id]);

--- a/src/MembershipManagerInterface.php
+++ b/src/MembershipManagerInterface.php
@@ -201,7 +201,7 @@ interface MembershipManagerInterface {
    *   TRUE if the entity (e.g. the user or node) belongs to a group with
    *   a certain state.
    */
-  public function isMember(EntityInterface $group, AccountInterface $user, $states = [OgMembershipInterface::STATE_ACTIVE]);
+  public function isMember(EntityInterface $group, AccountInterface $user, array $states = [OgMembershipInterface::STATE_ACTIVE]);
 
   /**
    * Returns whether a user belongs to a group with a pending status.

--- a/src/Og.php
+++ b/src/Og.php
@@ -197,7 +197,7 @@ class Og {
    * @return bool
    *   TRUE if the user belongs to a group with a certain state.
    */
-  public static function isMember(EntityInterface $group, AccountInterface $user, $states = [OgMembershipInterface::STATE_ACTIVE]) {
+  public static function isMember(EntityInterface $group, AccountInterface $user, array $states = [OgMembershipInterface::STATE_ACTIVE]) {
     /** @var \Drupal\og\MembershipManagerInterface $membership_manager */
     $membership_manager = \Drupal::service('og.membership_manager');
     return $membership_manager->isMember($group, $user, $states);

--- a/tests/src/Kernel/Form/GroupSubscribeFormTest.php
+++ b/tests/src/Kernel/Form/GroupSubscribeFormTest.php
@@ -193,7 +193,7 @@ class GroupSubscribeFormTest extends KernelTestBase {
    * @return \Drupal\user\Entity\User
    *   The created user entity.
    */
-  protected function createUser($permissions = []) {
+  protected function createUser(array $permissions = []) {
     $values = [];
     if ($permissions) {
       // Create a new role and apply permissions to it.

--- a/tests/src/Unit/DefaultRoleEventTest.php
+++ b/tests/src/Unit/DefaultRoleEventTest.php
@@ -53,7 +53,7 @@ class DefaultRoleEventTest extends UnitTestCase {
    *
    * @dataProvider defaultRoleProvider
    */
-  public function testGetRole($roles) {
+  public function testGetRole(array $roles) {
     $this->expectOgRoleCreation($roles);
 
     $this->defaultRoleEvent->setRoles($roles);
@@ -74,7 +74,7 @@ class DefaultRoleEventTest extends UnitTestCase {
    *
    * @dataProvider defaultRoleProvider
    */
-  public function testGetRoles($roles) {
+  public function testGetRoles(array $roles) {
     $this->expectOgRoleCreation($roles);
 
     $this->defaultRoleEvent->setRoles($roles);
@@ -97,7 +97,7 @@ class DefaultRoleEventTest extends UnitTestCase {
    *
    * @dataProvider defaultRoleProvider
    */
-  public function testAddRole($roles) {
+  public function testAddRole(array $roles) {
     $this->expectOgRoleCreation($roles);
 
     foreach ($roles as $name => $role) {
@@ -126,7 +126,7 @@ class DefaultRoleEventTest extends UnitTestCase {
    *
    * @dataProvider defaultRoleProvider
    */
-  public function testAddRoles($roles) {
+  public function testAddRoles(array $roles) {
     $this->expectOgRoleCreation($roles);
 
     $this->defaultRoleEvent->addRoles($roles);
@@ -149,7 +149,7 @@ class DefaultRoleEventTest extends UnitTestCase {
    *
    * @dataProvider defaultRoleProvider
    */
-  public function testSetRole($roles) {
+  public function testSetRole(array $roles) {
     $this->expectOgRoleCreation($roles);
 
     foreach ($roles as $name => $role) {
@@ -173,7 +173,7 @@ class DefaultRoleEventTest extends UnitTestCase {
    *
    * @dataProvider defaultRoleProvider
    */
-  public function testDeleteRole($roles) {
+  public function testDeleteRole(array $roles) {
     $this->expectOgRoleCreation($roles);
 
     $this->defaultRoleEvent->setRoles($roles);
@@ -195,7 +195,7 @@ class DefaultRoleEventTest extends UnitTestCase {
    *
    * @dataProvider defaultRoleProvider
    */
-  public function testHasRole($roles) {
+  public function testHasRole(array $roles) {
     $this->expectOgRoleCreation($roles);
 
     foreach ($roles as $name => $role) {
@@ -215,7 +215,7 @@ class DefaultRoleEventTest extends UnitTestCase {
    *
    * @dataProvider defaultRoleProvider
    */
-  public function testOffsetGet($roles) {
+  public function testOffsetGet(array $roles) {
     $this->expectOgRoleCreation($roles);
 
     $this->defaultRoleEvent->setRoles($roles);
@@ -235,7 +235,7 @@ class DefaultRoleEventTest extends UnitTestCase {
    *
    * @dataProvider defaultRoleProvider
    */
-  public function testOffsetSet($roles) {
+  public function testOffsetSet(array $roles) {
     $this->expectOgRoleCreation($roles);
 
     foreach ($roles as $name => $role) {
@@ -255,7 +255,7 @@ class DefaultRoleEventTest extends UnitTestCase {
    *
    * @dataProvider defaultRoleProvider
    */
-  public function testOffsetUnset($roles) {
+  public function testOffsetUnset(array $roles) {
     $this->expectOgRoleCreation($roles);
 
     $this->defaultRoleEvent->setRoles($roles);
@@ -277,7 +277,7 @@ class DefaultRoleEventTest extends UnitTestCase {
    *
    * @dataProvider defaultRoleProvider
    */
-  public function testOffsetExists($roles) {
+  public function testOffsetExists(array $roles) {
     $this->expectOgRoleCreation($roles);
 
     foreach ($roles as $name => $role) {
@@ -297,7 +297,7 @@ class DefaultRoleEventTest extends UnitTestCase {
    *
    * @dataProvider defaultRoleProvider
    */
-  public function testIteratorAggregate($roles) {
+  public function testIteratorAggregate(array $roles) {
     $this->expectOgRoleCreation($roles);
 
     $this->defaultRoleEvent->setRoles($roles);
@@ -321,7 +321,7 @@ class DefaultRoleEventTest extends UnitTestCase {
    *
    * @dataProvider invalidDefaultRoleProvider
    */
-  public function testAddInvalidRole($invalid_roles) {
+  public function testAddInvalidRole(array $invalid_roles) {
     $this->expectOgRoleCreation($invalid_roles);
 
     try {
@@ -348,7 +348,7 @@ class DefaultRoleEventTest extends UnitTestCase {
    * @dataProvider invalidDefaultRoleProvider
    * @expectedException \InvalidArgumentException
    */
-  public function testAddInvalidRoles($invalid_roles) {
+  public function testAddInvalidRoles(array $invalid_roles) {
     $this->expectOgRoleCreation($invalid_roles);
 
     $this->defaultRoleEvent->addRoles($invalid_roles);
@@ -366,7 +366,7 @@ class DefaultRoleEventTest extends UnitTestCase {
    * @dataProvider invalidDefaultRoleProvider
    * @expectedException \InvalidArgumentException
    */
-  public function testSetInvalidRole($invalid_roles) {
+  public function testSetInvalidRole(array $invalid_roles) {
     $this->expectOgRoleCreation($invalid_roles);
 
     foreach ($invalid_roles as $name => $invalid_role) {
@@ -385,7 +385,7 @@ class DefaultRoleEventTest extends UnitTestCase {
    * @dataProvider invalidDefaultRoleProvider
    * @expectedException \InvalidArgumentException
    */
-  public function testSetInvalidRoles($invalid_roles) {
+  public function testSetInvalidRoles(array $invalid_roles) {
     $this->expectOgRoleCreation($invalid_roles);
 
     $this->defaultRoleEvent->setRoles($invalid_roles);
@@ -402,7 +402,7 @@ class DefaultRoleEventTest extends UnitTestCase {
    * @dataProvider invalidDefaultRoleProvider
    * @expectedException \InvalidArgumentException
    */
-  public function testInvalidOffsetSet($invalid_roles) {
+  public function testInvalidOffsetSet(array $invalid_roles) {
     $this->expectOgRoleCreation($invalid_roles);
 
     foreach ($invalid_roles as $name => $invalid_role) {

--- a/tests/src/Unit/GroupContentOperationPermissionTest.php
+++ b/tests/src/Unit/GroupContentOperationPermissionTest.php
@@ -24,7 +24,7 @@ class GroupContentOperationPermissionTest extends UnitTestCase {
    *
    * @dataProvider groupContentOperationPermissionProvider
    */
-  public function testGetEntityType($values) {
+  public function testGetEntityType(array $values) {
     $permission = new GroupContentOperationPermission($values);
     $this->assertEquals($values['entity type'], $permission->getEntityType());
   }

--- a/tests/src/Unit/GroupManagerTest.php
+++ b/tests/src/Unit/GroupManagerTest.php
@@ -351,7 +351,7 @@ class GroupManagerTest extends UnitTestCase {
    * @param array $groups
    *   The expected group map that will be returned by the mocked config.
    */
-  protected function expectGroupMapRetrieval($groups = []) {
+  protected function expectGroupMapRetrieval(array $groups = []) {
     $this->configFactory->get('og.settings')
       ->willReturn($this->config->reveal())
       ->shouldBeCalled();

--- a/tests/src/Unit/OgResolvedGroupCollectionTest.php
+++ b/tests/src/Unit/OgResolvedGroupCollectionTest.php
@@ -131,7 +131,7 @@ class OgResolvedGroupCollectionTest extends UnitTestCase {
    *
    * @see testAddGroup()
    */
-  public function testGetGroupInfo($votes, array $expected_groups) {
+  public function testGetGroupInfo(array $votes, array $expected_groups) {
     $collection = new OgResolvedGroupCollection();
 
     foreach ($votes as $vote) {
@@ -243,7 +243,7 @@ class OgResolvedGroupCollectionTest extends UnitTestCase {
    *
    * @see testAddGroup()
    */
-  public function testSort($votes, array $expected_groups) {
+  public function testSort(array $votes, array $expected_groups) {
     $collection = new OgResolvedGroupCollection();
 
     // Cast all votes.

--- a/tests/src/Unit/Plugin/OgGroupResolver/RequestQueryArgumentResolverTest.php
+++ b/tests/src/Unit/Plugin/OgGroupResolver/RequestQueryArgumentResolverTest.php
@@ -54,7 +54,7 @@ class RequestQueryArgumentResolverTest extends OgGroupResolverTestBase {
    * @param array $previously_added_groups
    *   An array of test entity IDs that were added to the collection by plugins
    *   that ran previously.
-   * @param array $expected_added_group
+   * @param string $expected_added_group
    *   The group that is expected to be added by the plugin. If left empty it is
    *   explicitly expected that the plugin will not add any group to the
    *   collection.
@@ -62,7 +62,7 @@ class RequestQueryArgumentResolverTest extends OgGroupResolverTestBase {
    * @covers ::resolve
    * @dataProvider resolveProvider
    */
-  public function testResolve($group_type = NULL, $group_id = NULL, $previously_added_groups = [], $expected_added_group = NULL) {
+  public function testResolve($group_type = NULL, $group_id = NULL, array $previously_added_groups = [], $expected_added_group = NULL) {
     // It is expected that the plugin will retrieve the current request from the
     // request stack.
     $request = $this->prophesize(Request::class)->reveal();

--- a/tests/src/Unit/Plugin/OgGroupResolver/UserGroupAccessResolverTest.php
+++ b/tests/src/Unit/Plugin/OgGroupResolver/UserGroupAccessResolverTest.php
@@ -41,7 +41,7 @@ class UserGroupAccessResolverTest extends OgGroupResolverTestBase {
    * @covers ::resolve
    * @dataProvider resolveProvider
    */
-  public function testResolve($previously_added_groups = [], $expected_added_groups = [], $expected_removed_groups = []) {
+  public function testResolve(array $previously_added_groups = [], array $expected_added_groups = [], array $expected_removed_groups = []) {
     // Construct a collection of groups that were discovered by other plugins.
     /** @var \Drupal\og\OgResolvedGroupCollectionInterface|\Prophecy\Prophecy\ObjectProphecy $collection */
     $collection = $this->prophesize(OgResolvedGroupCollectionInterface::class);


### PR DESCRIPTION
There was an update of Coder that detects some new coding standards failures.