### PR TITLE
Don't generate cache keys for users that have lost their membership role

### DIFF
--- a/src/Cache/Context/OgRoleCacheContext.php
+++ b/src/Cache/Context/OgRoleCacheContext.php
@@ -91,7 +91,9 @@ class OgRoleCacheContext extends UserCacheContextBase implements CacheContextInt
         $role_names = array_map(function (OgRoleInterface $role) {
           return $role->getName();
         }, $membership->getRoles());
-        $memberships[$membership->getGroupEntityType()][$membership->getGroupId()] = $role_names;
+        if ($role_names) {
+          $memberships[$membership->getGroupEntityType()][$membership->getGroupId()] = $role_names;
+        }
       }
 
       // Sort the memberships, so that the same key can be generated, even if


### PR DESCRIPTION
Fixes the secondary problem from #356.

When a user has a certain role in a group but then the role is deleted from config, the membership entity still exists but contains an orphaned reference to role that was deleted. In this case no cache context keys should be generated for the user any more.