### PR TITLE
Optimize some calls to og_is_group()

### DIFF
--- a/og_context/og_context.module
+++ b/og_context/og_context.module
@@ -640,7 +640,7 @@ function _group_context_handler_entity($entity_type = 'node', $entity = NULL, $p
   }
 
   // Check if the entity is itself a group.
-  if ($group = og_is_group($entity_type, $id)) {
+  if (og_is_group($entity_type, $entity)) {
     $contexts[$entity_type][] = $id;
   }
   elseif ($gids = og_get_entity_groups($entity_type, $entity)) {

--- a/og_ui/og_ui.module
+++ b/og_ui/og_ui.module
@@ -333,7 +333,7 @@ function og_ui_user_access_group($perm, $group_type, $gid) {
     // Not a valid entity type.
     return FALSE;
   }
-  return og_is_group($group_type, $gid) && og_user_access($group_type, $gid, $perm);
+  return og_is_group($group_type, $group) && og_user_access($group_type, $gid, $perm);
 }
 
 /**


### PR DESCRIPTION
`og_is_group()` is faster when an entire entity is provided. I found two places where an entity is already available.