### PR TITLE
Fixed assigning default overridden role to user

### DIFF
--- a/og.module
+++ b/og.module
@@ -855,7 +855,7 @@ function og_entity_insert($entity, $entity_type) {
     $name = 'og_group_manager_default_rids_' . $entity_type . '_' . $bundle;
     if ($rids = variable_get($name)) {
       foreach ($rids as $rid) {
-        og_role_grant($entity_type, $id, $entity->uid, $rid);
+        og_role_grant($entity_type, $id, $entity->uid, $rid, TRUE);
       }
     }
   }
@@ -3062,15 +3062,19 @@ function og_roles_override($group_type, $bundle, $gid) {
  *   The user ID.
  * @param $rid
  *   The role ID.
+ * @param $skipcheck
+ *   Set to true to skip checking if the role exists.
  */
-function og_role_grant($group_type, $gid, $uid, $rid) {
+function og_role_grant($group_type, $gid, $uid, $rid, $skipcheck = FALSE) {
   // Make sure the role is valid.
-  $group = entity_load_single($group_type, $gid);
-  list(,, $bundle) = entity_extract_ids($group_type, $group);
-  $og_roles = og_roles($group_type, $bundle, $gid, FALSE, FALSE);
-  if (empty($og_roles[$rid])) {
-    // Role isn't valid.
-    return;
+  if (!$skipcheck) {
+    $group = entity_load_single($group_type, $gid);
+    list(,, $bundle) = entity_extract_ids($group_type, $group);
+    $og_roles = og_roles($group_type, $bundle, $gid, FALSE, FALSE);
+    if (empty($og_roles[$rid])) {
+      // Role isn't valid.
+      return;
+    }
   }
 
   // Get the existing user roles.

--- a/og.test
+++ b/og.test
@@ -453,6 +453,9 @@ class OgGroupAndUngroup extends DrupalWebTestCase {
     // Add OG group field to the entity_test's "main" bundle.
     og_create_field(OG_GROUP_FIELD, 'entity_test', 'main');
 
+    // Add default access field to the entity_test's "main" bundle.
+    og_create_field(OG_DEFAULT_ACCESS_FIELD, 'entity_test', 'main');
+
     // Add OG audience field to the node's "article" bundle.
     $og_field = og_fields_info(OG_AUDIENCE_FIELD);
     $og_field['field']['settings']['target_type'] = 'entity_test';
@@ -641,6 +644,7 @@ class OgGroupAndUngroup extends DrupalWebTestCase {
     variable_set('og_group_manager_default_rids_entity_test_main', array_keys($og_roles));
     $user1 = $this->drupalCreateUser();
 
+    // Entity with default roles.
     $entity1 = entity_create('entity_test', array('name' => 'main', 'uid' => $user1->uid));
     $wrapper = entity_metadata_wrapper('entity_test', $entity1);
     $wrapper->{OG_GROUP_FIELD}->set(1);
@@ -648,6 +652,16 @@ class OgGroupAndUngroup extends DrupalWebTestCase {
 
     $user_roles = og_get_user_roles('entity_test', $entity1->pid, $user1->uid, FALSE);
     $this->assertEqual($og_roles, $user_roles, t('Group manager was granted default role.'));
+
+    // Entity with overridden roles.
+    $entity2 = entity_create('entity_test', array('name' => 'main', 'uid' => $user1->uid));
+    $wrapper2 = entity_metadata_wrapper('entity_test', $entity2);
+    $wrapper2->{OG_GROUP_FIELD}->set(1);
+    $wrapper2->{OG_DEFAULT_ACCESS_FIELD}->set(1);
+    $wrapper2->save();
+    $user_roles = og_get_user_roles('entity_test', $entity2->pid, $user1->uid, FALSE);
+    // Compare role names only as the role ids will be different.
+    $this->assertEqual(array_values($og_roles), array_values($user_roles), t('Group manager was granted default overridden role.'));
   }
 }
 


### PR DESCRIPTION
When roles are overridden for a group while the overridden roles are not yet created, `og_role_grant()` refuses to assign the default role.

By adding the `$skipcheck` parameter the role is inserted in the database and changed to the overridden role later by `og_roles_override()`. Adding this parameter was the easiest way of solving the chicken-and-egg problem because `og_roles_override()` is already capable of mapping the default role to the overridden one.

I added a test case to `OgGroupAndUngroup` even though `OgDefaultAccessFieldTestCase` also seemed a good candidate because `OgGroupAndUngroup` already contains a test method specifically for assigning default roles to the group creator.