### PR TITLE
Fix fatal error when retrieving orphaned / non-existing roles from a membership

### DIFF
--- a/src/Entity/OgMembership.php
+++ b/src/Entity/OgMembership.php
@@ -219,10 +219,14 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
    * {@inheritdoc}
    */
   public function getRoles() {
+    $roles = [];
+
     // Add the member role.
-    $roles = [
-      OgRole::getRole($this->getGroupEntityType(), $this->getGroup()->bundle(), OgRoleInterface::AUTHENTICATED),
-    ];
+    if ($group = $this->getGroup()) {
+      $roles = [
+        OgRole::getRole($this->getGroupEntityType(), $group->bundle(), OgRoleInterface::AUTHENTICATED),
+      ];
+    }
     $roles = array_merge($roles, $this->get('roles')->referencedEntities());
     return $roles;
   }

--- a/src/Entity/OgMembership.php
+++ b/src/Entity/OgMembership.php
@@ -221,7 +221,8 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
   public function getRoles() {
     $roles = [];
 
-    // Add the member role.
+    // Add the member role. This is only possible if a group has been set on the
+    // membership.
     if ($group = $this->getGroup()) {
       $roles = [
         OgRole::getRole($this->getGroupEntityType(), $group->bundle(), OgRoleInterface::AUTHENTICATED),

--- a/tests/src/Kernel/Entity/OgMembershipTest.php
+++ b/tests/src/Kernel/Entity/OgMembershipTest.php
@@ -490,6 +490,21 @@ class OgMembershipTest extends KernelTestBase {
   }
 
   /**
+   * Tests that we can retrieve the (empty) roles list from a new membership.
+   *
+   * If a membership is newly created and doesn't have a group associated with
+   * it yet, it should still be possible to get the (empty) list of roles
+   * without getting any errors.
+   *
+   * @covers ::getRoles
+   */
+  public function testGetRolesFromMembershipWithoutGroup() {
+    $membership = OgMembership::create();
+    $roles = $membership->getRoles();
+    $this->assertEquals([], $roles);
+  }
+
+  /**
    * Tests that the membership can return if it belongs to the group owner.
    *
    * @covers ::isOwner


### PR DESCRIPTION
Fixes #356.