### PR TITLE
Type hint on `OgRoleInterface` instead of on `OgRole`

### DIFF
--- a/src/Entity/OgMembership.php
+++ b/src/Entity/OgMembership.php
@@ -167,7 +167,7 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
   /**
    * {@inheritdoc}
    */
-  public function addRole(OgRole $role) {
+  public function addRole(OgRoleInterface $role) {
     $roles = $this->getRoles();
     $roles[] = $role;
 
@@ -177,7 +177,7 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
   /**
    * {@inheritdoc}
    */
-  public function revokeRole(OgRole $role) {
+  public function revokeRole(OgRoleInterface $role) {
     $roles = $this->getRoles();
 
     foreach ($roles as $key => $existing_role) {

--- a/src/OgMembershipInterface.php
+++ b/src/OgMembershipInterface.php
@@ -5,7 +5,6 @@ namespace Drupal\og;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Session\AccountInterface;
-use Drupal\og\Entity\OgRole;
 
 /**
  * Provides an interface for OG memberships.
@@ -170,24 +169,24 @@ interface OgMembershipInterface extends ContentEntityInterface {
   /**
    * Adds a role to the user membership.
    *
-   * @param \Drupal\og\Entity\OgRole $role
+   * @param \Drupal\og\OgRoleInterface $role
    *   The OG role.
    *
    * @return \Drupal\og\OgMembershipInterface
    *   The updated OG Membership object.
    */
-  public function addRole(OgRole $role);
+  public function addRole(OgRoleInterface $role);
 
   /**
    * Revokes a role from the OG membership.
    *
-   * @param \Drupal\og\Entity\OgRole $role
+   * @param \Drupal\og\OgRoleInterface $role
    *   The OG role.
    *
    * @return \Drupal\og\OgMembershipInterface
    *   The updated OG Membership object.
    */
-  public function revokeRole(OgRole $role);
+  public function revokeRole(OgRoleInterface $role);
 
   /**
    * Gets all the referenced OG roles.


### PR DESCRIPTION
This is split off from PR #244.

We should always type hint on the interface instead of the implementation if possible. This will allow developers to customize and extend our entities and services.