### PR TITLE
Infinite loop with og_context()

### DIFF
--- a/og_context/og_context.module
+++ b/og_context/og_context.module
@@ -217,77 +217,97 @@ function og_context_is_init($called = FALSE) {
  *   was found.
  */
 function og_context($group_type = 'node', $group = NULL, $account = NULL, $check_access = TRUE) {
-  global $user;
-  // User account is sent.
-  $account = $account ? $account : user_load($user->uid);
+  static $in_og_context = FALSE;
 
-  $id = FALSE;
-  if ($group) {
-    list($id) = entity_extract_ids($group_type, $group);
+  // Prevent infinite loops if we are already in the middle of calling
+  // Only allow it to continue if *setting* the context
+  if ($in_og_context && is_null($group)) {
+    return FALSE;
   }
 
-  $cache_keys = array(
-    $group_type,
-    $id,
-    $account->uid,
-    $check_access,
-  );
-  $cache_key = implode(':', $cache_keys);
+  // Set $in_og_context to TRUE to define that function is being executed.
+  $in_og_context = TRUE;
+  $result = FALSE;
 
-  $context = &drupal_static(__FUNCTION__, array());
+  try {
 
-  if (!array_key_exists($cache_key, $context)) {
-    // Mark that this context hasn't been checked yet.
-    $context[$cache_key] = FALSE;
+    global $user;
+    // User account is sent.
+    $account = $account ? $account : user_load($user->uid);
+
+    $id = FALSE;
+    if ($group) {
+      list($id) = entity_extract_ids($group_type, $group);
+    }
+
+    $cache_keys = array(
+      $group_type,
+      $id,
+      $account->uid,
+      $check_access,
+    );
+    $cache_key = implode(':', $cache_keys);
+
+    $context = &drupal_static(__FUNCTION__, array());
+
+    if (!array_key_exists($cache_key, $context)) {
+      // Mark that this context hasn't been checked yet.
+      $context[$cache_key] = FALSE;
+    }
+
+    if (empty($group) && $context[$cache_key] !== FALSE) {
+      // Set og_context_is_init to TRUE to define that function was already executed.
+      og_context_is_init(TRUE);
+      // Determine if we can return cached values.
+      if (empty($context[$cache_key])) {
+        // We already tried to find a context, but couldn't.
+        $result = FALSE;
+      }
+      elseif ($context[$cache_key]['group_type'] == $group_type) {
+        // Return the cached values.
+        $result = $context[$cache_key];
+      }
+    }
+
+    // Set the context to array, so we can know this function has been already
+    // executed.
+    $context[$cache_key] = array();
+
+    if (!empty($group)) {
+      // Set og_context_is_init to TRUE to define that function was already executed.
+      og_context_is_init(TRUE);
+      if (!og_is_group($group_type, $group)) {
+        // The passed entity isn't a valid group.
+        $result = FALSE;
+      }
+      elseif ($check_access && !entity_access('view', $group_type, $group, $account)) {
+        // User doesn't have access to the group.
+        $result = FALSE;
+      }
+      else {
+        list($id) = entity_extract_ids($group_type, $group);
+        $result = array('group_type' => $group_type, 'gid' => $id);
+      }
+    }
+    // Get context from context handlers.
+    elseif ($gid = og_context_determine_context($group_type, NULL, $check_access)) {
+      // Set og_context_is_init to TRUE to define that function was already executed.
+      og_context_is_init(TRUE);
+      $result = array('group_type' => $group_type, 'gid' => $gid);
+      if ($user->uid) {
+        // Save the group ID in the authenticated user's session.
+        $_SESSION['og_context'] = array('group_type' => $group_type, 'gid' => $gid);
+      }
+    }
   }
 
-  if (empty($group) && $context[$cache_key] !== FALSE) {
-    // Set og_context_is_init to TRUE to define that function was already executed.
-    og_context_is_init(TRUE);
-    // Determine if we can return cached values.
-    if (empty($context[$cache_key])) {
-      // We already tried to find a context, but couldn't.
-      return FALSE;
-    }
-
-    if ($context[$cache_key]['group_type'] == $group_type) {
-      // Return the cached values.
-      return $context[$cache_key];
-    }
+  catch (Exception $e) {
   }
 
-  // Set the context to array, so we can know this function has been already
-  // executed.
-  $context[$cache_key] = array();
-
-  if (!empty($group)) {
-    // Set og_context_is_init to TRUE to define that function was already executed.
-    og_context_is_init(TRUE);
-    if (!og_is_group($group_type, $group)) {
-      // The passed entity isn't a valid group.
-      return FALSE;
-    }
-
-    if ($check_access && !entity_access('view', $group_type, $group, $account)) {
-      // User doesn't have access to the group.
-      return FALSE;
-    }
-
-    list($id) = entity_extract_ids($group_type, $group);
-    $context[$cache_key] = array('group_type' => $group_type, 'gid' => $id);
-  }
-  // Get context from context handlers.
-  elseif ($gid = og_context_determine_context($group_type, NULL, $check_access)) {
-    // Set og_context_is_init to TRUE to define that function was already executed.
-    og_context_is_init(TRUE);
-    $context[$cache_key] = array('group_type' => $group_type, 'gid' => $gid);
-    if ($user->uid) {
-      // Save the group ID in the authenticated user's session.
-      $_SESSION['og_context'] = array('group_type' => $group_type, 'gid' => $gid);
-    }
-  }
-
-  return $context[$cache_key];
+  // Ensure $in_context is unset to FALSE since we are done.
+  $in_og_context = FALSE;
+  $context[$cache_key] = $result;
+  return $result;
 }
 
 /**

--- a/og_context/og_context.module
+++ b/og_context/og_context.module
@@ -227,13 +227,11 @@ function og_context($group_type = 'node', $group = NULL, $account = NULL, $check
 
   // Set $in_og_context to TRUE to define that function is being executed.
   $in_og_context = TRUE;
-  $result = FALSE;
+  $result = NULL;
 
   try {
-
     global $user;
-    // User account is sent.
-    $account = $account ? $account : user_load($user->uid);
+    $uid = $account ? $account->uid : $user->uid;
 
     $id = FALSE;
     if ($group) {
@@ -243,7 +241,7 @@ function og_context($group_type = 'node', $group = NULL, $account = NULL, $check
     $cache_keys = array(
       $group_type,
       $id,
-      $account->uid,
+      $uid,
       $check_access,
     );
     $cache_key = implode(':', $cache_keys);
@@ -269,44 +267,47 @@ function og_context($group_type = 'node', $group = NULL, $account = NULL, $check
       }
     }
 
-    // Set the context to array, so we can know this function has been already
-    // executed.
-    $context[$cache_key] = array();
+    // If no cached result was found, try to find a context.
+    if ($result === NULL) {
+      // Set the context to array, so we can know this function has been already
+      // executed.
+      $context[$cache_key] = array();
 
-    if (!empty($group)) {
-      // Set og_context_is_init to TRUE to define that function was already executed.
-      og_context_is_init(TRUE);
-      if (!og_is_group($group_type, $group)) {
-        // The passed entity isn't a valid group.
-        $result = FALSE;
+      if (!empty($group)) {
+        // Set og_context_is_init to TRUE to define that function was already executed.
+        og_context_is_init(TRUE);
+        if (!og_is_group($group_type, $group)) {
+          // The passed entity isn't a valid group.
+          $result = FALSE;
+        }
+        elseif ($check_access && !entity_access('view', $group_type, $group, $account)) {
+          // User doesn't have access to the group.
+          $result = FALSE;
+        }
+        else {
+          list($id) = entity_extract_ids($group_type, $group);
+          $result = array('group_type' => $group_type, 'gid' => $id);
+        }
       }
-      elseif ($check_access && !entity_access('view', $group_type, $group, $account)) {
-        // User doesn't have access to the group.
-        $result = FALSE;
+      // Get context from context handlers.
+      elseif ($gid = og_context_determine_context($group_type, NULL, $check_access)) {
+        // Set og_context_is_init to TRUE to define that function was already executed.
+        og_context_is_init(TRUE);
+        $result = array('group_type' => $group_type, 'gid' => $gid);
+        if ($user->uid) {
+          // Save the group ID in the authenticated user's session.
+          $_SESSION['og_context'] = array('group_type' => $group_type, 'gid' => $gid);
+        }
       }
-      else {
-        list($id) = entity_extract_ids($group_type, $group);
-        $result = array('group_type' => $group_type, 'gid' => $id);
-      }
-    }
-    // Get context from context handlers.
-    elseif ($gid = og_context_determine_context($group_type, NULL, $check_access)) {
-      // Set og_context_is_init to TRUE to define that function was already executed.
-      og_context_is_init(TRUE);
-      $result = array('group_type' => $group_type, 'gid' => $gid);
-      if ($user->uid) {
-        // Save the group ID in the authenticated user's session.
-        $_SESSION['og_context'] = array('group_type' => $group_type, 'gid' => $gid);
-      }
+
+      $context[$cache_key] = $result;
     }
   }
-
   catch (Exception $e) {
   }
 
   // Ensure $in_context is unset to FALSE since we are done.
   $in_og_context = FALSE;
-  $context[$cache_key] = $result;
   return $result;
 }
 


### PR DESCRIPTION
(copy from https://www.drupal.org/node/2717489)

There have been cases in the past where og_context() can cause an infinite loop depending on what submodules are doing. In the latest OG 2.9 I ran into a very specific case:

1) Enable the RealName module
2) Enable the Variables module and create a hook_variable_info() that needs to set the options of a variable based on og_vocab (so calls og_vocab_get_accessible_vocabs()).

What happens to an anonymous user is:
1) og_context() gets called by some hook_init() function
2) og_context calls user_load at the beginning to get the current user
3) user_load needs to load tokens
4) RealName module adds a token
5) Variables module adds tokens, so calls all hook_variable_info() hooks
6) A site specific module implements hook_variable_info() and calls og_vocab_get_accessible_vocabs() to get og_vocab data
7) og_vocab_get_accessible_vocabs() calls og_context()
--> goto 1, infinite loop.

Now, granted this is a bit obscure. But you can see other instances where this can happen. Doing any sort of user_load or node_load during og_context processing (such as in an og_context plugin) is just asking for complex situations like this.

It looks like the og_context_is_init() might have been intended to prevent infinite loops, but it is not used anywhere I can see.

So here is a simple patch to once-and-for-all prevent og_context() from getting into an infinite loop.