### PR TITLE
Return AccessResult::neutral() by default

### DIFF
--- a/og.module
+++ b/og.module
@@ -166,7 +166,7 @@ function og_entity_access(EntityInterface $entity, $operation, AccountInterface 
     return AccessResult::forbiddenIf($node_access_strict);
   }
 
-  return AccessResult::forbidden();
+  return AccessResult::neutral();
 }
 
 /**


### PR DESCRIPTION
I am currently in the process of updating from an older version of OG. I think `::forbidden` as default value is too strict. Because it takes precedence over all the return values from other ``hook_entity_access`` implementations.