### PR TITLE
Validate that roles are valid for a membership before saving it

### DIFF
--- a/src/Entity/OgMembership.php
+++ b/src/Entity/OgMembership.php
@@ -134,6 +134,11 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
   public function getGroup() {
     $entity_type = $this->get('entity_type')->value;
     $entity_id = $this->get('entity_id')->value;
+
+    if (empty($entity_type) || empty($entity_id)) {
+      return NULL;
+    }
+
     return \Drupal::entityTypeManager()->getStorage($entity_type)->load($entity_id);
   }
 

--- a/src/Entity/OgMembership.php
+++ b/src/Entity/OgMembership.php
@@ -324,14 +324,20 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
       throw new \LogicException(sprintf('Entity type %s with ID %s is not an OG group.', $entity_type_id, $group->id()));
     }
 
-    // Make sure we don't save non-member or member role with a membership.
+    // Check if the roles are valid.
     foreach ($this->getRoles() as $role) {
       /** @var \Drupal\og\Entity\OgRole $role */
+      // Make sure we don't save a membership for a non-member.
       if ($role->getName() == OgRoleInterface::ANONYMOUS) {
         throw new \LogicException('Cannot save an OgMembership with reference to a non-member role.');
       }
+      // The regular membership is implied, we do not need to store it.
       elseif ($role->getName() == OgRoleInterface::AUTHENTICATED) {
         $this->revokeRole($role);
+      }
+      // The roles should apply to the group type.
+      elseif ($role->getGroupType() !== $group->getEntityTypeId() || $role->getGroupBundle() !== $group->bundle()) {
+        throw new \LogicException(sprintf('The role with ID %s does not match the group type of the membership.', $role->id()));
       }
     }
 

--- a/src/Entity/OgMembership.php
+++ b/src/Entity/OgMembership.php
@@ -246,7 +246,6 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
       return FALSE;
     }
 
-
     // If the entity type and bundle of the role doesn't match the group then
     // the role is intended for a different group type.
     elseif ($role->getGroupType() !== $group->getEntityTypeId() || $role->getGroupBundle() !== $group->bundle()) {

--- a/src/OgMembershipInterface.php
+++ b/src/OgMembershipInterface.php
@@ -101,7 +101,7 @@ interface OgMembershipInterface extends ContentEntityInterface {
   /**
    * Gets the group associated with the membership.
    *
-   * @return \Drupal\Core\Entity\EntityInterface|NULL
+   * @return \Drupal\Core\Entity\EntityInterface|null
    *   The group object which is referenced by the membership, or NULL if no
    *   group has been set yet.
    */

--- a/src/OgMembershipInterface.php
+++ b/src/OgMembershipInterface.php
@@ -101,8 +101,9 @@ interface OgMembershipInterface extends ContentEntityInterface {
   /**
    * Gets the group associated with the membership.
    *
-   * @return \Drupal\Core\Entity\EntityInterface
-   *   The group object which the membership reference to.
+   * @return \Drupal\Core\Entity\EntityInterface|NULL
+   *   The group object which is referenced by the membership, or NULL if no
+   *   group has been set yet.
    */
   public function getGroup();
 

--- a/src/OgMembershipInterface.php
+++ b/src/OgMembershipInterface.php
@@ -197,6 +197,21 @@ interface OgMembershipInterface extends ContentEntityInterface {
   public function getRoles();
 
   /**
+   * Returns whether the given role is valid for this membership.
+   *
+   * @param \Drupal\og\OgRoleInterface $role
+   *   The role to check.
+   *
+   * @return bool
+   *   True if the role is valid, false otherwise.
+   *
+   * @throws \LogicException
+   *   Thrown when the validity of the role cannot be established, for example
+   *   because the group hasn't yet been set on the membership.
+   */
+  public function isRoleValid(OgRoleInterface $role);
+
+  /**
    * Checks if the user has a permission inside the group.
    *
    * @param string $permission

--- a/tests/src/Kernel/Entity/OgMembershipTest.php
+++ b/tests/src/Kernel/Entity/OgMembershipTest.php
@@ -139,7 +139,7 @@ class OgMembershipTest extends KernelTestBase {
    * @expectedException \Drupal\Core\Entity\EntityStorageException
    */
   public function testSetNoUserException() {
-    /** @var \Drupal\og\Entity\OgMembershipInterface $membership */
+    /** @var \Drupal\og\OgMembershipInterface $membership */
     $membership = OgMembership::create(['type' => OgMembershipInterface::TYPE_DEFAULT]);
     $membership
       ->setGroup($this->group)
@@ -153,7 +153,7 @@ class OgMembershipTest extends KernelTestBase {
    * @expectedException \Drupal\Core\Entity\EntityStorageException
    */
   public function testSetNoGroupException() {
-    /** @var \Drupal\og\Entity\OgMembershipInterface $membership */
+    /** @var \Drupal\og\OgMembershipInterface $membership */
     $membership = OgMembership::create();
     $membership
       ->setUser($this->user)
@@ -173,7 +173,7 @@ class OgMembershipTest extends KernelTestBase {
     ]);
 
     $non_group->save();
-    /** @var \Drupal\og\Entity\OgMembershipInterface $membership */
+    /** @var \Drupal\og\OgMembershipInterface $membership */
     $membership = Og::createMembership($non_group, $this->user);
     $membership->save();
   }
@@ -194,7 +194,7 @@ class OgMembershipTest extends KernelTestBase {
 
     Og::groupTypeManager()->addGroup('entity_test', $group->bundle());
 
-    /** @var \Drupal\og\Entity\OgMembershipInterface $membership */
+    /** @var \Drupal\og\OgMembershipInterface $membership */
     $membership1 = Og::createMembership($group, $this->user);
     $membership1->save();
 
@@ -266,7 +266,7 @@ class OgMembershipTest extends KernelTestBase {
 
     Og::groupTypeManager()->addGroup('entity_test', $group->bundle());
 
-    /** @var \Drupal\og\Entity\OgMembershipInterface $membership */
+    /** @var \Drupal\og\OgMembershipInterface $membership */
     $membership = Og::createMembership($group, $this->user);
     $membership->save();
 

--- a/tests/src/Kernel/Entity/OgMembershipTest.php
+++ b/tests/src/Kernel/Entity/OgMembershipTest.php
@@ -379,6 +379,25 @@ class OgMembershipTest extends KernelTestBase {
   }
 
   /**
+   * Tests getting the group that is associated with a membership.
+   *
+   * @covers ::getGroup
+   */
+  public function testGetGroup() {
+    $membership = OgMembership::create();
+
+    // When no group has been set yet, the method should return NULL.
+    $this->assertNull($membership->getGroup());
+
+    // Set a group.
+    $membership->setGroup($this->group);
+
+    // Now the group should be returned. Check both the entity type and ID.
+    $this->assertEquals($this->group->getEntityTypeId(), $membership->getGroup()->getEntityTypeId());
+    $this->assertEquals($this->group->id(), $membership->getGroup()->id());
+  }
+
+  /**
    * Tests that membership has "member" role when roles are retrieved.
    *
    * @covers ::getRoles


### PR DESCRIPTION
This has been split off from PR #244 - @amitaibu remarked:

> My concern about the "out of group context" is that I want to prevent granting invalid roles. That is, roles that don't apply to the user selected, as `OgRoles` are referenced from `OgMembership` not from the `User`.

It is currently possible to save memberships that have roles from a different group type, either by calling `OgMembership::addRole()` with the wrong `OgRole` entity, or by changing the group type of an existing membership by calling `OgMembership::setGroup()` with a different group type.

This PR enforces valid roles on API level by validating the roles in `OgRole::preSave()`.