### PR TITLE
Fix the data type of the membership state

### DIFF
--- a/src/OgMembershipInterface.php
+++ b/src/OgMembershipInterface.php
@@ -125,7 +125,7 @@ interface OgMembershipInterface extends ContentEntityInterface {
   /**
    * Sets the membership state.
    *
-   * @param int $state
+   * @param string $state
    *   The state of the membership. It may be of the following constants:
    *   - OgMembershipInterface::STATE_ACTIVE
    *   - OgMembershipInterface::STATE_PENDING
@@ -139,7 +139,7 @@ interface OgMembershipInterface extends ContentEntityInterface {
   /**
    * Gets the membership state.
    *
-   * @return int
+   * @return string
    *   The state of the membership. It may be of the following constants:
    *   - OgMembershipInterface::STATE_ACTIVE
    *   - OgMembershipInterface::STATE_PENDING


### PR DESCRIPTION
The membership states are strings, but the documentation currently mentions they are integers.