### PR TITLE
`GroupMembershipManagerTest::testStaticCache()` doesn't have the right `@covers` annotation

### DIFF
--- a/tests/src/Kernel/Entity/GroupMembershipManagerTest.php
+++ b/tests/src/Kernel/Entity/GroupMembershipManagerTest.php
@@ -179,7 +179,7 @@ class GroupMembershipManagerTest extends KernelTestBase {
    * Verify that entities from different entity types with colliding Ids that
    * point to different groups do not confuse the membership manager.
    *
-   * @covers ::getGroupIds
+   * @covers ::getGroups
    */
   public function testStaticCache() {
     /** @var \Drupal\og\MembershipManagerInterface $membership_manager */


### PR DESCRIPTION
Very small fix, while reading through the `GroupMembershipManagerTest` I noticed that `::testStaticCache()` has an annotation declaring that it is testing the `::getGroupIds()` method, but actually it is calling `::getGroups()` in the test.