### PR TITLE
Provide a method to check if an OgRole is a default role

### DIFF
--- a/src/Entity/OgRole.php
+++ b/src/Entity/OgRole.php
@@ -242,13 +242,20 @@ class OgRole extends Role implements OgRoleInterface {
     // The default roles are required. Prevent them from being deleted for as
     // long as the group still exists, unless the group itself is in the process
     // of being removed.
-    if (!$this->parentEntityIsBeingRemoved && in_array($this->getName(), [self::ANONYMOUS, self::AUTHENTICATED]) && $this->groupTypeManager()->isGroup($this->getGroupType(), $this->getGroupBundle())) {
+    if (!$this->parentEntityIsBeingRemoved && $this->isDefaultRole() && $this->groupTypeManager()->isGroup($this->getGroupType(), $this->getGroupBundle())) {
       throw new OgRoleException('The default roles "non-member" and "member" cannot be deleted.');
     }
 
     // Reset access cache, as the role is no longer present.
     $this->ogAccess()->reset();
     parent::delete();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isDefaultRole() {
+    return in_array($this->getName(), [self::ANONYMOUS, self::AUTHENTICATED]);
   }
 
   /**

--- a/src/Entity/OgRole.php
+++ b/src/Entity/OgRole.php
@@ -242,7 +242,7 @@ class OgRole extends Role implements OgRoleInterface {
     // The default roles are required. Prevent them from being deleted for as
     // long as the group still exists, unless the group itself is in the process
     // of being removed.
-    if (!$this->parentEntityIsBeingRemoved && $this->isDefaultRole() && $this->groupTypeManager()->isGroup($this->getGroupType(), $this->getGroupBundle())) {
+    if (!$this->parentEntityIsBeingRemoved && $this->isRequired() && $this->groupTypeManager()->isGroup($this->getGroupType(), $this->getGroupBundle())) {
       throw new OgRoleException('The default roles "non-member" and "member" cannot be deleted.');
     }
 
@@ -254,8 +254,8 @@ class OgRole extends Role implements OgRoleInterface {
   /**
    * {@inheritdoc}
    */
-  public function isDefaultRole() {
-    return in_array($this->getName(), [self::ANONYMOUS, self::AUTHENTICATED]);
+  public function isRequired() {
+    return static::getRoleTypeByName($this->getName()) === OgRoleInterface::ROLE_TYPE_REQUIRED;
   }
 
   /**

--- a/src/OgRoleInterface.php
+++ b/src/OgRoleInterface.php
@@ -178,6 +178,6 @@ interface OgRoleInterface {
    * @return bool
    *   True if this is a default role. False otherwise.
    */
-  public function isDefaultRole();
+  public function isRequired();
 
 }

--- a/src/OgRoleInterface.php
+++ b/src/OgRoleInterface.php
@@ -172,4 +172,12 @@ interface OgRoleInterface {
    */
   public static function getRole($entity_type_id, $bundle, $role_name);
 
+  /**
+   * Returns if this is a default role which is required and cannot be deleted.
+   *
+   * @return bool
+   *   True if this is a default role. False otherwise.
+   */
+  public function isDefaultRole();
+
 }

--- a/tests/src/Kernel/Entity/OgRoleTest.php
+++ b/tests/src/Kernel/Entity/OgRoleTest.php
@@ -106,6 +106,9 @@ class OgRoleTest extends KernelTestBase {
     // Checking creation of the role.
     $this->assertEquals($og_role->getPermissions(), ['administer group']);
 
+    // Check if the role is correctly recognized as a non-default role.
+    $this->assertFalse($og_role->isDefaultRole());
+
     // Try to create the same role again.
     try {
       $og_role = OgRole::create();
@@ -214,6 +217,9 @@ class OgRoleTest extends KernelTestBase {
         $this->assertEquals($group_type, $default_role->getGroupType());
         $this->assertEquals('group', $default_role->getGroupBundle());
         $this->assertEquals($role_name, $default_role->getName());
+
+        // Check that the role is recognized as a default role.
+        $this->assertTrue($default_role->isDefaultRole());
 
         // Keep track of the role so we can later test if they can be deleted.
         $default_roles[] = $default_role;

--- a/tests/src/Kernel/Entity/OgRoleTest.php
+++ b/tests/src/Kernel/Entity/OgRoleTest.php
@@ -107,7 +107,7 @@ class OgRoleTest extends KernelTestBase {
     $this->assertEquals($og_role->getPermissions(), ['administer group']);
 
     // Check if the role is correctly recognized as a non-default role.
-    $this->assertFalse($og_role->isDefaultRole());
+    $this->assertFalse($og_role->isRequired());
 
     // Try to create the same role again.
     try {
@@ -200,37 +200,39 @@ class OgRoleTest extends KernelTestBase {
   }
 
   /**
-   * Tests the creation and deletion of default roles.
+   * Tests the creation and deletion of required roles.
    */
-  public function testDefaultRoles() {
-    // Check that the default roles are created when a new group type is
+  public function testRequiredRoles() {
+    // Check that the required roles are created when a new group type is
     // declared.
     foreach (['node', 'entity_test_with_bundle'] as $entity_type_id) {
       $this->groupTypeManager->addGroup($entity_type_id, 'group');
     }
 
-    $default_roles = [];
+    $required_roles = [];
     foreach ([OgRole::ANONYMOUS, OgRole::AUTHENTICATED] as $role_name) {
       foreach (['node', 'entity_test_with_bundle'] as $group_type) {
         $role_id = "$group_type-group-$role_name";
-        $default_role = OgRole::load($role_id);
-        $this->assertEquals($group_type, $default_role->getGroupType());
-        $this->assertEquals('group', $default_role->getGroupBundle());
-        $this->assertEquals($role_name, $default_role->getName());
+        $required_role = OgRole::load($role_id);
 
-        // Check that the role is recognized as a default role.
-        $this->assertTrue($default_role->isDefaultRole());
+        // Check that the role is actually a required role.
+        $this->assertTrue($required_role->isRequired());
+
+        // Check that the other data is correct.
+        $this->assertEquals($group_type, $required_role->getGroupType());
+        $this->assertEquals('group', $required_role->getGroupBundle());
+        $this->assertEquals($role_name, $required_role->getName());
 
         // Keep track of the role so we can later test if they can be deleted.
-        $default_roles[] = $default_role;
+        $required_roles[] = $required_role;
       }
     }
 
-    // Default roles cannot be deleted, so an exception should be thrown when
-    // trying to delete a default role for a group type that still exists.
-    foreach ($default_roles as $default_role) {
+    // Required roles cannot be deleted, so an exception should be thrown when
+    // trying to delete them when the group type still exists.
+    foreach ($required_roles as $required_role) {
       try {
-        $default_role->delete();
+        $required_role->delete();
         $this->fail('A default role cannot be deleted.');
       }
       catch (OgRoleException $e) {
@@ -241,10 +243,10 @@ class OgRoleTest extends KernelTestBase {
     foreach ($this->groupTypes as $group_type) {
       $group_type->delete();
     }
-    // The default roles are dependent on the group types so this action should
-    // result in the deletion of the default roles.
-    foreach ($default_roles as $default_role) {
-      $this->assertEmpty($this->loadUnchangedOgRole($default_role->id()));
+    // The required roles are dependent on the group types so this action should
+    // result in the deletion of the roles.
+    foreach ($required_roles as $required_role) {
+      $this->assertEmpty($this->loadUnchangedOgRole($required_role->id()));
     }
   }
 


### PR DESCRIPTION
Default OgRole entities (`anonymous` and `member`) are different from the standard roles. For example it is not possible to delete them.

Because of these differences we should provide a method so that it can be checked whether a role is a default role.