### PR TITLE
Add condition plugin that allows to control block visibility per group type

### DIFF
--- a/config/schema/og.schema.yml
+++ b/config/schema/og.schema.yml
@@ -145,3 +145,11 @@ field.widget.settings.og_complex:
     placeholder:
       type: label
       label: 'Placeholder'
+
+condition.plugin.og_group_type:
+  type: condition.plugin
+  mapping:
+    group_types:
+      type: sequence
+      sequence:
+        type: string

--- a/src/Plugin/Condition/GroupType.php
+++ b/src/Plugin/Condition/GroupType.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Drupal\og\Plugin\Condition;
+
+use Drupal\Core\Condition\ConditionPluginBase;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\og\GroupTypeManager;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides a 'Group Type' block visibility condition.
+ *
+ * @Condition(
+ *   id = "og_group_type",
+ *   label = @Translation("Group type"),
+ *   context = {
+ *     "og" = @ContextDefinition("entity", label = @Translation("Group"))
+ *   }
+ * )
+ */
+class GroupType extends ConditionPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The group type manager.
+   *
+   * @var \Drupal\og\GroupTypeManager
+   */
+  protected $groupTypeManager;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The entity type bundle info service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeBundleInfoInterface
+   */
+  protected $entityTypeBundleInfo;
+
+  /**
+   * Creates a new GroupType instance.
+   *
+   * @param array $configuration
+   *   The plugin configuration, i.e. an array with configuration values keyed
+   *   by configuration option name. The special key 'context' may be used to
+   *   initialize the defined contexts by setting it to an array of context
+   *   values keyed by context names.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\og\GroupTypeManager $group_type_manager
+   *   The group type manager.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entity_type_bundle_info
+   *   The entity type bundle info service.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, GroupTypeManager $group_type_manager, EntityTypeManagerInterface $entity_type_manager, EntityTypeBundleInfoInterface $entity_type_bundle_info) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->groupTypeManager = $group_type_manager;
+    $this->entityTypeManager = $entity_type_manager;
+    $this->entityTypeBundleInfo = $entity_type_bundle_info;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('og.group_type_manager'),
+      $container->get('entity_type.manager'),
+      $container->get('entity_type.bundle.info')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    $options = [];
+    $group_types = $this->groupTypeManager->getAllGroupBundles();
+    foreach ($group_types as $entity_type => $bundles) {
+      $definition = $this->entityTypeManager->getDefinition($entity_type);
+      $entity_type_label = $definition->getLabel();
+      $bundle_info = $this->entityTypeBundleInfo->getBundleInfo($entity_type);
+      foreach ($bundles as $bundle) {
+        $bundle_label = $bundle_info[$bundle]['label'];
+        $options["$entity_type-$bundle"] = "$entity_type_label - $bundle_label";
+      }
+    }
+    $form['group_types'] = [
+      '#title' => $this->t('Group types'),
+      '#type' => 'checkboxes',
+      '#options' => $options,
+      '#default_value' => $this->configuration['group_types'],
+    ];
+    return parent::buildConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+    $this->configuration['group_types'] = array_filter($form_state->getValue('group_types'));
+    parent::submitConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function summary() {
+    if (count($this->configuration['group_types']) > 1) {
+      $group_types = $this->configuration['group_types'];
+      $last_group = array_pop($group_types);
+      $group_types = implode(', ', $group_types);
+      return $this->t('The group type is @group_types or @last_group', ['@group_types' => $group_types, '@last_group' => $last_group]);
+    }
+    $group_type = reset($this->configuration['group_types']);
+    return $this->t('The group type is @group_type', ['@group_type' => $group_type]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function evaluate() {
+    if (empty($this->configuration['group_types']) && !$this->isNegated()) {
+      return TRUE;
+    }
+    $group = $this->getContextValue('og');
+    $key = $group->getEntityTypeId() . '-' . $group->bundle();
+    return !empty($this->configuration['group_types'][$key]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return ['group_types' => []] + parent::defaultConfiguration();
+  }
+
+}

--- a/src/Plugin/Condition/GroupType.php
+++ b/src/Plugin/Condition/GroupType.php
@@ -90,6 +90,18 @@ class GroupType extends ConditionPluginBase implements ContainerFactoryPluginInt
   public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
     $options = [];
     $group_types = $this->groupTypeManager->getAllGroupBundles();
+
+    // If no groups have been created yet, show only the error message and hide
+    // the other elements.
+    if (empty($group_types)) {
+      $form['empty'] = [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => $this->t('No groups have been set up yet.'),
+      ];
+      return $form;
+    }
+
     foreach ($group_types as $entity_type => $bundles) {
       $definition = $this->entityTypeManager->getDefinition($entity_type);
       $entity_type_label = $definition->getLabel();
@@ -105,6 +117,7 @@ class GroupType extends ConditionPluginBase implements ContainerFactoryPluginInt
       '#options' => $options,
       '#default_value' => $this->configuration['group_types'],
     ];
+
     return parent::buildConfigurationForm($form, $form_state);
   }
 

--- a/tests/src/Kernel/GroupTypeConditionTest.php
+++ b/tests/src/Kernel/GroupTypeConditionTest.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace Drupal\Tests\og\Kernel;
+
+use Drupal\entity_test\Entity\EntityTest;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+
+/**
+ * Tests the GroupType condition plugin.
+ *
+ * @group og
+ */
+class GroupTypeConditionTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'entity_test',
+    'field',
+    'node',
+    'og',
+    'system',
+    'user',
+  ];
+
+  /**
+   * Test groups.
+   *
+   * @var \Drupal\Core\Entity\EntityInterface[]
+   */
+  protected $groups;
+
+  /**
+   * The condition plugin manager.
+   *
+   * @var \Drupal\Component\Plugin\PluginManagerInterface
+   */
+  protected $conditionManager;
+
+  /**
+   * The group type manager.
+   *
+   * @var \Drupal\og\GroupTypeManager
+   */
+  protected $groupTypeManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->conditionManager = $this->container->get('plugin.manager.condition');
+    $this->groupTypeManager = $this->container->get('og.group_type_manager');
+
+    // Add membership and config schema.
+    $this->installConfig(['og']);
+    $this->installEntitySchema('entity_test');
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('user');
+    $this->installSchema('system', ['queue', 'sequences']);
+
+    // Create three test groups of different types.
+    for ($i = 0; $i < 2; $i++) {
+      $bundle = "node$i";
+
+      NodeType::create([
+        'name' => $this->randomString(),
+        'type' => $bundle,
+      ])->save();
+      $this->groupTypeManager->addGroup('node', $bundle);
+
+      $group = Node::create([
+        'title' => $this->randomString(),
+        'type' => $bundle,
+      ]);
+      $group->save();
+
+      $this->groups[$bundle] = $group;
+    }
+
+    // The Entity Test entity doesn't have 'real' bundles, so we don't need to
+    // create one, we can just add the group to the fake bundle.
+    $bundle = 'entity_test';
+    $this->groupTypeManager->addGroup('entity_test', $bundle);
+
+    $group = EntityTest::create([
+      'type' => $bundle,
+      'name' => $this->randomString(),
+    ]);
+    $group->save();
+    $this->groups[$bundle] = $group;
+  }
+
+  /**
+   * Tests conditions.
+   *
+   * @dataProvider conditionsProvider
+   */
+  public function testConditions($group_types, $negate, $context_value, $expected) {
+    // Create an instance of the group type condition plugin.
+    /** @var \Drupal\og\Plugin\Condition\GroupType $plugin_instance */
+
+    $plugin_instance = $this->conditionManager->createInstance('og_group_type')
+      ->setConfig('group_types', array_combine($group_types, $group_types))
+      ->setConfig('negate', $negate)
+      ->setContextValue('og', $this->groups[$context_value]);
+
+    $this->assertEquals($expected, $plugin_instance->execute());
+  }
+
+  /**
+   * Data provider for ::testConditions().
+   *
+   * @return array
+   *   An indexed array with the following elements:
+   *   - 0: An array of group types that are configured in the plugin, in the
+   *     format '{entity_type_id}-{bundle_id}'.
+   *   - 1: A boolean indicating whether or not the plugin is configured to
+   *     negate the condition.
+   *   - 2: The ID of the test group that is present on the route context.
+   *   - 3: A boolean indicating whether or not the condition is expected to be
+   *     true.
+   */
+  public static function conditionsProvider() {
+    return [
+      [
+        // The plugin is configured to act on group type node, bundle node0.
+        ['node-node0'],
+        // It's configuration is not negated.
+        FALSE,
+        // Our test group 'node0' is available as context.
+        'node0',
+        // So the condition is expected to match.
+        TRUE,
+      ],
+      [
+        ['node-node1'],
+        TRUE,
+        'node1',
+        FALSE,
+      ],
+      [
+        ['entity_test-entity_test'],
+        TRUE,
+        'node1',
+        TRUE,
+      ],
+      [
+        ['node-node0', 'node-node1'],
+        FALSE,
+        'entity_test',
+        FALSE,
+      ],
+      [
+        ['node-node0', 'node-node1', 'entity_test-entity_test'],
+        FALSE,
+        'entity_test',
+        TRUE,
+      ],
+      [
+        ['node-node0', 'node-node1'],
+        TRUE,
+        'node0',
+        FALSE,
+      ],
+    ];
+  }
+
+}


### PR DESCRIPTION
This PR provides a `Condition` plugin that can be used to display blocks only on pages that belong to groups of a certain type. It does this by leveraging the `OgContext` context provider.

![block-visibility-plugin](https://cloud.githubusercontent.com/assets/442924/25944536/f3b6ac82-3643-11e7-93d7-3fa7cf59bf5d.png)

