### PR TITLE
OgDeleteOrphans Simple Plugin does not delete content

### DIFF
--- a/src/Command/OgAddFieldCommand.php
+++ b/src/Command/OgAddFieldCommand.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Command\Command;
-use Drupal\Console\Style\DrupalStyle;
+use Drupal\Console\Core\Style\DrupalStyle;
 
 /**
  * Class OgAddFieldCommand.

--- a/src/OgDeleteOrphansBase.php
+++ b/src/OgDeleteOrphansBase.php
@@ -128,6 +128,9 @@ abstract class OgDeleteOrphansBase extends PluginBase implements OgDeleteOrphans
    */
   protected function deleteOrphan($entity_type, $entity_id) {
     $entity = $this->entityTypeManager->getStorage($entity_type)->load($entity_id);
+    if (!$entity) {
+      return;
+    }
     // Only delete content that is fully orphaned, i.e. it is no longer
     // associated with any groups.
     $group_count = $this->membershipManager->getGroupCount($entity);

--- a/src/OgDeleteOrphansBase.php
+++ b/src/OgDeleteOrphansBase.php
@@ -128,9 +128,13 @@ abstract class OgDeleteOrphansBase extends PluginBase implements OgDeleteOrphans
    */
   protected function deleteOrphan($entity_type, $entity_id) {
     $entity = $this->entityTypeManager->getStorage($entity_type)->load($entity_id);
+
+    // The entity might already be removed by other modules that implement
+    // hook_entity_delete().
     if (!$entity) {
       return;
     }
+
     // Only delete content that is fully orphaned, i.e. it is no longer
     // associated with any groups.
     $group_count = $this->membershipManager->getGroupCount($entity);

--- a/src/Plugin/OgDeleteOrphans/Simple.php
+++ b/src/Plugin/OgDeleteOrphans/Simple.php
@@ -22,7 +22,7 @@ class Simple extends OgDeleteOrphansBase {
   public function register(EntityInterface $entity) {
     parent::register($entity);
     // Delete the orphans on the fly.
-    $this->process();
+    drupal_register_shutdown_function([$this, 'process']);
   }
 
   /**

--- a/tests/src/Kernel/OgDeleteOrphansTest.php
+++ b/tests/src/Kernel/OgDeleteOrphansTest.php
@@ -48,7 +48,7 @@ class OgDeleteOrphansTest extends KernelTestBase {
    *
    * @var \Drupal\Core\Entity\EntityInterface
    */
-  protected $group_content;
+  protected $groupContent;
 
   /**
    * {@inheritdoc}
@@ -97,12 +97,12 @@ class OgDeleteOrphansTest extends KernelTestBase {
     $this->group->save();
 
     // Create a group content item.
-    $this->group_content = Node::create([
+    $this->groupContent = Node::create([
       'title' => $this->randomString(),
       'type' => $group_content_bundle,
       OgGroupAudienceHelperInterface::DEFAULT_FIELD => [['target_id' => $this->group->id()]],
     ]);
-    $this->group_content->save();
+    $this->groupContent->save();
   }
 
   /**
@@ -163,7 +163,7 @@ class OgDeleteOrphansTest extends KernelTestBase {
     }
 
     // Verify the group content is deleted.
-    $this->assertNull(Node::load($this->group_content->id()), 'The orphaned node is deleted.');
+    $this->assertNull(Node::load($this->groupContent->id()), 'The orphaned node is deleted.');
 
     // Verify that the user membership is now deleted.
     $this->assertUserMembershipCount(0);


### PR DESCRIPTION
The content deletion should be deferred because the OgDeleteOrphans plugins run in ``og_entity_predelete``. The group entity still exists at this point. ``OgDeleteOrphansBase::deleteOrphan`` does delete the group content because the ``$group_count`` is not zero (contains the original group).

I can think of two solutions:

1. defer the simple plugin until shutdown
2. adjust OgDeleteOrphansBase::deleteOrphan and exclude the the current group from the count