### PR TITLE
Declare the dependency between `OgRole` entities and their parent group

### DIFF
--- a/src/Entity/OgRole.php
+++ b/src/Entity/OgRole.php
@@ -337,4 +337,15 @@ class OgRole extends Role implements OgRoleInterface {
     return \Drupal::service('og.access');
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function calculateDependencies() {
+    parent::calculateDependencies();
+
+    // Create a dependency on the group bundle.
+    $bundle_config_dependency = \Drupal::entityTypeManager()->getDefinition($this->getGroupType())->getBundleConfigDependency($this->getGroupBundle());
+    $this->addDependency($bundle_config_dependency['type'], $bundle_config_dependency['name']);
+  }
+
 }

--- a/src/GroupTypeManager.php
+++ b/src/GroupTypeManager.php
@@ -396,9 +396,6 @@ class GroupTypeManager {
       $editable->set('groups', $groups);
       $editable->save();
 
-      // Remove all roles associated with this group type.
-      $this->ogRoleManager->removeRoles($entity_type_id, $bundle_id);
-
       $this->resetGroupMap();
 
       // Routes will need to be rebuilt.

--- a/tests/src/Functional/GroupSubscribeTest.php
+++ b/tests/src/Functional/GroupSubscribeTest.php
@@ -4,6 +4,7 @@ namespace Drupal\Tests\og\Functional;
 
 use Drupal\Component\Utility\Unicode;
 use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
 use Drupal\og\Entity\OgMembershipType;
 use Drupal\og\Entity\OgRole;
 use Drupal\og\Og;
@@ -93,12 +94,14 @@ class GroupSubscribeTest extends BrowserTestBase {
     parent::setUp();
 
     // Create bundles.
-    // We don't need to later call NodeType::create() on the bundles, as we
-    // don't call the node view.
     $this->groupBundle1 = Unicode::strtolower($this->randomMachineName());
+    NodeType::create(['type' => $this->groupBundle1])->save();
     $this->groupBundle2 = Unicode::strtolower($this->randomMachineName());
+    NodeType::create(['type' => $this->groupBundle2])->save();
     $this->nonGroupBundle = Unicode::strtolower($this->randomMachineName());
+    NodeType::create(['type' => $this->nonGroupBundle])->save();
     $this->membershipTypeBundle = Unicode::strtolower($this->randomMachineName());
+    NodeType::create(['type' => $this->membershipTypeBundle])->save();
 
     // Define the entities as groups.
     Og::groupTypeManager()->addGroup('node', $this->groupBundle1);

--- a/tests/src/Functional/OgComplexWidgetTest.php
+++ b/tests/src/Functional/OgComplexWidgetTest.php
@@ -35,7 +35,7 @@ class OgComplexWidgetTest extends BrowserTestBase {
     // Create a "group" bundle on the Custom Block entity type and turn it into
     // a group. Note we're not using the Entity Test entity for this since it
     // does not have real support for multiple bundles.
-    BlockContentType::create(['type' => 'group']);
+    BlockContentType::create(['id' => 'group'])->save();
     Og::groupTypeManager()->addGroup('block_content', 'group');
 
     // Add a group audience field to the "post" node type, turning it into a

--- a/tests/src/Kernel/Access/AccessByOgMembershipTest.php
+++ b/tests/src/Kernel/Access/AccessByOgMembershipTest.php
@@ -102,7 +102,7 @@ class AccessByOgMembershipTest extends KernelTestBase {
     // Create a "group" bundle on the Custom Block entity type and turn it into
     // a group. Note we're not using the Entity Test entity for this since it
     // does not have real support for multiple bundles.
-    BlockContentType::create(['type' => 'group']);
+    BlockContentType::create(['id' => 'group'])->save();
     Og::groupTypeManager()->addGroup('block_content', 'group');
 
     // Create a group.

--- a/tests/src/Kernel/Access/OgAccessHookTest.php
+++ b/tests/src/Kernel/Access/OgAccessHookTest.php
@@ -118,7 +118,7 @@ class OgAccessHookTest extends KernelTestBase {
     // Create a "group" bundle on the Custom Block entity type and turn it into
     // a group. Note we're not using the Entity Test entity for this since it
     // does not have real support for multiple bundles.
-    BlockContentType::create(['type' => 'group']);
+    BlockContentType::create(['id' => 'group'])->save();
     Og::groupTypeManager()->addGroup('block_content', 'group');
 
     // Create a group.

--- a/tests/src/Kernel/Entity/OgMembershipRoleReferenceTest.php
+++ b/tests/src/Kernel/Entity/OgMembershipRoleReferenceTest.php
@@ -63,13 +63,13 @@ class OgMembershipRoleReferenceTest extends KernelTestBase {
     $this->installSchema('system', 'sequences');
 
     // Create a "group" node type and turn it into a group type.
-    $group_bundle = Unicode::strtolower($this->randomMachineName());
+    $this->groupBundle = Unicode::strtolower($this->randomMachineName());
     NodeType::create([
-      'type' => $group_bundle,
+      'type' => $this->groupBundle,
       'name' => $this->randomString(),
     ])->save();
 
-    Og::groupTypeManager()->addGroup('node', $group_bundle);
+    Og::groupTypeManager()->addGroup('node', $this->groupBundle);
 
     $this->user = User::create(['name' => $this->randomString()]);
     $this->user->save();
@@ -77,7 +77,7 @@ class OgMembershipRoleReferenceTest extends KernelTestBase {
     $this->group = Node::create([
       'title' => $this->randomString(),
       'uid' => $this->user->id(),
-      'type' => $group_bundle,
+      'type' => $this->groupBundle,
     ]);
     $this->group->save();
   }
@@ -90,7 +90,7 @@ class OgMembershipRoleReferenceTest extends KernelTestBase {
     $content_editor = OgRole::create();
     $content_editor
       ->setGroupType('node')
-      ->setGroupBundle('group')
+      ->setGroupBundle($this->groupBundle)
       ->setName('content_editor')
       ->setLabel('Content editor')
       ->grantPermission('administer group');
@@ -100,7 +100,7 @@ class OgMembershipRoleReferenceTest extends KernelTestBase {
     $group_member = OgRole::create();
     $group_member
       ->setGroupType('node')
-      ->setGroupBundle('group')
+      ->setGroupBundle($this->groupBundle)
       ->setName('group_member')
       ->setLabel('Group member');
     $group_member->save();

--- a/tests/src/Kernel/Entity/OgRoleTest.php
+++ b/tests/src/Kernel/Entity/OgRoleTest.php
@@ -4,7 +4,9 @@ namespace Drupal\Tests\og\Kernel\Entity;
 
 use Drupal\Core\Config\ConfigValueException;
 use Drupal\Core\Entity\EntityStorageException;
+use Drupal\entity_test\Entity\EntityTest;
 use Drupal\KernelTests\KernelTestBase;
+use Drupal\node\Entity\NodeType;
 use Drupal\og\Entity\OgRole;
 use Drupal\og\Exception\OgRoleException;
 
@@ -18,7 +20,14 @@ class OgRoleTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = ['field', 'og'];
+  public static $modules = [
+    'entity_test',
+    'field',
+    'node',
+    'og',
+    'system',
+    'user',
+  ];
 
   /**
    * The entity storage handler for OgRole entities.
@@ -35,8 +44,14 @@ class OgRoleTest extends KernelTestBase {
 
     // Installing needed schema.
     $this->installConfig(['og']);
+    $this->installEntitySchema('entity_test');
 
     $this->roleStorage = $this->container->get('entity_type.manager')->getStorage('og_role');
+
+    // Create two test group types.
+    $values = ['type' => 'group', 'name' => 'Group'];
+    NodeType::create($values)->save();
+    EntityTest::create($values)->save();
   }
 
   /**

--- a/tests/src/Unit/GroupManagerTest.php
+++ b/tests/src/Unit/GroupManagerTest.php
@@ -309,8 +309,6 @@ class GroupManagerTest extends UnitTestCase {
       ->willReturn($groups_after)
       ->shouldBeCalled();
 
-    $this->ogRoleManager->removeRoles('test_entity', 'b')->shouldBeCalled();
-
     $manager = $this->createGroupManager();
 
     // Add to existing.


### PR DESCRIPTION
This has been split off from #244. It was originally included in the scope of that ticket but this has uncovered quite a few small bugs in our tests, so it has been split off to not confuse the parent issue.

`OgRole` entities are depending on the parent entity type and bundle, but this dependency is not declared in the config entity. We were instead cleaning up the roles manually whenever a parent bundle is deleted. With the dependency in place the cleaning up of orphaned roles is taken care of automatically by the configuration management system.

Due to the dependency not being declared it was possible to accidentally create orphaned roles, by e.g. making a typo in the group type. This is something that can happen easily, as evidenced by 8 of our tests being affected by this!

It might also cause problems when importing / syncing configuration since the exact order in which the config entities are updated depends on a correct dependency chain.