### PR TITLE
Membership manager static cache misbehaves

### DIFF
--- a/src/MembershipManager.php
+++ b/src/MembershipManager.php
@@ -87,6 +87,7 @@ class MembershipManager implements MembershipManagerInterface {
 
     $identifier = [
       __METHOD__,
+      'user',
       $user->id(),
       $states_identifier,
     ];
@@ -154,6 +155,7 @@ class MembershipManager implements MembershipManagerInterface {
 
     $identifier = [
       __METHOD__,
+      $entity->getEntityTypeId(),
       $entity->id(),
       $group_type_id,
       $group_bundle,

--- a/tests/src/Kernel/Entity/GroupMembershipManagerTest.php
+++ b/tests/src/Kernel/Entity/GroupMembershipManagerTest.php
@@ -175,6 +175,9 @@ class GroupMembershipManagerTest extends KernelTestBase {
   /**
    * Tests that the static cache loads the appropriate group.
    *
+   * Verify that entities from different entity types with colliding Ids that
+   * point to different groups do not confuse the membership manager.
+   *
    * @covers ::getGroupIds
    */
   public function testStaticCache() {
@@ -182,7 +185,7 @@ class GroupMembershipManagerTest extends KernelTestBase {
     $membership_manager = \Drupal::service('og.membership_manager');
     $bundle_rev = Unicode::strtolower($this->randomMachineName());
     $bundle_update = Unicode::strtolower($this->randomMachineName());
-    $field_settigns = [
+    $field_settings = [
       'field_name' => 'group_audience_node',
       'field_storage_config' => [
         'settings' => [
@@ -190,8 +193,8 @@ class GroupMembershipManagerTest extends KernelTestBase {
         ],
       ],
     ];
-    Og::createField(OgGroupAudienceHelperInterface::DEFAULT_FIELD, 'entity_test_rev', $bundle_rev, $field_settigns);
-    Og::createField(OgGroupAudienceHelperInterface::DEFAULT_FIELD, 'entity_test_update', $bundle_update, $field_settigns);
+    Og::createField(OgGroupAudienceHelperInterface::DEFAULT_FIELD, 'entity_test_rev', $bundle_rev, $field_settings);
+    Og::createField(OgGroupAudienceHelperInterface::DEFAULT_FIELD, 'entity_test_update', $bundle_update, $field_settings);
 
     $group_content_rev = EntityTestRev::create([
       'type' => $bundle_rev,

--- a/tests/src/Kernel/Entity/GroupMembershipManagerTest.php
+++ b/tests/src/Kernel/Entity/GroupMembershipManagerTest.php
@@ -217,6 +217,10 @@ class GroupMembershipManagerTest extends KernelTestBase {
     ]);
     $group_content_update->save();
 
+    // Ensure that both entities share the same Id. This is an assertion to
+    // ensure that the next assertions are addressing the proper issue.
+    $this->assertEquals($group_content_rev->id(), $group_content_update->id());
+
     $group_content_rev_group = $membership_manager->getGroups($group_content_rev);
     /** @var \Drupal\node\NodeInterface $group */
     $group = reset($group_content_rev_group['node']);

--- a/tests/src/Kernel/Entity/GroupMembershipManagerTest.php
+++ b/tests/src/Kernel/Entity/GroupMembershipManagerTest.php
@@ -3,7 +3,6 @@
 namespace Drupal\Tests\og\Kernel\Entity;
 
 use Drupal\Component\Utility\Unicode;
-use Drupal\entity_test\Entity\EntityTestNew;
 use Drupal\entity_test\Entity\EntityTestRev;
 use Drupal\entity_test\Entity\EntityTestUpdate;
 use Drupal\KernelTests\KernelTestBase;
@@ -222,7 +221,6 @@ class GroupMembershipManagerTest extends KernelTestBase {
     $group_content_update_group = $membership_manager->getGroups($group_content_update);
     $group = reset($group_content_update_group['node']);
     $this->assertEquals($this->groups['node'][1]->id(), $group->id());
-
   }
 
   /**


### PR DESCRIPTION
So I noticed the following wrong behaviour in the Membership manager related to the static cache.
Let's say we have 3 entity types, A, B, C.
A and B are group content both pointing to group C.
Now, since A and B are different entity types, they have different base tables so they have their own unique Ids.

So let's create A1 with id 1 and B1 with id 1. A1 points to C1 with Id 1 and B1 points to C2 with id 2.
If that creation happens at the same request and the groups are requested, the membership is using the identifier `<method name>:$entity->id():<group_type(optional)>:<group_bundle(optional)>`.
In the above case it will be something like `OgMemberhsip::getGroupIds:1::`.

The problem is that when the B1 group will be requested, the C1 will be returned instead of C2.
This is because the content's entity type Id is not taken into account.

I am providing a test to prove the issue. I had to extend the group membership test by including two more entity types as the case is quite difficult to reproduce. It takes that two entities from different types share the same Id and point to different groups.
