### PR TITLE
Skip creation of action plugins while in sync mode (aka config-import)

### DIFF
--- a/og.module
+++ b/og.module
@@ -8,6 +8,7 @@
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Config\Entity\ConfigEntityBundleBase;
+use Drupal\Core\Config\Entity\ConfigEntityInterface;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
@@ -370,7 +371,7 @@ function og_og_role_insert(OgRoleInterface $role) {
     return;
   }
 
-  if ($role instanceof \Drupal\Core\Config\Entity\ConfigEntityInterface) {
+  if ($role instanceof ConfigEntityInterface) {
     if ($role->isSyncing()) {
       return;
     }

--- a/og.module
+++ b/og.module
@@ -371,6 +371,7 @@ function og_og_role_insert(OgRoleInterface $role) {
     return;
   }
 
+  // Skip creation of action plugins while importing configuration.
   if ($role instanceof ConfigEntityInterface) {
     if ($role->isSyncing()) {
       return;

--- a/og.module
+++ b/og.module
@@ -370,6 +370,12 @@ function og_og_role_insert(OgRoleInterface $role) {
     return;
   }
 
+  if ($role instanceof \Drupal\Core\Config\Entity\ConfigEntityInterface) {
+    if ($role->isSyncing()) {
+      return;
+    }
+  }
+
   $add_id = 'og_membership_add_single_role_action.' . $role->getName();
   if (!Action::load($add_id)) {
     $action = Action::create([


### PR DESCRIPTION
Config import fails if og creates addional config on import.

```
The import failed due to the following reasons:   

  Deleted and replaced configuration entity "system.action.og_membership_add_  
  single_role_action.administrator"                                            
  Deleted and replaced configuration entity "system.action.og_membership_remo  
  ve_single_role_action.administrator"           

```