### PR TITLE
Don't allow to set a group ID on a role, it breaks everything

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,13 +52,7 @@ before_script:
 
   # Download Drupal console so we can run the test for it. Skip this for the
   # coding standards test.
-
-  # When downloading DrupalConsole using Composer an old version is supplied.
-  # Sepficing the correct version and the versions of DrupalComposer dependancy
-  # will fix the problem for now. Need to be removed when https://goo.gl/i6rVhT
-  # will be merged.
-  # Remove symfony/dom-crawler:2.* when https://www.drupal.org/node/2840596#comment-11868149 is merged.
-  - test ${TEST_SUITE} == "PHP_CodeSniffer" || composer require --dev symfony/dom-crawler:2.* drupal/console:~1.0@rc --working-dir=$DRUPAL_DIR
+  - test ${TEST_SUITE} == "PHP_CodeSniffer" || composer require --dev drupal/console:~1.0@rc --working-dir=$DRUPAL_DIR
 
   # Install Composer dependencies for core. Skip this for the coding standards test.
   - test ${TEST_SUITE} == "PHP_CodeSniffer" || composer install --working-dir=$DRUPAL_DIR

--- a/src/Entity/OgRole.php
+++ b/src/Entity/OgRole.php
@@ -91,29 +91,6 @@ class OgRole extends Role implements OgRoleInterface {
   }
 
   /**
-   * Returns the group ID.
-   *
-   * @return int
-   *   The group ID.
-   */
-  public function getGroupId() {
-    return $this->get('group_id');
-  }
-
-  /**
-   * Sets the group ID.
-   *
-   * @param int $group_id
-   *   The group ID to set.
-   *
-   * @return $this
-   */
-  public function setGroupId($group_id) {
-    $this->set('group_id', $group_id);
-    return $this;
-  }
-
-  /**
    * Returns the group type.
    *
    * @return string
@@ -255,10 +232,6 @@ class OgRole extends Role implements OgRoleInterface {
       // When assigning a role to group we need to add a prefix to the ID in
       // order to prevent duplicate IDs.
       $prefix = $this->getGroupType() . '-' . $this->getGroupBundle() . '-';
-
-      if ($this->getGroupId()) {
-        $prefix .= $this->getGroupId() . '-';
-      }
 
       $this->setId($prefix . $this->getName());
     }

--- a/tests/src/Kernel/Entity/OgRoleTest.php
+++ b/tests/src/Kernel/Entity/OgRoleTest.php
@@ -95,10 +95,9 @@ class OgRoleTest extends KernelTestBase {
       ->setLabel('Content editor')
       ->setGroupType('entity_test')
       ->setGroupBundle('group')
-      ->setGroupID(1)
       ->save();
 
-    $this->assertEquals('entity_test-group-1-content_editor', $og_role->id());
+    $this->assertEquals('entity_test-group-content_editor', $og_role->id());
 
     // Confirm role can be re-saved.
     $og_role->save();
@@ -119,7 +118,6 @@ class OgRoleTest extends KernelTestBase {
         ->setLabel('Content editor')
         ->setGroupType('entity_test')
         ->setGroupBundle('group')
-        ->setGroupID(1)
         ->save();
 
       $this->fail('OG role with the same ID on the same group can be saved.');


### PR DESCRIPTION
In `OgRole` we have two methods that allow to get and set the group ID. Calling this will inject the group ID in the `OgRole` entity ID. This actually causes the ID to be mangled and will be invalid for the remainder of the code base which expects the ID to consist of `{$entity_type_id}-{$bundle_id}-{$role_name}`. Once this group ID is set on a role and the role is saved practically everything related to roles breaks, resulting in errors like:

```
Call to a member function getPermissions() on null in OgAccess.php:203
```

The only way to return to a normal working state is to delete the role from the database and recreate it without the group ID.

These methods are there because in D7 we had the possibility to override roles on a per-group basis (ref #259). However, if we want to keep this functionality in D8 we will probably not implement by mangling the ID but by providing a separate config entity for overridden roles.

These broken methods are currently not used anywhere so we can safely remove them.

Once we have made a decision in #259 we can make something that actually works :)