### PR TITLE
Introduce OgMembershipInterface::revokeRoleById()

### DIFF
--- a/src/Entity/OgMembership.php
+++ b/src/Entity/OgMembership.php
@@ -178,10 +178,17 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
    * {@inheritdoc}
    */
   public function revokeRole(OgRoleInterface $role) {
+    return $this->revokeRoleById($role->id());
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function revokeRoleById($role_id) {
     $roles = $this->getRoles();
 
     foreach ($roles as $key => $existing_role) {
-      if ($existing_role->id() == $role->id()) {
+      if ($existing_role->id() == $role_id) {
         unset($roles[$key]);
 
         // We can stop iterating.

--- a/src/OgMembershipInterface.php
+++ b/src/OgMembershipInterface.php
@@ -189,6 +189,17 @@ interface OgMembershipInterface extends ContentEntityInterface {
   public function revokeRole(OgRoleInterface $role);
 
   /**
+   * Revokes a role from the OG membership.
+   *
+   * @param string $role_id
+   *   The OG role ID.
+   *
+   * @return \Drupal\og\OgMembershipInterface
+   *   The updated OG Membership object.
+   */
+  public function revokeRoleById($role_id);
+
+  /**
    * Gets all the referenced OG roles.
    *
    * @return \Drupal\og\Entity\OgRole[]

--- a/tests/src/Kernel/Entity/OgMembershipRoleReferenceTest.php
+++ b/tests/src/Kernel/Entity/OgMembershipRoleReferenceTest.php
@@ -105,7 +105,7 @@ class OgMembershipRoleReferenceTest extends KernelTestBase {
       ->setLabel('Group member');
     $group_member->save();
 
-    /** @var \Drupal\og\OgMembership $membership */
+    /** @var \Drupal\og\OgMembershipInterface $membership */
     $membership = Og::getMembership($this->group, $this->user);
     $membership
       // Assign only the content editor role for now.
@@ -133,6 +133,11 @@ class OgMembershipRoleReferenceTest extends KernelTestBase {
     $this->assertFalse($membership->hasPermission('administer group'), 'The user has permission to administer groups.');
     $membership->addRole($content_editor);
     $this->assertTrue($membership->hasPermission('administer group'), 'The user has permission to administer groups.');
+
+    // Remove a role by ID.
+    $membership->revokeRoleById($group_member->id());
+    $roles_ids = $membership->getRolesIds();
+    $this->assertFalse(in_array($group_member->id(), $roles_ids), 'The group member role has been revoked.');
   }
 
 }


### PR DESCRIPTION
Currently if we want to revoke a role from a membership we need to provide the full `RoleInterface` object to `OgMembership::revokeRole()`. Let's introduce a new method to be able to delete a role when we only have the ID available. This will make sure we don't unnecessarily need to load the role from the database in order to delete it from a membership.