### PR TITLE
Add #access checks in group permissions screen

### DIFF
--- a/og_ui/og_ui.admin.inc
+++ b/og_ui/og_ui.admin.inc
@@ -884,7 +884,7 @@ function theme_og_ui_admin_permissions($variables) {
   $form = $variables['form'];
   $role_names = $form['role_names']['#value'];
 
-  foreach (element_children($form['permission']) as $key) {
+  foreach (element_get_visible_children($form['permission']) as $key) {
     $row = array();
     // Module name.
     if (is_numeric($key)) {
@@ -897,7 +897,7 @@ function theme_og_ui_admin_permissions($variables) {
         'class' => array('permission'),
       );
 
-      foreach (element_children($form['checkboxes']) as $rid) {
+      foreach (element_get_visible_children($form['checkboxes']) as $rid) {
         $form['checkboxes'][$rid][$key]['#title'] = $role_names[$rid] . ': ' . $form['permission'][$key]['#markup'];
         $form['checkboxes'][$rid][$key]['#title_display'] = 'invisible';
         $row[] = array('data' => drupal_render($form['checkboxes'][$rid][$key]), 'class' => array('checkbox'));
@@ -906,7 +906,7 @@ function theme_og_ui_admin_permissions($variables) {
     $rows[] = $row;
   }
   $header[] = (t('Permission'));
-  foreach (element_children($form['role_names']) as $rid) {
+  foreach (element_get_visible_children($form['role_names']) as $rid) {
     $header[] = array('data' => drupal_render($form['role_names'][$rid]), 'class' => array('checkbox'));
   }
   $output = '';


### PR DESCRIPTION
This change allows alter/after build hook to change the `#access` setting of form elements of the `og_ui_admin_permissions` form.

I want to hide certain modules from the group permissions screen for usability purposes. Setting the `#access` value of form elements in an after_build hook allows me to do this without taking special precautions to keep hidden permissions in their original state, as Drupal handles this automatically. The theme hook `theme_og_ui_admin_permissions` needs three small adjustments to take `#access` into account.