### PR TITLE
Add a cache context service that allows to vary by OG role

### DIFF
--- a/og.services.yml
+++ b/og.services.yml
@@ -14,6 +14,11 @@ services:
     arguments: ['@current_user', '@og.context', '@og.membership_manager']
     tags:
       - { name: 'cache.context'}
+  cache_context.og_role:
+    class: 'Drupal\og\Cache\Context\OgRoleCacheContext'
+    arguments: ['@current_user', '@og.membership_manager', '@private_key']
+    tags:
+      - { name: 'cache.context'}
   og.access:
     class: Drupal\og\OgAccess
     arguments: ['@config.factory', '@current_user', '@module_handler', '@og.group_type_manager', '@og.permission_manager', '@og.membership_manager', '@og.group_audience_helper']

--- a/src/Cache/Context/OgRoleCacheContext.php
+++ b/src/Cache/Context/OgRoleCacheContext.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Drupal\og\Cache\Context;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Cache\Context\CacheContextInterface;
+use Drupal\Core\Cache\Context\UserCacheContextBase;
+use Drupal\Core\PrivateKey;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Site\Settings;
+use Drupal\og\MembershipManagerInterface;
+use Drupal\og\OgRoleInterface;
+
+/**
+ * Defines a cache context service for the OG roles of the current user.
+ *
+ * This cache context allows to cache render elements that vary by the role of
+ * the user within the available group(s). This is useful for elements that for
+ * example display information that is only intended for group members or
+ * administrators.
+ *
+ * A user might have multiple roles in a group, this is also taken into account
+ * when calculating the cache context key.
+ *
+ * Since the user might be a member of a large number of groups this cache
+ * context key is presented as a hashed value.
+ *
+ * Cache context ID: 'og_role'
+ */
+class OgRoleCacheContext extends UserCacheContextBase implements CacheContextInterface {
+
+  /**
+   * The string to return when no context is found.
+   */
+  const NO_CONTEXT = 'none';
+
+  /**
+   * The membership manager service.
+   *
+   * @var \Drupal\og\MembershipManagerInterface
+   */
+  protected $membershipManager;
+
+  /**
+   * The private key service.
+   *
+   * @var \Drupal\Core\PrivateKey
+   */
+  protected $privateKey;
+
+  /**
+   * An array of cached cache context key hashes.
+   *
+   * @var string[]
+   */
+  protected $hashes = [];
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getLabel() {
+    return t('OG role');
+  }
+
+  /**
+   * Constructs a new UserCacheContextBase class.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $user
+   *   The current user.
+   * @param \Drupal\og\MembershipManagerInterface $membership_manager
+   *   The membership manager service.
+   * @param \Drupal\Core\PrivateKey $private_key
+   *   The private key service.
+   */
+  public function __construct(AccountInterface $user, MembershipManagerInterface $membership_manager, PrivateKey $private_key) {
+    parent::__construct($user);
+
+    $this->membershipManager = $membership_manager;
+    $this->privateKey = $private_key;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getContext() {
+    // Due to cacheability metadata bubbling this can be called often. Only
+    // compute the hash once.
+    if (empty($this->hashes[$this->user->id()])) {
+      $memberships = [];
+      foreach ($this->membershipManager->getMemberships($this->user) as $membership) {
+        $role_names = array_map(function (OgRoleInterface $role) {
+          return $role->getName();
+        }, $membership->getRoles());
+        $memberships[$membership->getGroupEntityType()][$membership->getGroupId()] = $role_names;
+      }
+
+      // Sort the memberships, so that the same key can be generated, even if
+      // the memberships were defined in a different order.
+      ksort($memberships);
+      foreach ($memberships as $entity_type_id => &$groups) {
+        ksort($groups);
+        foreach ($groups as $group_id => &$role_names) {
+          sort($role_names);
+        }
+      }
+
+      // If the user is not a member of any groups, return a unique key.
+      $this->hashes[$this->user->id()] = empty($memberships) ? self::NO_CONTEXT : $this->hash(serialize($memberships));
+    }
+
+    return $this->hashes[$this->user->id()];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheableMetadata() {
+    return new CacheableMetadata();
+  }
+
+  /**
+   * Hashes the given string.
+   *
+   * @param string $identifier
+   *   The string to be hashed.
+   *
+   * @return string
+   *   The hash.
+   */
+  protected function hash($identifier) {
+    return hash('sha256', $this->privateKey->get() . Settings::getHashSalt() . $identifier);
+  }
+
+}

--- a/src/MembershipManagerInterface.php
+++ b/src/MembershipManagerInterface.php
@@ -63,7 +63,7 @@ interface MembershipManagerInterface {
    * @param array $states
    *   (optional) Array with the state to return. Defaults to active.
    *
-   * @return \Drupal\og\Entity\OgMembership[]
+   * @return \Drupal\og\OgMembershipInterface[]
    *   An array of OgMembership entities, keyed by ID.
    */
   public function getMemberships(AccountInterface $user, array $states = [OgMembershipInterface::STATE_ACTIVE]);
@@ -78,7 +78,7 @@ interface MembershipManagerInterface {
    * @param array $states
    *   (optional) Array with the state to return. Defaults to active.
    *
-   * @return \Drupal\og\Entity\OgMembership|null
+   * @return \Drupal\og\OgMembershipInterface|null
    *   The OgMembership entity. NULL will be returned if no membership is
    *   available that matches the passed in $states.
    */
@@ -94,7 +94,7 @@ interface MembershipManagerInterface {
    * @param string $membership_type
    *   (optional) The membership type. Defaults to OG_MEMBERSHIP_TYPE_DEFAULT.
    *
-   * @return \Drupal\og\Entity\OgMembership
+   * @return \Drupal\og\OgMembershipInterface
    *   The unsaved membership object.
    */
   public function createMembership(EntityInterface $group, AccountInterface $user, $membership_type = OgMembershipInterface::TYPE_DEFAULT);

--- a/tests/src/Unit/Cache/Context/OgCacheContextTestBase.php
+++ b/tests/src/Unit/Cache/Context/OgCacheContextTestBase.php
@@ -2,82 +2,12 @@
 
 namespace Drupal\Tests\og\Unit\Cache\Context;
 
-use Drupal\Core\Entity\EntityInterface;
-use Drupal\og\OgContextInterface;
 use Drupal\Tests\UnitTestCase;
 
 /**
  * Base class for testing cache context services.
  */
 abstract class OgCacheContextTestBase extends UnitTestCase {
-
-  /**
-   * The mocked OG context service.
-   *
-   * @var \Drupal\og\OgContextInterface|\Prophecy\Prophecy\ObjectProphecy
-   */
-  protected $ogContext;
-
-  /**
-   * A mocked group entity.
-   *
-   * @var \Drupal\Core\Entity\EntityInterface|\Prophecy\Prophecy\ObjectProphecy
-   */
-  protected $group;
-
-  /**
-   * {@inheritdoc}
-   */
-  public function setUp() {
-    parent::setUp();
-
-    $this->ogContext = $this->prophesize(OgContextInterface::class);
-    $this->group = $this->prophesize(EntityInterface::class);
-  }
-
-  /**
-   * Tests the result of the cache context service with active context objects.
-   *
-   * This tests the most common use case: the service retrieves data from the
-   * active context, and will be able to provide a relevant cache context string
-   * in accordance with the provided data.
-   *
-   * @param mixed $context
-   *   Data used to set up the expectations of the context objects. See
-   *   setupExpectedContext().
-   * @param string $expected_result
-   *   The cache context string which is expected to be returned by the service
-   *   under test.
-   *
-   * @covers ::getContext
-   * @dataProvider contextProvider
-   */
-  public function testWithContext($context, $expected_result) {
-    $this->setupExpectedContext($context);
-
-    $result = $this->getContextResult();
-    $this->assertEquals($expected_result, $result);
-  }
-
-  /**
-   * Tests the result of the cache context service without active context.
-   *
-   * @covers ::getContext
-   */
-  abstract public function testWithoutContext();
-
-  /**
-   * Provides test data for the test with active context objects.
-   *
-   * @return array
-   *   An array of test data arrays, each array having two elements:
-   *   1. The test data that is used to set up the active context.
-   *   2. The cache context string that is expected to be returned by the cache
-   *      context service being tested.
-   *
-   * @see ::testWithContext()
-   */
-  abstract public function contextProvider();
 
   /**
    * Returns the instantiated cache context service which is being tested.
@@ -88,16 +18,6 @@ abstract class OgCacheContextTestBase extends UnitTestCase {
   abstract protected function getCacheContext();
 
   /**
-   * Set up expectations for tests that have an active context object.
-   *
-   * @param mixed $context
-   *   The test data for the active context, as provided by contextProvider().
-   *
-   * @see ::contextProvider()
-   */
-  abstract protected function setupExpectedContext($context);
-
-  /**
    * Return the context result.
    *
    * @return string
@@ -105,17 +25,6 @@ abstract class OgCacheContextTestBase extends UnitTestCase {
    */
   protected function getContextResult() {
     return $this->getCacheContext()->getContext();
-  }
-
-  /**
-   * Sets an expectation that OgContext will return the given group.
-   *
-   * @param \Drupal\Core\Entity\EntityInterface $group
-   *   The group to return, or NULL if no group is expected to be returned by
-   *   OgContext.
-   */
-  protected function expectGroupContext(EntityInterface $group = NULL) {
-    $this->ogContext->getGroup()->willReturn($group);
   }
 
 }

--- a/tests/src/Unit/Cache/Context/OgContextCacheContextTestBase.php
+++ b/tests/src/Unit/Cache/Context/OgContextCacheContextTestBase.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Drupal\Tests\og\Unit\Cache\Context;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\og\OgContextInterface;
+
+/**
+ * Base class for testing cache contexts that rely on OgContext.
+ *
+ * Use this for testing cache contexts that vary by the group that is active in
+ * the current context, as determined by OgContext::getGroup().
+ *
+ * @see \Drupal\og\OgContextInterface
+ */
+abstract class OgContextCacheContextTestBase extends OgCacheContextTestBase {
+
+  /**
+   * The mocked OG context service.
+   *
+   * @var \Drupal\og\OgContextInterface|\Prophecy\Prophecy\ObjectProphecy
+   */
+  protected $ogContext;
+
+  /**
+   * A mocked group entity.
+   *
+   * @var \Drupal\Core\Entity\EntityInterface|\Prophecy\Prophecy\ObjectProphecy
+   */
+  protected $group;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+
+    $this->ogContext = $this->prophesize(OgContextInterface::class);
+    $this->group = $this->prophesize(EntityInterface::class);
+  }
+
+  /**
+   * Tests the result of the cache context service with active context objects.
+   *
+   * This tests the most common use case: the service retrieves data from the
+   * active context, and will be able to provide a relevant cache context string
+   * in accordance with the provided data.
+   *
+   * @param mixed $context
+   *   Data used to set up the expectations of the context objects. See
+   *   setupExpectedContext().
+   * @param string $expected_result
+   *   The cache context string which is expected to be returned by the service
+   *   under test.
+   *
+   * @covers ::getContext
+   * @dataProvider contextProvider
+   */
+  public function testWithContext($context, $expected_result) {
+    $this->setupExpectedContext($context);
+
+    $result = $this->getContextResult();
+    $this->assertEquals($expected_result, $result);
+  }
+
+  /**
+   * Tests the result of the cache context service without active context.
+   *
+   * @covers ::getContext
+   */
+  abstract public function testWithoutContext();
+
+  /**
+   * Provides test data for the test with active context objects.
+   *
+   * @return array
+   *   An array of test data arrays, each array having two elements:
+   *   1. The test data that is used to set up the active context.
+   *   2. The cache context string that is expected to be returned by the cache
+   *      context service being tested.
+   *
+   * @see ::testWithContext()
+   */
+  abstract public function contextProvider();
+
+  /**
+   * Set up expectations for tests that have an active context object.
+   *
+   * @param mixed $context
+   *   The test data for the active context, as provided by contextProvider().
+   *
+   * @see ::contextProvider()
+   */
+  abstract protected function setupExpectedContext($context);
+
+  /**
+   * Sets an expectation that OgContext will return the given group.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $group
+   *   The group to return, or NULL if no group is expected to be returned by
+   *   OgContext.
+   */
+  protected function expectGroupContext(EntityInterface $group = NULL) {
+    $this->ogContext->getGroup()->willReturn($group);
+  }
+
+}

--- a/tests/src/Unit/Cache/Context/OgGroupContextCacheContextTest.php
+++ b/tests/src/Unit/Cache/Context/OgGroupContextCacheContextTest.php
@@ -5,10 +5,10 @@ namespace Drupal\Tests\og\Unit\Cache\Context;
 use Drupal\og\Cache\Context\OgGroupContextCacheContext;
 
 /**
- * Tests OG membership state cache context.
+ * Tests the OG group context cache context.
  *
  * @group og
- * @coversDefaultClass \Drupal\og\Cache\Context\OgMembershipStateCacheContext
+ * @coversDefaultClass \Drupal\og\Cache\Context\OgGroupContextCacheContext
  */
 class OgGroupContextCacheContextTest extends OgContextCacheContextTestBase {
 

--- a/tests/src/Unit/Cache/Context/OgGroupContextCacheContextTest.php
+++ b/tests/src/Unit/Cache/Context/OgGroupContextCacheContextTest.php
@@ -10,7 +10,7 @@ use Drupal\og\Cache\Context\OgGroupContextCacheContext;
  * @group og
  * @coversDefaultClass \Drupal\og\Cache\Context\OgMembershipStateCacheContext
  */
-class OgGroupContextCacheContextTest extends OgCacheContextTestBase {
+class OgGroupContextCacheContextTest extends OgContextCacheContextTestBase {
 
   /**
    * Tests getting cache context when there is no matching group on the route.

--- a/tests/src/Unit/Cache/Context/OgMembershipStateCacheContextTest.php
+++ b/tests/src/Unit/Cache/Context/OgMembershipStateCacheContextTest.php
@@ -13,7 +13,7 @@ use Drupal\og\OgMembershipInterface;
  * @group og
  * @coversDefaultClass \Drupal\og\Cache\Context\OgMembershipStateCacheContext
  */
-class OgMembershipStateCacheContextTest extends OgCacheContextTestBase {
+class OgMembershipStateCacheContextTest extends OgContextCacheContextTestBase {
 
   /**
    * The OG membership entity.

--- a/tests/src/Unit/Cache/Context/OgRoleCacheContextTest.php
+++ b/tests/src/Unit/Cache/Context/OgRoleCacheContextTest.php
@@ -1,0 +1,320 @@
+<?php
+
+namespace Drupal\Tests\og\Unit\Cache\Context;
+
+use Drupal\Core\PrivateKey;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Site\Settings;
+use Drupal\og\Cache\Context\OgRoleCacheContext;
+use Drupal\og\MembershipManagerInterface;
+use Drupal\og\OgMembershipInterface;
+use Drupal\og\OgRoleInterface;
+
+/**
+ * Tests the OG role cache context.
+ *
+ * @group og
+ * @coversDefaultClass \Drupal\og\Cache\Context\OgRoleCacheContext
+ */
+class OgRoleCacheContextTest extends OgCacheContextTestBase {
+
+  /**
+   * The mocked OG membership manager service.
+   *
+   * @var \Drupal\og\MembershipManagerInterface|\Prophecy\Prophecy\ObjectProphecy
+   */
+  protected $membershipManager;
+
+  /**
+   * The mocked private key handler.
+   *
+   * @var \Drupal\Core\PrivateKey|\Prophecy\Prophecy\ObjectProphecy
+   */
+  protected $privateKey;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+
+    $this->membershipManager = $this->prophesize(MembershipManagerInterface::class);
+    $this->privateKey = $this->prophesize(PrivateKey::class);
+  }
+
+  /**
+   * Tests generating of a cache context key for a user with no memberships.
+   *
+   * This is a common case, e.g. for anonymous users.
+   *
+   * @covers ::getContext
+   */
+  public function testNoMemberships() {
+    // No memberships (an empty array) will be returned by the membership
+    // manager.
+    /** @var \Drupal\Core\Session\AccountInterface|\Prophecy\Prophecy\ObjectProphecy $user */
+    $user = $this->prophesize(AccountInterface::class)->reveal();
+    $this->membershipManager->getMemberships($user)->willReturn([]);
+
+    // The result should be the predefined 'NO_CONTEXT' value.
+    $result = $this->getContextResult($user);
+    $this->assertEquals(OgRoleCacheContext::NO_CONTEXT, $result);
+  }
+
+  /**
+   * Tests that the correct cache context key is returned for group members.
+   *
+   * Different users might have the identical roles across a number of different
+   * groups. Verify that a unique hash is returned for each combination of
+   * roles.
+   *
+   * @param array $group_memberships
+   *   An array that defines the roles test users have in test groups. See the
+   *   data provider for a description of the format of the array.
+   * @param array $expected_identical_role_groups
+   *   An array containing arrays of user IDs that are expected to have
+   *   identical cache context keys, since they have identical memberships in
+   *   the defined test groups.
+   *
+   * @covers ::getContext
+   * @dataProvider membershipsProvider
+   */
+  public function testMemberships(array $group_memberships, array $expected_identical_role_groups) {
+    // 'Mock' the unmockable singleton that holds the Drupal settings array by
+    // instantiating it and populating it with a random salt.
+    new Settings(['hash_salt' => $this->randomMachineName()]);
+
+    // Mock the private key that will be returned by the private key handler.
+    $this->privateKey->get()->willReturn($this->randomMachineName());
+
+    // Mock the users that are defined in the test case.
+    $user_ids = array_keys($group_memberships);
+    $users = array_map(function ($user_id) {
+      /** @var \Drupal\Core\Session\AccountInterface|\Prophecy\Prophecy\ObjectProphecy $user */
+      $user = $this->prophesize(AccountInterface::class);
+      $user->id()->willReturn($user_id);
+      return $user->reveal();
+    }, array_combine($user_ids, $user_ids));
+
+    // Set up the memberships that are expected to be returned from the
+    // membership manager.
+    $memberships = [];
+    // Use incremental IDs for the OgMembership object. These are not actually
+    // used for calculating the cache context, but this simulates that in the
+    // database no two memberships will have the same ID.
+    $membership_id = 0;
+    foreach ($group_memberships as $user_id => $group_entity_type_ids) {
+      $memberships[$user_id] = [];
+      foreach ($group_entity_type_ids as $group_entity_type_id => $group_ids) {
+        foreach ($group_ids as $group_id => $roles) {
+          // Mock the role objects that will be contained in the memberships.
+          $roles = array_map(function ($role_name) {
+            /** @var \Drupal\og\OgRoleInterface|\Prophecy\Prophecy\ObjectProphecy $role */
+            $role = $this->prophesize(OgRoleInterface::class);
+            $role->getName()->willReturn($role_name);
+            return $role->reveal();
+          }, $roles);
+          // Mock the expected returns of method calls on the membership.
+          /** @var \Drupal\og\OgMembershipInterface|\Prophecy\Prophecy\ObjectProphecy $membership */
+          $membership = $this->prophesize(OgMembershipInterface::class);
+          $membership->getGroupEntityType()->willReturn($group_entity_type_id);
+          $membership->getGroupId()->willReturn($group_id);
+          $membership->getRoles()->willReturn($roles);
+          $memberships[$user_id][++$membership_id] = $membership->reveal();
+        }
+      }
+    }
+
+    // Calculate the cache context keys for every user.
+    $cache_context_ids = [];
+    foreach ($users as $user_id => $user) {
+      // When the memberships for every user in the test case are requested from
+      // the membership manager, the respective array of memberships will be
+      // returned.
+      $this->membershipManager->getMemberships($user)->willReturn($memberships[$user_id]);
+      $cache_context_ids[$user_id] = $this->getContextResult($user);
+    }
+
+    // Loop over the expected results and check that all users that have
+    // identical roles have the same cache context key.
+    foreach ($expected_identical_role_groups as $expected_identical_role_group) {
+      // Check that the cache context keys for all users in the group are
+      // identical.
+      $cache_context_ids_subset = array_intersect_key($cache_context_ids, array_flip($expected_identical_role_group));
+      $this->assertTrue(count(array_unique($cache_context_ids_subset)) === 1);
+
+      // Also check that the cache context keys for the other users are
+      // different than the ones from our test group.
+      $cache_context_id_from_test_group = reset($cache_context_ids_subset);
+      $cache_context_ids_from_other_users = array_diff_key($cache_context_ids, array_flip($expected_identical_role_group));
+      $this->assertFalse(in_array($cache_context_id_from_test_group, $cache_context_ids_from_other_users));
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getContextResult(AccountInterface $user = NULL) {
+    return $this->getCacheContext($user)->getContext();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getCacheContext(AccountInterface $user = NULL) {
+    return new OgRoleCacheContext($user, $this->membershipManager->reveal(), $this->privateKey->reveal());
+  }
+
+  /**
+   * Data provider for testMemberships().
+   *
+   * Format of the user list:
+   *
+   * @code
+   *   $user_id => [
+   *     $group_entity_type_id => [
+   *       $group_id => [
+   *         $role_name,
+   *       ],
+   *     ],
+   *   ],
+   * @endcode
+   *
+   * @return array
+   *   An array of test data, each array consisting of two arrays. The first
+   *   array defines a list of users, the groups of which they are a member, and
+   *   the roles the users have in the groups. It is in the format described
+   *   above.
+   *   The second array contains arrays of user IDs that are expected to have
+   *   identical cache context keys, since they have identical memberships in
+   *   the defined test groups.
+   *
+   * @see ::testMemberships()
+   */
+  public function membershipsProvider() {
+    return [
+      [
+        // Set up a number of users with different roles within different
+        // groups.
+        [
+          // An anonymous user which is not a member of any groups.
+          0 => [],
+          // A user which is a normal member of three groups, one group of type
+          // node, and two groups of type entity_test.
+          1 => [
+            'node' => [
+              1 => [OgRoleInterface::AUTHENTICATED],
+            ],
+            'entity_test' => [
+              1 => [OgRoleInterface::AUTHENTICATED],
+              2 => [OgRoleInterface::AUTHENTICATED],
+            ],
+          ],
+          // A user which is a member of one single group.
+          2 => ['entity_test' => [2 => [OgRoleInterface::AUTHENTICATED]]],
+          // A user which is an administrator in one group and a regular member
+          // in another. Note that an administrator is also a normal member, so
+          // the user will have two roles.
+          3 => [
+            'node' => [
+              1 => [
+                OgRoleInterface::AUTHENTICATED,
+                OgRoleInterface::ADMINISTRATOR,
+              ],
+              2 => [OgRoleInterface::AUTHENTICATED],
+            ],
+          ],
+          // A user which has a custom role 'moderator' in three different
+          // groups.
+          4 => [
+            'node' => [
+              1 => ['moderator', OgRoleInterface::AUTHENTICATED],
+            ],
+            'entity_test' => [
+              1 => ['moderator', OgRoleInterface::AUTHENTICATED],
+              2 => ['moderator', OgRoleInterface::AUTHENTICATED],
+            ],
+          ],
+          // A user which has the same memberships as user 1, and one additional
+          // membership.
+          5 => [
+            'node' => [
+              1 => [OgRoleInterface::AUTHENTICATED],
+              2 => [OgRoleInterface::AUTHENTICATED],
+            ],
+            'entity_test' => [
+              1 => [OgRoleInterface::AUTHENTICATED],
+              2 => [OgRoleInterface::AUTHENTICATED],
+            ],
+          ],
+          // A user which has the same memberships as user 1, but defined in a
+          // different order.
+          6 => [
+            'entity_test' => [
+              2 => [OgRoleInterface::AUTHENTICATED],
+              1 => [OgRoleInterface::AUTHENTICATED],
+            ],
+            'node' => [
+              1 => [OgRoleInterface::AUTHENTICATED],
+            ],
+          ],
+          // A user which has the same memberships as user 3.
+          7 => [
+            'node' => [
+              1 => [
+                OgRoleInterface::AUTHENTICATED,
+                OgRoleInterface::ADMINISTRATOR,
+              ],
+              2 => [OgRoleInterface::AUTHENTICATED],
+            ],
+          ],
+          // A user which has the same memberships as user 4, with the
+          // memberships declared in a different order.
+          8 => [
+            'node' => [
+              1 => [OgRoleInterface::AUTHENTICATED, 'moderator'],
+            ],
+            'entity_test' => [
+              1 => [OgRoleInterface::AUTHENTICATED, 'moderator'],
+              2 => [OgRoleInterface::AUTHENTICATED, 'moderator'],
+            ],
+          ],
+          // A user which has the same memberships as user 4, with the
+          // memberships declared in the same order.
+          9 => [
+            'node' => [
+              1 => ['moderator', OgRoleInterface::AUTHENTICATED],
+            ],
+            'entity_test' => [
+              1 => ['moderator', OgRoleInterface::AUTHENTICATED],
+              2 => ['moderator', OgRoleInterface::AUTHENTICATED],
+            ],
+          ],
+          // A user which has the same memberships as user 4, but with one
+          // role missing.
+          10 => [
+            'node' => [
+              1 => ['moderator', OgRoleInterface::AUTHENTICATED],
+            ],
+            'entity_test' => [
+              1 => ['moderator'],
+              2 => ['moderator', OgRoleInterface::AUTHENTICATED],
+            ],
+          ],
+        ],
+        // Define the users which have identical memberships and should have an
+        // identical hash in their cache context key.
+        [
+          [0],
+          [1, 6],
+          [2],
+          [3, 7],
+          [4, 8, 9],
+          [5],
+          [10],
+        ],
+      ],
+    ];
+  }
+
+}


### PR DESCRIPTION
This allows to cache elements on the page that vary by membership role, for example if content is shown only to members of a group, or to administrators.