### PR TITLE
Avoid registering the orphan cleanup process more than once.

### DIFF
--- a/src/Plugin/OgDeleteOrphans/Simple.php
+++ b/src/Plugin/OgDeleteOrphans/Simple.php
@@ -21,8 +21,18 @@ class Simple extends OgDeleteOrphansBase {
    */
   public function register(EntityInterface $entity) {
     parent::register($entity);
-    // Delete the orphans on the fly.
-    drupal_register_shutdown_function([$this, 'process']);
+
+    // Check if our cleanup process is already registered, so we don't add any
+    // duplicates.
+    $callbacks = array_filter(drupal_register_shutdown_function(), function ($callback) {
+      $callable = $callback['callback'];
+      return is_array($callable) && $callable[0] instanceof $this && $callable[1] === 'process';
+    });
+
+    // Register a shutdown function that deletes the orphans on the fly.
+    if (empty($callbacks)) {
+      drupal_register_shutdown_function([$this, 'process']);
+    }
   }
 
   /**


### PR DESCRIPTION
This is a followup of #230.

When running one of our Behat test suites I noticed that I got over 100 duplicate `Simple::process()` callbacks in drupal_register_shutdown_function(). This happens because during this long running test a large number of groups are created and deleted, and each time a group with orphans is deleted a new duplicate callback is added. During normal usage this might also happen when for example a large number of groups are deleted in the UI.

This is not causing any real problems; the duplicate callbacks will not do any processing, but they repeatedly try to load an empty queue to iterate over it. This causes a small amount of processing and increased memory usage. The solution is to check if the callback already exists before adding a new one.

I just stepped through it to check what happens exactly when the `process()` method is called. Regardless of which `Simple` instance registers the entity to be deleted, they all get added to the same queue with ID `og_orphaned_group_content`. Then the first time `Simple::process()` gets called, it will iterate over the entire queue and clean up all of it. All subsequent calls just iterate over an empty queue.

This is a very minor bug, just something that caught my attention.