### PR TITLE
Fix PHP warning in MembershipManager::getGroupIds()

### DIFF
--- a/src/MembershipManager.php
+++ b/src/MembershipManager.php
@@ -183,10 +183,15 @@ class MembershipManager implements MembershipManagerInterface {
         continue;
       }
 
+      // Clean up empty items.
+      $values = array_filter($entity->get($field->getName())->getValue(), function($value) {
+        return isset($value['target_id']);
+      });
+
       // Compile a list of group target IDs.
       $target_ids = array_map(function ($value) {
-        return isset($value['target_id']) && $value['target_id'];
-      }, $entity->get($field->getName())->getValue());
+        return $value['target_id'];
+      }, $values);
 
       if (empty($target_ids)) {
         continue;

--- a/src/MembershipManager.php
+++ b/src/MembershipManager.php
@@ -185,7 +185,7 @@ class MembershipManager implements MembershipManagerInterface {
 
       // Compile a list of group target IDs.
       $target_ids = array_map(function ($value) {
-        return $value['target_id'];
+        return isset($value['target_id']) && $value['target_id'];
       }, $entity->get($field->getName())->getValue());
 
       if (empty($target_ids)) {

--- a/src/MembershipManager.php
+++ b/src/MembershipManager.php
@@ -184,7 +184,7 @@ class MembershipManager implements MembershipManagerInterface {
       }
 
       // Clean up empty items.
-      $values = array_filter($entity->get($field->getName())->getValue(), function($value) {
+      $values = array_filter($entity->get($field->getName())->getValue(), function ($value) {
         return isset($value['target_id']);
       });
 


### PR DESCRIPTION
On PHP 7.0.x, create a group content node.

Go to edit the node:

```
Notice: Undefined index: target_id in Drupal\og\MembershipManager->Drupal\og\{closure}() (line 227 of modules/contrib/og/src/MembershipManager.php).
Drupal\og\MembershipManager->Drupal\og\{closure}(Array)
array_map(Object, Array) (Line: 228)
Drupal\og\MembershipManager->getGroupIds(Object, NULL, NULL) (Line: 268)
Drupal\og\MembershipManager->getGroups(Object) (Line: 93)
Drupal\og\Plugin\OgGroupResolver\RouteGroupContentResolver->resolve(Object) (Line: 144)
Drupal\og\ContextProvider\OgContext->getBestCandidate() (Line: 100)
Drupal\og\ContextProvider\OgContext->getOgContext() (Line: 79)
Drupal\og\ContextProvider\OgContext->getRuntimeContexts(Array) (Line: 173)
Drupal\og\ContextProvider\OgContext->getGroup() (Line: 54)
```