### PR TITLE
Add missing methods to `OgRoleInterface`

### DIFF
--- a/src/Entity/OgRole.php
+++ b/src/Entity/OgRole.php
@@ -55,12 +55,7 @@ class OgRole extends Role implements OgRoleInterface {
   }
 
   /**
-   * Sets the ID of the role.
-   *
-   * @param string $id
-   *   The machine name of the role.
-   *
-   * @return $this
+   * {@inheritdoc}
    */
   public function setId($id) {
     $this->set('id', $id);
@@ -68,22 +63,14 @@ class OgRole extends Role implements OgRoleInterface {
   }
 
   /**
-   * Returns the label.
-   *
-   * @return string
-   *   The label.
+   * {@inheritdoc}
    */
   public function getLabel() {
     return $this->get('label');
   }
 
   /**
-   * Sets the label.
-   *
-   * @param string $label
-   *   The label to set.
-   *
-   * @return $this
+   * {@inheritdoc}
    */
   public function setLabel($label) {
     $this->set('label', $label);
@@ -91,22 +78,14 @@ class OgRole extends Role implements OgRoleInterface {
   }
 
   /**
-   * Returns the group type.
-   *
-   * @return string
-   *   The group type.
+   * {@inheritdoc}
    */
   public function getGroupType() {
     return $this->get('group_type');
   }
 
   /**
-   * Sets the group type.
-   *
-   * @param string $group_type
-   *   The group type to set.
-   *
-   * @return $this
+   * {@inheritdoc}
    */
   public function setGroupType($group_type) {
     $this->set('group_type', $group_type);
@@ -114,22 +93,14 @@ class OgRole extends Role implements OgRoleInterface {
   }
 
   /**
-   * Returns the group bundle.
-   *
-   * @return string
-   *   The group bundle.
+   * {@inheritdoc}
    */
   public function getGroupBundle() {
     return $this->get('group_bundle');
   }
 
   /**
-   * Sets the group bundle.
-   *
-   * @param string $group_bundle
-   *   The group bundle to set.
-   *
-   * @return $this
+   * {@inheritdoc}
    */
   public function setGroupBundle($group_bundle) {
     $this->set('group_bundle', $group_bundle);

--- a/src/OgRoleInterface.php
+++ b/src/OgRoleInterface.php
@@ -50,6 +50,83 @@ interface OgRoleInterface {
   public function setId($id);
 
   /**
+   * Returns the label.
+   *
+   * @return string
+   *   The label.
+   */
+  public function getLabel();
+
+  /**
+   * Sets the label.
+   *
+   * @param string $label
+   *   The label to set.
+   *
+   * @return $this
+   */
+  public function setLabel($label);
+
+  /**
+   * Returns the group type.
+   *
+   * @return string
+   *   The group type.
+   */
+  public function getGroupType();
+
+  /**
+   * Sets the group type.
+   *
+   * @param string $group_type
+   *   The group type to set.
+   *
+   * @return $this
+   */
+  public function setGroupType($group_type);
+
+  /**
+   * Returns the group bundle.
+   *
+   * @return string
+   *   The group bundle.
+   */
+  public function getGroupBundle();
+
+  /**
+   * Sets the group bundle.
+   *
+   * @param string $group_bundle
+   *   The group bundle to set.
+   *
+   * @return $this
+   */
+  public function setGroupBundle($group_bundle);
+
+  /**
+   * Returns the role type.
+   *
+   * @return string
+   *   The role type. One of OgRoleInterface::ROLE_TYPE_REQUIRED or
+   *   OgRoleInterface::ROLE_TYPE_STANDARD.
+   */
+  public function getRoleType();
+
+  /**
+   * Sets the role type.
+   *
+   * @param string $role_type
+   *   The role type to set. One of OgRoleInterface::ROLE_TYPE_REQUIRED or
+   *   OgRoleInterface::ROLE_TYPE_STANDARD.
+   *
+   * @return $this
+   *
+   * @throws \InvalidArgumentException
+   *   Thrown when an invalid role type is given.
+   */
+  public function setRoleType($role_type);
+
+  /**
    * Returns the role name.
    *
    * @return string


### PR DESCRIPTION
This has been split off from #244.

There are a couple of methods in `OgRole` that are not declared in `OgRoleInterface`. This PR adds the missing methods.