### PR TITLE
Undefined property stdClass::$original in og_entity_update when updating group

### DIFF
--- a/og.module
+++ b/og.module
@@ -885,10 +885,10 @@ function og_entity_update($entity, $entity_type) {
       }
     }
   }
-  $original_entity = $entity->original;
+  $original_entity = isset($entity->original) ? $entity->original : NULL;
   $property = OG_DEFAULT_ACCESS_FIELD;
 
-  if (!empty($entity->{$property}) && $entity->{$property} != $original_entity->{$property}) {
+  if (!empty($entity->{$property}) && !empty($original_entity->{$property}) && $entity->{$property} != $original_entity->{$property}) {
     if (!og_is_group_default_access($entity_type, $entity)) {
       // Override default roles.
       og_roles_override($entity_type, $bundle, $id);


### PR DESCRIPTION
drupal.org original issue found by SomebodySysop: https://www.drupal.org/project/og/issues/2792031

If for some reason the node update was called twice (or more), the next time any other hook that tries to operate with this "original" property will return a "Notice: Undefined property: stdClass::$original".

It happened in other projects too and they all changed the code to optionally use the "original" property. Anyway it was there the first time when node update executed.

Check: https://www.drupal.org/project/entity/issues/2602346
and https://www.drupal.org/project/password_policy/issues/2688123

In my case I had multilevel field collection items in a node and deletion of a deep nested item requested parent entity (node) to update and of course the node submission with node_save and was executed at the end because this was a node form after all.
Only this line where "og_entity_update" strictly requested "original" property was blocking me keeping this nested structure.
I wouldn't say that is og's fault, but it's how core works now and it can happen that node is updated multiple times in a complex process like this, so "og_entity_update" could easily adjust that with a simple fix.