### PR TITLE
Fix random failure in OgRoleManagerTest

### DIFF
--- a/tests/src/Kernel/OgRoleManagerTest.php
+++ b/tests/src/Kernel/OgRoleManagerTest.php
@@ -48,6 +48,13 @@ class OgRoleManagerTest extends KernelTestBase {
   protected $roleName;
 
   /**
+   * The OG role manager.
+   *
+   * @var \Drupal\og\OgRoleManagerInterface
+   */
+  protected $ogRoleManager;
+
+  /**
    * {@inheritdoc}
    */
   public function setUp() {
@@ -58,6 +65,8 @@ class OgRoleManagerTest extends KernelTestBase {
     $this->installEntitySchema('node');
     $this->bundle = Unicode::strtolower($this->randomMachineName());
     $this->roleName = Unicode::strtolower($this->randomMachineName());
+
+    $this->ogRoleManager = $this->container->get('og.role_manager');
 
     // Create a group entity type.
     NodeType::create([
@@ -89,9 +98,10 @@ class OgRoleManagerTest extends KernelTestBase {
       'node-' . $this->bundle . '-' . $this->roleName,
     ];
 
-    $role_manager = $this->container->get('og.role_manager');
-    $roles = $role_manager->getRolesByBundle('node', $this->bundle);
+    $roles = $this->ogRoleManager->getRolesByBundle('node', $this->bundle);
     $role_ids = array_keys($roles);
+    sort($expected_role_ids);
+    sort($role_ids);
     $this->assertEquals($expected_role_ids, $role_ids);
   }
 


### PR DESCRIPTION
During the work on #244 a random failure in `OgRoleManagerTest` was discovered. Entities are not guaranteed to be returned in the same order every time, so we should sort the results before comparing them with the expected values.

For an example of this random failure occurring, check build https://travis-ci.org/Gizra/og/builds/226714806 - in jobs 804.1, 804.2 and 804.6 this test failed, in the others it was fine.