### PR TITLE
Test current versions of Drupal and PHP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ matrix:
   exclude:
     - php: 5.6
       env: TEST_SUITE=PHP_CodeSniffer
+    - php: 7.0
+      env: TEST_SUITE=PHP_CodeSniffer
 
 mysql:
   database: og

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,9 @@ before_script:
 
   # Download Drupal console so we can run the test for it. Skip this for the
   # coding standards test.
-  - test ${TEST_SUITE} == "PHP_CodeSniffer" || composer require --dev drupal/console:~1.0@rc --working-dir=$DRUPAL_DIR
+  # Drupal console doesn't support Drupal 8.4.x so only require it on 8.3.x.
+  # See https://github.com/hechoendrupal/drupal-console-core/issues/151
+  - test ${TEST_SUITE} == "PHP_CodeSniffer" || test ${TEST_SUITE} == "8.3.x" && composer require --dev drupal/console:~1.0@rc --working-dir=$DRUPAL_DIR || true
 
   # Install Composer dependencies for core. Skip this for the coding standards test.
   - test ${TEST_SUITE} == "PHP_CodeSniffer" || composer install --working-dir=$DRUPAL_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ sudo: false
 php:
   - 5.6
   - 7.0
+  - 7.1
 
 env:
-  - TEST_SUITE=8.1.x
-  - TEST_SUITE=8.2.x
   - TEST_SUITE=8.3.x
+  - TEST_SUITE=8.4.x
   - TEST_SUITE=PHP_CodeSniffer
 
 # Only run the coding standards check once.

--- a/scripts/travis-ci/run-test.sh
+++ b/scripts/travis-ci/run-test.sh
@@ -10,9 +10,16 @@ case "$1" in
         ./vendor/bin/phpcs
         exit $?
         ;;
-    *)
+    # Drupal console only works on Drupal 8.3.x.
+    8.3.x)
         ln -s $MODULE_DIR $DRUPAL_DIR/modules/og
         cd $DRUPAL_DIR
         ./vendor/bin/phpunit -c ./core/phpunit.xml.dist $MODULE_DIR/tests
+        exit $?
+        ;;
+    *)
+        ln -s $MODULE_DIR $DRUPAL_DIR/modules/og
+        cd $DRUPAL_DIR
+        ./vendor/bin/phpunit -c ./core/phpunit.xml.dist --exclude-group=console $MODULE_DIR/tests
         exit $?
 esac

--- a/tests/src/Kernel/Console/DrupalConsoleAddFieldTest.php
+++ b/tests/src/Kernel/Console/DrupalConsoleAddFieldTest.php
@@ -11,6 +11,7 @@ use Symfony\Component\Console\Helper\HelperSet;
  * Tests CLI integration for fields creation.
  *
  * @group og
+ * @group console
  * @coversDefaultClass \Drupal\og\Og
  */
 class DrupalConsoleAddFieldTest extends KernelTestBase {


### PR DESCRIPTION
There is little point in testing obsolete versions of Drupal 8, since not even core is doing this. Once OG is released and our users decide to stick with an older version of D8 for some business reason, they should pin their contrib modules in `composer.json` at the same time as they pin the core version to maintain compatibility.

I think it would be a good idea to always test the current version as well as the upcoming version (currently 8.3.x and 8.4.x).

There is also a new stable PHP release, let's test this too.