### PR TITLE
API breaks for entities without an owner

### DIFF
--- a/og.module
+++ b/og.module
@@ -40,7 +40,8 @@ function og_entity_insert(EntityInterface $entity) {
     return;
   }
 
-  if (!$entity->getOwner()) {
+  $owner = $entity->getOwner();
+  if (empty($owner) || $owner->isAnonymous()) {
     // User is anonymous, se we cannot set a membership for them.
     return;
   }

--- a/tests/src/Kernel/Entity/OgMembershipTest.php
+++ b/tests/src/Kernel/Entity/OgMembershipTest.php
@@ -71,6 +71,7 @@ class OgMembershipTest extends KernelTestBase {
     $this->entityTypeManager = $this->container->get('entity_type.manager');
     $storage = $this->entityTypeManager->getStorage('user');
     // Insert a row for the anonymous user.
+    // @see user_install().
     $storage->create(['uid' => 0, 'status' => 0, 'name' => ''])->save();
 
     // Create a bundle and add as a group.
@@ -167,7 +168,7 @@ class OgMembershipTest extends KernelTestBase {
   }
 
   /**
-   * Tests that a logic exception is not thrown for groups with no owner.
+   * Test that it is possible to create groups without an owner.
    */
   public function testNoOwnerException() {
     // Create a bundle and add as a group.

--- a/tests/src/Kernel/Entity/OgMembershipTest.php
+++ b/tests/src/Kernel/Entity/OgMembershipTest.php
@@ -5,6 +5,8 @@ namespace Drupal\Tests\og\Kernel\Entity;
 use Drupal\Component\Utility\Unicode;
 use Drupal\entity_test\Entity\EntityTest;
 use Drupal\KernelTests\KernelTestBase;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
 use Drupal\og\Entity\OgMembership;
 use Drupal\og\Og;
 use Drupal\og\OgMembershipInterface;
@@ -26,6 +28,7 @@ class OgMembershipTest extends KernelTestBase {
   public static $modules = [
     'entity_test',
     'field',
+    'node',
     'og',
     'system',
     'user',
@@ -61,10 +64,14 @@ class OgMembershipTest extends KernelTestBase {
     $this->installConfig(['og']);
     $this->installEntitySchema('og_membership');
     $this->installEntitySchema('entity_test');
+    $this->installEntitySchema('node');
     $this->installEntitySchema('user');
     $this->installSchema('system', 'sequences');
 
     $this->entityTypeManager = $this->container->get('entity_type.manager');
+    $storage = $this->entityTypeManager->getStorage('user');
+    // Insert a row for the anonymous user.
+    $storage->create(['uid' => 0, 'status' => 0, 'name' => ''])->save();
 
     // Create a bundle and add as a group.
     $group = EntityTest::create([
@@ -157,6 +164,27 @@ class OgMembershipTest extends KernelTestBase {
     $membership
       ->setUser($this->user)
       ->save();
+  }
+
+  /**
+   * Tests that a logic exception is not thrown for groups with no owner.
+   */
+  public function testNoOwnerException() {
+    // Create a bundle and add as a group.
+    $bundle = Unicode::strtolower($this->randomMachineName());
+    $group = NodeType::create([
+      'type' => $bundle,
+      'label' => $this->randomString(),
+    ]);
+    $group->save();
+
+    // Add that as a group.
+    Og::groupTypeManager()->addGroup('node', $bundle);
+    $entity = Node::create([
+      'title' => $this->randomString(),
+      'type' => $bundle,
+    ]);
+    $entity->save();
   }
 
   /**


### PR DESCRIPTION
I was trying to create a group using the API and I was writing a test that creates a group only for testing purposes. Since it's a test group, I only cared about the label and the bundle as the rest would be handled later on. The group is a custom entity type that fires the insert hooks properly.
Now, the issue is that the test breaks with the error "OG membership can not be created for an empty or anonymous user." and the problem comes from the og_entity_insert.

In og_entity_insert there is the following:
```
  if (!$entity->getOwner()) {
    // User is anonymous, se we cannot set a membership for them.
    return;
  }
```
which checks for the owner by retrieving the owner entity. The problem is that in Drupal 8, the anonymous user does have an entity (@see user_install()) and does retrieve an owner but since Kernel tests do not fire the installation hooks apparently (maybe I'm wrong), the tests can prove wrong maybe.
The second problem of the tests is that the EntityTest entity type does not fire the hook_entity_insert hooks (again I think, I did not have time to look deep into that one but it seems that the ContentEntityBase only runs the ::postSave hooks).

So in order to test this, I updated the OgMembership Kernel test by doing two things.
First, I am replicating the code from the user_install hook to create an anonymous user so that `$entity->getOwner` retrieves a user and does not falsely return NULL.
Secondly, for that test, I am using the nodes, that in the entity save, they fire the hook_insert hooks and a membership is attempted to be created.

The fix is actually pretty simple. It is to check if the owner is an anonymous in the above piece of code. 
Of course I did not touch the exception itself as I find it normal to fire it if a membership is attempted to be created through the API for an anonymous user.