### PR TITLE
Schema for OG audience handler settings is wrong

### DIFF
--- a/config/schema/og.schema.yml
+++ b/config/schema/og.schema.yml
@@ -42,10 +42,10 @@ field.field_settings.og_standard_reference:
       type: boolean
       label: 'Access Override'
 
-#entity_reference_selection.og:default:
-#  type: entity_reference_selection.default
-#  label: 'The OG selection handler settings'
-#
+entity_reference_selection.og:default:
+  type: entity_reference_selection.default
+  label: 'The OG selection handler settings'
+
 og.settings:
   type: config_object
   label: 'Organic Groups settings'

--- a/config/schema/og.schema.yml
+++ b/config/schema/og.schema.yml
@@ -42,6 +42,10 @@ field.field_settings.og_standard_reference:
       type: boolean
       label: 'Access Override'
 
+#entity_reference_selection.og:default:
+#  type: entity_reference_selection.default
+#  label: 'The OG selection handler settings'
+#
 og.settings:
   type: config_object
   label: 'Organic Groups settings'

--- a/tests/src/Kernel/SelectionHandlerSettingsSchemaTest.php
+++ b/tests/src/Kernel/SelectionHandlerSettingsSchemaTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Drupal\Tests\og\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\node\Entity\NodeType;
+
+/**
+ * Tests the config schema for OG selection handler settings.
+ *
+ * @group og
+ */
+class SelectionHandlerSettingsSchemaTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'field',
+    'node',
+    'og',
+    'og_ui',
+    'system',
+    'user',
+  ];
+
+  /**
+   * Tests the config schema for OG selection handler settings.
+   */
+  public function testSelectionHandlerSettingsSchema() {
+    $node_type = NodeType::create([
+      'type' => $bundle = strtolower($this->randomMachineName()),
+      'name' => $this->randomString(),
+    ]);
+    // We are using the 'og_ui' mechanism for adding the audience field.
+    // @see og_ui_entity_type_save().
+    $node_type->og_group_content_bundle = TRUE;
+    $node_type->og_is_group = FALSE;
+    $node_type->og_target_type = 'node';
+    $node_type->og_target_bundles = [$bundle];
+    $node_type->save();
+  }
+
+}


### PR DESCRIPTION
I'm getting this error while running a kernel test:

```
Drupal\Core\Config\Schema\SchemaIncompleteException: Schema errors
for field.field.node.article.og_audience with the following errors:
field.field.node.article.og_audience:settings.handler_settings.target_bundles
missing schema
```

and, yes, the schema is missing for that part because, right now, the schema is:
```yaml
    handler_settings:
      type: entity_reference_selection.[%parent.handler]
```
which resolves to `entity_reference_selection.og:default`. This value is not falling back to the generic `entity_reference_selection.default:*` but to `entity_reference_selection.*`. And the last one doesn't define any schema for `handler_settings`.

Solution: Add a schema for `entity_reference_selection.og:default` that simply extends `entity_reference_selection.default`.
