### PR TITLE
On audience change, cache is not properly invalidated

### DIFF
--- a/og.module
+++ b/og.module
@@ -340,7 +340,7 @@ function og_invalidate_group_content_cache_tags(EntityInterface $entity) {
         }
       }
       if ($audience_has_changed) {
-        // If at least group has changed, we clear tha static cache of the
+        // If at least a group has changed, we clear tha static cache of the
         // membership manager which stores such relations. This is important
         // when the membership manager was used previously in the same request.
         $membership_manager->reset();

--- a/og.module
+++ b/og.module
@@ -312,13 +312,48 @@ function og_invalidate_group_content_cache_tags(EntityInterface $entity) {
   // group listings to be cached effectively. Also invalidate the tags if the
   // group itself changes. The cache tag format is
   // 'og-group-content:{group entity type}:{group entity id}'.
-  if (Og::isGroup($entity->getEntityTypeId(), $entity->bundle()) || Og::isGroupContent($entity->getEntityTypeId(), $entity->bundle())) {
+  $is_group_content = Og::isGroupContent($entity->getEntityTypeId(), $entity->bundle());
+  $group_is_updated = Og::isGroup($entity->getEntityTypeId(), $entity->bundle()) && $entity->original;
+  if ($group_is_updated || $is_group_content) {
+    /** @var \Drupal\og\MembershipManagerInterface $membership_manager */
+    $membership_manager = \Drupal::service('og.membership_manager');
     $tags = [];
-    foreach (\Drupal::service('og.membership_manager')->getGroupIds($entity) as $entity_type => $ids) {
-      foreach ($ids as $id) {
-        $tags[] = "$entity_type:$id";
+
+    // If the entity is a group content and we came here as an effect of an
+    // update, check if any of the OG audience fields has been changed (AKA 'the
+    // group of the entity has changed') and add also the tags of the old group.
+    /** @var \Drupal\Core\Entity\FieldableEntityInterface $entity */
+    if ($is_group_content && $original = $entity->original) {
+      /** @var \Drupal\og\OgGroupAudienceHelperInterface $group_audience_helper */
+      $group_audience_helper = \Drupal::service('og.group_audience_helper');
+      $audience_has_changed = FALSE;
+      /** @var \Drupal\Core\Entity\FieldableEntityInterface $original */
+      foreach ($group_audience_helper->getAllGroupAudienceFields($entity->getEntityTypeId(), $entity->bundle()) as $field) {
+        $field_name = $field->getName();
+        /** @var \Drupal\Core\Field\EntityReferenceFieldItemListInterface $original_field_item_list */
+        $original_field_item_list = $original->get($field_name);
+        if (!$entity->get($field_name)->equals($original_field_item_list)) {
+          foreach ($original_field_item_list->referencedEntities() as $old_group) {
+            $tags = Cache::mergeTags($tags, $old_group->getCacheTagsToInvalidate());
+          }
+          $audience_has_changed = TRUE;
+        }
+      }
+      if ($audience_has_changed) {
+        // If at least group has changed, we clear tha static cache of the
+        // membership manager which stores such relations. This is important
+        // when the membership manager was used previously in the same request.
+        $membership_manager->reset();
       }
     }
+
+    foreach ($membership_manager->getGroups($entity) as $group_entity_type_id => $groups) {
+      /** @var \Drupal\Core\Entity\ContentEntityInterface $group */
+      foreach ($groups as $group) {
+        $tags = Cache::mergeTags($tags, $group->getCacheTagsToInvalidate());
+      }
+    }
+
     Cache::invalidateTags(Cache::buildTags('og-group-content', $tags));
   }
 }

--- a/og.module
+++ b/og.module
@@ -320,8 +320,9 @@ function og_invalidate_group_content_cache_tags(EntityInterface $entity) {
     $tags = [];
 
     // If the entity is a group content and we came here as an effect of an
-    // update, check if any of the OG audience fields has been changed (AKA 'the
-    // group of the entity has changed') and add also the tags of the old group.
+    // update, check if any of the OG audience fields have been changed. This
+    // means the group(s) of the entity changed and we should also invalidate
+    // the tags of the old group(s).
     /** @var \Drupal\Core\Entity\FieldableEntityInterface $entity */
     $original = !empty($entity->original) ? $entity->original : NULL;
     if ($is_group_content && $original) {
@@ -341,7 +342,7 @@ function og_invalidate_group_content_cache_tags(EntityInterface $entity) {
         }
       }
       if ($audience_has_changed) {
-        // If at least a group has changed, we clear tha static cache of the
+        // If at least a group has changed, we clear the static cache of the
         // membership manager which stores such relations. This is important
         // when the membership manager was used previously in the same request.
         $membership_manager->reset();

--- a/og.module
+++ b/og.module
@@ -313,7 +313,7 @@ function og_invalidate_group_content_cache_tags(EntityInterface $entity) {
   // group itself changes. The cache tag format is
   // 'og-group-content:{group entity type}:{group entity id}'.
   $is_group_content = Og::isGroupContent($entity->getEntityTypeId(), $entity->bundle());
-  $group_is_updated = Og::isGroup($entity->getEntityTypeId(), $entity->bundle()) && $entity->original;
+  $group_is_updated = Og::isGroup($entity->getEntityTypeId(), $entity->bundle()) && !empty($entity->original);
   if ($group_is_updated || $is_group_content) {
     /** @var \Drupal\og\MembershipManagerInterface $membership_manager */
     $membership_manager = \Drupal::service('og.membership_manager');
@@ -323,7 +323,8 @@ function og_invalidate_group_content_cache_tags(EntityInterface $entity) {
     // update, check if any of the OG audience fields has been changed (AKA 'the
     // group of the entity has changed') and add also the tags of the old group.
     /** @var \Drupal\Core\Entity\FieldableEntityInterface $entity */
-    if ($is_group_content && $original = $entity->original) {
+    $original = !empty($entity->original) ? $entity->original : NULL;
+    if ($is_group_content && $original) {
       /** @var \Drupal\og\OgGroupAudienceHelperInterface $group_audience_helper */
       $group_audience_helper = \Drupal::service('og.group_audience_helper');
       $audience_has_changed = FALSE;

--- a/src/Plugin/Block/RecentGroupContentBlock.php
+++ b/src/Plugin/Block/RecentGroupContentBlock.php
@@ -206,8 +206,7 @@ class RecentGroupContentBlock extends BlockBase implements ContainerFactoryPlugi
   public function getCacheTags() {
     $tags = parent::getCacheTags();
     if ($group = $this->ogContext->getGroup()) {
-      $tag = $group->getEntityTypeId() . ':' . $group->id();
-      $tags = Cache::mergeTags(Cache::buildTags('og-group-content', [$tag]), $tags);
+      $tags = Cache::mergeTags(Cache::buildTags('og-group-content', $group->getCacheTagsToInvalidate()), $tags);
     }
     return $tags;
   }

--- a/src/Plugin/views/argument_default/Group.php
+++ b/src/Plugin/views/argument_default/Group.php
@@ -106,8 +106,7 @@ class Group extends ArgumentDefaultPluginBase implements CacheableDependencyInte
   public function getCacheTags() {
     $group = $this->getGroup();
     if ($group instanceof ContentEntityInterface) {
-      $tag = $group->getEntityTypeId() . ':' . $group->id();
-      return Cache::buildTags('og-group-content', [$tag]);
+      return Cache::buildTags('og-group-content', $group->getCacheTagsToInvalidate());
     }
     return [];
   }

--- a/tests/src/Kernel/Entity/CacheInvalidationOnGroupChangeTest.php
+++ b/tests/src/Kernel/Entity/CacheInvalidationOnGroupChangeTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Drupal\Tests\og\Kernel\Entity;
+
+use Drupal\Core\Cache\Cache;
+use Drupal\entity_test\Entity\EntityTest;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\og\Og;
+use Drupal\og\OgGroupAudienceHelperInterface;
+
+/**
+ * Tests if the cache is correctly invalidated on group change.
+ *
+ * @group og
+ */
+class CacheInvalidationOnGroupChangeTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'entity_test',
+    'field',
+    'og',
+    'system',
+    'user',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->installEntitySchema('entity_test');
+    $this->installEntitySchema('user');
+
+    // Add a OG group audience.
+    Og::groupTypeManager()->addGroup('entity_test', 'group');
+    $settings =       [
+      'field_storage_config' => [
+        'field_name' => OgGroupAudienceHelperInterface::DEFAULT_FIELD,
+        'settings' => [
+          'target_type' => 'entity_test',
+        ],
+      ],
+      'field_config' => [
+        'label' => $this->randomString(),
+        'settings' => [
+          'handler_settings' => [
+            'target_bundles' => ['group' => 'group'],
+          ],
+        ],
+      ],
+    ];
+    Og::createField(OgGroupAudienceHelperInterface::DEFAULT_FIELD, 'entity_test', 'group_content', $settings);
+  }
+
+  /**
+   * Tests if the cache is correctly invalidated on group change.
+   */
+  public function testCacheInvalidationOnGroupChange() {
+    // Create two groups.
+    $group1 = EntityTest::create([
+      'type' => 'group',
+      'name' => $this->randomString(),
+    ]);
+    $group1->save();
+    $group2 = EntityTest::create([
+      'type' => 'group',
+      'name' => $this->randomString(),
+    ]);
+    $group2->save();
+
+    // Create a group content.
+    $group_content = EntityTest::create([
+      'type' => 'group_content',
+      'name' => $this->randomString(),
+      OgGroupAudienceHelperInterface::DEFAULT_FIELD => $group1->id(),
+    ]);
+    $group_content->save();
+
+    // Cache some arbitrary data tagged with the OG group content tag.
+    $bin = \Drupal::cache();
+    $cid = strtolower($this->randomMachineName());
+    $tags = Cache::buildTags('og-group-content', $group1->getCacheTagsToInvalidate());
+    $bin->set($cid, $this->randomString(), Cache::PERMANENT, $tags);
+
+    // Change the group content entity group. We're clearing first the static
+    // cache of membership manager because in a real application, usually, the
+    // static cache is warmed in a previous request, so that in the request
+    // where the audience is changed, is already empty.
+    $this->container->get('og.membership_manager')->reset();
+    $group_content
+      ->set(OgGroupAudienceHelperInterface::DEFAULT_FIELD, $group2->id())
+      ->save();
+
+    // Cache entries tagged with 'og-group-content:entity_type:{$group->id()}'
+    // should have been invalidated at this point because the content members of
+    // $group1 have changed.
+    $this->assertFalse($bin->get($cid));
+  }
+
+}

--- a/tests/src/Kernel/Entity/CacheInvalidationOnGroupChangeTest.php
+++ b/tests/src/Kernel/Entity/CacheInvalidationOnGroupChangeTest.php
@@ -37,7 +37,7 @@ class CacheInvalidationOnGroupChangeTest extends KernelTestBase {
 
     // Add a OG group audience.
     Og::groupTypeManager()->addGroup('entity_test', 'group');
-    $settings =       [
+    $settings = [
       'field_storage_config' => [
         'field_name' => OgGroupAudienceHelperInterface::DEFAULT_FIELD,
         'settings' => [


### PR DESCRIPTION
If the entity audience is changing the old group content OG tag is not invalidated. For example, if the old group is a node with nid 123 and the new group is nid 789 then the tag `og-group-content:node:123` is not invalidated. The test reveals the bug.

Additionally, the cache tags `og-group-content:{group entity type}:{group entity id}` are not correctly built because the code is making the assumption that a custom entity is using the core `\Drupal\Core\Entity\Entity::getCacheTagsToInvalidate()` method. But a custom entity may want to extend this method. For example in our project we hash the entity ID because the ID is a very long string that might break the `{cachetags}` table.