### PR TITLE
Provide a helper method to load roles by group type

### DIFF
--- a/src/Entity/OgRole.php
+++ b/src/Entity/OgRole.php
@@ -162,6 +162,17 @@ class OgRole extends Role implements OgRoleInterface {
   /**
    * {@inheritdoc}
    */
+  public static function loadRolesByGroupType($group_entity_type_id, $group_bundle_id) {
+    $properties = [
+      'group_type' => $group_entity_type_id,
+      'group_bundle' => $group_bundle_id,
+    ];
+    return \Drupal::entityTypeManager()->getStorage('og_role')->loadByProperties($properties);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function save() {
     // The ID of a new OgRole has to consist of the entity type ID, bundle ID
     // and role name, separated by dashes.

--- a/src/Entity/OgRole.php
+++ b/src/Entity/OgRole.php
@@ -170,7 +170,7 @@ class OgRole extends Role implements OgRoleInterface {
   /**
    * {@inheritdoc}
    */
-  public static function loadRolesByGroupType($group_entity_type_id, $group_bundle_id) {
+  public static function loadByGroupType($group_entity_type_id, $group_bundle_id) {
     $properties = [
       'group_type' => $group_entity_type_id,
       'group_bundle' => $group_bundle_id,

--- a/src/OgRoleInterface.php
+++ b/src/OgRoleInterface.php
@@ -168,7 +168,7 @@ interface OgRoleInterface {
    * @return \Drupal\og\OgRoleInterface[]
    *   The roles.
    */
-  public static function loadRolesByGroupType($group_entity_type_id, $group_bundle_id_id);
+  public static function loadByGroupType($group_entity_type_id, $group_bundle_id_id);
 
   /**
    * Get a role by the group's bundle and role name.

--- a/src/OgRoleInterface.php
+++ b/src/OgRoleInterface.php
@@ -158,6 +158,19 @@ interface OgRoleInterface {
   public static function loadByGroupAndName(EntityInterface $group, $name);
 
   /**
+   * Returns the roles that are associated with the given group type and bundle.
+   *
+   * @param string $group_entity_type_id
+   *   The group entity type ID.
+   * @param string $group_bundle_id_id
+   *   The group bundle ID.
+   *
+   * @return \Drupal\og\OgRoleInterface[]
+   *   The roles.
+   */
+  public static function loadRolesByGroupType($group_entity_type_id, $group_bundle_id_id);
+
+  /**
    * Get a role by the group's bundle and role name.
    *
    * @param string $entity_type_id


### PR DESCRIPTION
This has been split off from #244.

Let's provide a simple helper method that allows to load all OgRole entities that belong to a given group type.