### PR TITLE
A bundle should no longer be marked as a group type after it is deleted

### DIFF
--- a/og.module
+++ b/og.module
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Cache\Cache;
+use Drupal\Core\Config\Entity\ConfigEntityBundleBase;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
@@ -92,6 +93,16 @@ function og_entity_delete(EntityInterface $entity) {
   // Clear static caches after a group or group content entity is deleted.
   if (Og::isGroup($entity->getEntityTypeId(), $entity->bundle()) || Og::isGroupContent($entity->getEntityTypeId(), $entity->bundle())) {
     Og::invalidateCache();
+  }
+
+  // If a group content type is deleted, make sure to remove it from the list of
+  // groups.
+  if ($entity instanceof ConfigEntityBundleBase) {
+    $bundle = $entity->id();
+    $entity_type_id = \Drupal::entityTypeManager()->getDefinition($entity->getEntityTypeId())->getBundleOf();
+    if (Og::isGroup($entity_type_id, $bundle)) {
+      Og::groupTypeManager()->removeGroup($entity_type_id, $bundle);
+    }
   }
 }
 

--- a/tests/src/Kernel/Entity/GroupTypeTest.php
+++ b/tests/src/Kernel/Entity/GroupTypeTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Drupal\Tests\og\Kernel\Entity;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\node\Entity\NodeType;
+
+/**
+ * Test creation and deletion of group types.
+ *
+ * @group og
+ */
+class GroupTypeTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = ['field', 'node', 'og', 'system', 'user'];
+
+  /**
+   * The group type manager.
+   *
+   * @var \Drupal\og\GroupTypeManager
+   */
+  protected $groupTypeManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    // Installing needed schema.
+    $this->installConfig(['og']);
+
+    $this->groupTypeManager = $this->container->get('og.group_type_manager');
+  }
+
+  /**
+   * Testing OG role creation.
+   */
+  public function testGroupType() {
+    // Create a content type.
+    /** @var \Drupal\node\NodeTypeInterface $group_type */
+    $group_type = NodeType::create(['type' => 'group', 'name' => 'Group']);
+    $group_type->save();
+
+    // Initially it is not a group.
+    $this->assertFalse($this->groupTypeManager->isGroup('node', 'group'));
+
+    // Turn it into a group.
+    $this->groupTypeManager->addGroup('node', 'group');
+    $this->assertTrue($this->groupTypeManager->isGroup('node', 'group'));
+
+    // Delete the content type. It should no longer be a group.
+    $group_type->delete();
+    $this->assertFalse($this->groupTypeManager->isGroup('node', 'group'));
+  }
+
+}

--- a/tests/src/Kernel/Entity/GroupTypeTest.php
+++ b/tests/src/Kernel/Entity/GroupTypeTest.php
@@ -30,14 +30,12 @@ class GroupTypeTest extends KernelTestBase {
   protected function setUp() {
     parent::setUp();
 
-    // Installing needed schema.
     $this->installConfig(['og']);
-
     $this->groupTypeManager = $this->container->get('og.group_type_manager');
   }
 
   /**
-   * Testing OG role creation.
+   * Test creation and deletion of a group type.
    */
   public function testGroupType() {
     // Create a content type.
@@ -45,7 +43,7 @@ class GroupTypeTest extends KernelTestBase {
     $group_type = NodeType::create(['type' => 'group', 'name' => 'Group']);
     $group_type->save();
 
-    // Initially it is not a group.
+    // Initially it should not be a group.
     $this->assertFalse($this->groupTypeManager->isGroup('node', 'group'));
 
     // Turn it into a group.


### PR DESCRIPTION
This has been split off from #244.

Currently when an entity type is declared as a group type and then is subsequently deleted, the configuration is not updated, and the deleted group type is still marked as a group.

We should make sure the list of group types is kept up to date and no orphaned entries stay behind when the parent entity type is deleted.