### PR TITLE
Test failures in 8.3.x caused by moving  entity_test_update to a separate module

### DIFF
--- a/tests/src/Kernel/Entity/GroupMembershipManagerTest.php
+++ b/tests/src/Kernel/Entity/GroupMembershipManagerTest.php
@@ -3,8 +3,9 @@
 namespace Drupal\Tests\og\Kernel\Entity;
 
 use Drupal\Component\Utility\Unicode;
+use Drupal\entity_test\Entity\EntityTestBundle;
 use Drupal\entity_test\Entity\EntityTestRev;
-use Drupal\entity_test\Entity\EntityTestUpdate;
+use Drupal\entity_test\Entity\EntityTestWithBundle;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\entity_test\Entity\EntityTest;
 use Drupal\node\Entity\Node;
@@ -63,7 +64,7 @@ class GroupMembershipManagerTest extends KernelTestBase {
     $this->installConfig(['og']);
     $this->installEntitySchema('entity_test');
     $this->installEntitySchema('entity_test_rev');
-    $this->installEntitySchema('entity_test_update');
+    $this->installEntitySchema('entity_test_with_bundle');
     $this->installEntitySchema('node');
     $this->installEntitySchema('og_membership');
     $this->installEntitySchema('user');
@@ -184,7 +185,8 @@ class GroupMembershipManagerTest extends KernelTestBase {
     /** @var \Drupal\og\MembershipManagerInterface $membership_manager */
     $membership_manager = \Drupal::service('og.membership_manager');
     $bundle_rev = Unicode::strtolower($this->randomMachineName());
-    $bundle_update = Unicode::strtolower($this->randomMachineName());
+    $bundle_with_bundle = Unicode::strtolower($this->randomMachineName());
+    EntityTestBundle::create(['id' => $bundle_with_bundle, 'label' => $bundle_with_bundle])->save();
     $field_settings = [
       'field_name' => 'group_audience_node',
       'field_storage_config' => [
@@ -194,7 +196,7 @@ class GroupMembershipManagerTest extends KernelTestBase {
       ],
     ];
     Og::createField(OgGroupAudienceHelperInterface::DEFAULT_FIELD, 'entity_test_rev', $bundle_rev, $field_settings);
-    Og::createField(OgGroupAudienceHelperInterface::DEFAULT_FIELD, 'entity_test_update', $bundle_update, $field_settings);
+    Og::createField(OgGroupAudienceHelperInterface::DEFAULT_FIELD, 'entity_test_with_bundle', $bundle_with_bundle, $field_settings);
 
     $group_content_rev = EntityTestRev::create([
       'type' => $bundle_rev,
@@ -206,8 +208,8 @@ class GroupMembershipManagerTest extends KernelTestBase {
       ],
     ]);
     $group_content_rev->save();
-    $group_content_update = EntityTestUpdate::create([
-      'type' => $bundle_update,
+    $group_content_with_bundle = EntityTestWithBundle::create([
+      'type' => $bundle_with_bundle,
       'name' => $this->randomString(),
       'group_audience_node' => [
         0 => [
@@ -215,18 +217,18 @@ class GroupMembershipManagerTest extends KernelTestBase {
         ],
       ],
     ]);
-    $group_content_update->save();
+    $group_content_with_bundle->save();
 
     // Ensure that both entities share the same Id. This is an assertion to
     // ensure that the next assertions are addressing the proper issue.
-    $this->assertEquals($group_content_rev->id(), $group_content_update->id());
+    $this->assertEquals($group_content_rev->id(), $group_content_with_bundle->id());
 
     $group_content_rev_group = $membership_manager->getGroups($group_content_rev);
     /** @var \Drupal\node\NodeInterface $group */
     $group = reset($group_content_rev_group['node']);
     $this->assertEquals($this->groups['node'][0]->id(), $group->id());
-    $group_content_update_group = $membership_manager->getGroups($group_content_update);
-    $group = reset($group_content_update_group['node']);
+    $group_content_with_bundle_group = $membership_manager->getGroups($group_content_with_bundle);
+    $group = reset($group_content_with_bundle_group['node']);
     $this->assertEquals($this->groups['node'][1]->id(), $group->id());
   }
 


### PR DESCRIPTION
In [Issue #2856808: Break out the 'entity_test_update' entity type into its own module and add additional test db dumps](https://www.drupal.org/node/2856808) the `entity_test_update` entity type was moved into a separate module, causing test failures in our 8.3.x tests.

Let's use a different test entity type in our test suite, one that is still compatible with all tested versions.

This makes me think that we shouldn't even be testing on 8.1.x and 8.2.x any more since they are deprecated. Not even core is testing those versions anymore. Instead we should be testing the current and the next version (now, 8.3.x and 8.4.x). But that is out of scope for this issue.