### PR TITLE
Provide tests for `OgRole::isAdmin()` and `OgRole::setIsAdmin()`

### DIFF
--- a/tests/src/Kernel/Access/OgEntityAccessTest.php
+++ b/tests/src/Kernel/Access/OgEntityAccessTest.php
@@ -65,6 +65,13 @@ class OgEntityAccessTest extends KernelTestBase {
   protected $adminUser;
 
   /**
+   * A second administrator which has an alternative administration role.
+   *
+   * @var \Drupal\user\Entity\User
+   */
+  protected $alternativeAdminUser;
+
+  /**
    * A group entity.
    *
    * @var \Drupal\entity_test\Entity\EntityTest
@@ -121,6 +128,13 @@ class OgEntityAccessTest extends KernelTestBase {
   protected $ogAdminRole;
 
   /**
+   * A custom OG admin role.
+   *
+   * @var \Drupal\og\Entity\OgRole
+   */
+  protected $ogAlternativeAdminRole;
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp() {
@@ -159,6 +173,10 @@ class OgEntityAccessTest extends KernelTestBase {
     // Admin user.
     $this->adminUser = User::create(['name' => $this->randomString()]);
     $this->adminUser->save();
+
+    // Second admin user which uses an alternative administration role.
+    $this->alternativeAdminUser = User::create(['name' => $this->randomString()]);
+    $this->alternativeAdminUser->save();
 
     // Declare the test entity as being a group.
     Og::groupTypeManager()->addGroup('entity_test', $this->groupBundle);
@@ -218,8 +236,14 @@ class OgEntityAccessTest extends KernelTestBase {
       ->grantPermission($this->randomMachineName())
       ->save();
 
-    $this->ogAdminRole = OgRole::create();
-    $this->ogAdminRole
+    // The administrator role is added automatically when the group is created.
+    // @see \Drupal\og\EventSubscriber\OgEventSubscriber::provideDefaultRoles()
+    $this->ogAdminRole = OgRole::loadByGroupAndName($this->group1, OgRoleInterface::ADMINISTRATOR);
+
+    // Create a second administration role, since this is a supported use case.
+    // It is possible to have multiple administration roles.
+    $this->ogAlternativeAdminRole = OgRole::create();
+    $this->ogAlternativeAdminRole
       ->setName($this->randomMachineName())
       ->setLabel($this->randomString())
       ->setGroupType($this->group1->getEntityTypeId())
@@ -254,6 +278,11 @@ class OgEntityAccessTest extends KernelTestBase {
     $membership = Og::createMembership($this->group1, $this->adminUser);
     $membership
       ->addRole($this->ogAdminRole)
+      ->save();
+
+    $membership = Og::createMembership($this->group1, $this->alternativeAdminUser);
+    $membership
+      ->addRole($this->ogAlternativeAdminRole)
       ->save();
   }
 
@@ -294,6 +323,16 @@ class OgEntityAccessTest extends KernelTestBase {
     // Group admin user should have access regardless.
     $this->assertTrue($og_access->userAccess($this->group1, 'some_perm', $this->adminUser)->isAllowed());
     $this->assertTrue($og_access->userAccess($this->group1, $this->randomMachineName(), $this->adminUser)->isAllowed());
+
+    // Also group admins that have a custom admin role should have access.
+    $this->assertTrue($og_access->userAccess($this->group1, 'some_perm', $this->alternativeAdminUser)->isAllowed());
+    $this->assertTrue($og_access->userAccess($this->group1, $this->randomMachineName(), $this->alternativeAdminUser)->isAllowed());
+
+    // The admin user should no longer have access if the role is demoted from
+    // being an admin role.
+    $this->ogAdminRole->setIsAdmin(FALSE)->save();
+    $this->assertFalse($og_access->userAccess($this->group1, 'some_perm', $this->adminUser)->isAllowed());
+    $this->assertFalse($og_access->userAccess($this->group1, $this->randomMachineName(), $this->adminUser)->isAllowed());
 
     // Add membership to user 3.
     $membership = Og::createMembership($this->group1, $this->user3);

--- a/tests/src/Unit/OgRoleTest.php
+++ b/tests/src/Unit/OgRoleTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\Tests\og\Unit;
+
+use Drupal\og\Entity\OgRole;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Unit tests for the OgRole config entity.
+ *
+ * @group og
+ * @coversDefaultClass \Drupal\og\Entity\OgRole
+ */
+class OgRoleTest extends UnitTestCase {
+
+  /**
+   * Tests getting and setting the admin role through the inherited methods.
+   *
+   * @param bool $value
+   *   A boolean value whether or not the admin role will be set.
+   *
+   * @covers ::isAdmin
+   * @covers ::setIsAdmin
+   *
+   * @dataProvider booleanProvider
+   */
+  public function testIsAdmin($value) {
+    $role = new OgRole([]);
+    $role->setIsAdmin($value);
+    $this->assertEquals($value, $role->isAdmin());
+  }
+
+  /**
+   * Provides boolean data.
+   */
+  public function booleanProvider() {
+    return [[TRUE], [FALSE]];
+  }
+
+}


### PR DESCRIPTION
Fix for #369.

Edit: I was mistaken, the `OgRole::isAdmin()` and `OgRole::setIsAdmin()` methods were not malfunctioning due a bug but due to a misconfiguration in my project.

I've now repurposed this PR to provide some additional test coverage that demonstrates the use of these methods.