### PR TITLE
Allow global administrators to reference any group

### DIFF
--- a/src/Plugin/EntityReferenceSelection/OgSelection.php
+++ b/src/Plugin/EntityReferenceSelection/OgSelection.php
@@ -77,6 +77,11 @@ class OgSelection extends DefaultSelection {
       $query->condition($bundle_key, $bundles, 'IN');
     }
 
+    // This is a global administrator, therefore they can add any group.
+    if ($this->currentUser->hasPermission('administer group')) {
+      return $query;
+    }
+
     $user_groups = $this->getUserGroups();
     if (!$user_groups) {
       return $query;


### PR DESCRIPTION
If a user has the global 'administer group' permission, they should be able to reference any group.

Currently, this is only possible when they do not belong to any group. The moment they are a member of a group, referencing one they don't belong to fails with "The entity (entity_type:id) cannot be referenced)