### PR TITLE
Fixes #152: Replaces NULL returns with emtpy array returns in og_get_groups_by_user()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
   - cd ../..
 
   # Install Drush
-  - composer global require drush/drush
+  - composer global require drush/drush:8
   - export PATH=$PATH:~/.composer/vendor/bin
 
   # Install php packages required for running Drupal

--- a/og.module
+++ b/og.module
@@ -3553,7 +3553,10 @@ function og_node_create_links($group_type, $gid, $field_name, $destination = NUL
  *   types will be fetched.
  *
  * @return
- *   An array with the group IDs or an empty array.
+ *   If $group_type is provided then an array of group IDs matching the
+ *   specified group type. If $group_type is not provided then an associative
+ *   array is returned containing arrays of group IDs keyed by group type. If
+ *   no results are found an empty array is returned.
  */
 function og_get_groups_by_user($account = NULL, $group_type = NULL) {
   if (empty($account)) {
@@ -3581,12 +3584,10 @@ function og_get_groups_by_user($account = NULL, $group_type = NULL) {
     }
   }
 
-  if (empty($group_type)) {
-    return $gids;
+  if (isset($group_type)) {
+    return isset($gids[$group_type]) ? $gids[$group_type] : array();
   }
-  elseif (!empty($gids[$group_type])) {
-    return $gids[$group_type];
-  }
+  return $gids;
 }
 
 /**

--- a/og.module
+++ b/og.module
@@ -3561,18 +3561,18 @@ function og_get_groups_by_user($account = NULL, $group_type = NULL) {
     $account = $user;
   }
 
+  $gids = array();
+
   if (!og_get_group_audience_fields()) {
     // User entity doesn't have group audience fields.
-    return;
+    return $gids;
   }
-
-  $gids = array();
 
   // Get all active OG membership that belong to the user.
   $wrapper = entity_metadata_wrapper('user', $account->uid);
   $og_memberships = $wrapper->{'og_membership__' . OG_STATE_ACTIVE}->value();
   if (!$og_memberships) {
-    return;
+    return $gids;
   }
 
   foreach ($og_memberships as $og_membership) {

--- a/plugins/entityreference/selection/OgSelectionHandler.class.php
+++ b/plugins/entityreference/selection/OgSelectionHandler.class.php
@@ -105,7 +105,6 @@ class OgSelectionHandler extends EntityReference_SelectionHandler_Generic {
 
     $field_mode = $this->instance['field_mode'];
     $user_groups = og_get_groups_by_user(NULL, $group_type);
-    $user_groups = $user_groups ? $user_groups : array();
     $user_groups = array_merge($user_groups, $this->getGidsForCreate());
 
 


### PR DESCRIPTION
This fixes #152 and [Drupal #2569471: og_get_groups_by_user don't respect @return documentation](https://www.drupal.org/project/og/issues/2569471), and it supersedes  #153.

#153 has the problem that when `$group_type` is specified, but no entries for that group type are entered in `$gid`, `NULL` is returned.