### PR TITLE
Add an interface for the GroupTypeManager service

### DIFF
--- a/og_ui/src/Controller/OgUiController.php
+++ b/og_ui/src/Controller/OgUiController.php
@@ -6,7 +6,7 @@ use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Link;
-use Drupal\og\GroupTypeManager;
+use Drupal\og\GroupTypeManagerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -17,7 +17,7 @@ class OgUiController extends ControllerBase {
   /**
    * The OG group manager.
    *
-   * @var \Drupal\og\GroupTypeManager
+   * @var \Drupal\og\GroupTypeManagerInterface
    */
   protected $groupTypeManager;
 
@@ -38,14 +38,14 @@ class OgUiController extends ControllerBase {
   /**
    * Constructs a OgUiController object.
    *
-   * @param \Drupal\og\GroupTypeManager $group_manager
+   * @param \Drupal\og\GroupTypeManagerInterface $group_manager
    *   The OG group manager.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
    * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entity_type_bundle_info
    *   The entity type bundle info service.
    */
-  public function __construct(GroupTypeManager $group_manager, EntityTypeManagerInterface $entity_type_manager, EntityTypeBundleInfoInterface $entity_type_bundle_info) {
+  public function __construct(GroupTypeManagerInterface $group_manager, EntityTypeManagerInterface $entity_type_manager, EntityTypeBundleInfoInterface $entity_type_bundle_info) {
     $this->groupTypeManager = $group_manager;
     $this->entityTypeManager = $entity_type_manager;
     $this->entityTypeBundleInfo = $entity_type_bundle_info;

--- a/src/Entity/OgRole.php
+++ b/src/Entity/OgRole.php
@@ -299,7 +299,7 @@ class OgRole extends Role implements OgRoleInterface {
   /**
    * Gets the group manager.
    *
-   * @return \Drupal\og\GroupTypeManager
+   * @return \Drupal\og\GroupTypeManagerInterface
    *   The group manager.
    */
   protected function groupTypeManager() {

--- a/src/GroupTypeManager.php
+++ b/src/GroupTypeManager.php
@@ -14,7 +14,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 /**
  * A manager to keep track of which entity type/bundles are OG group enabled.
  */
-class GroupTypeManager {
+class GroupTypeManager implements GroupTypeManagerInterface {
 
   /**
    * The key used to identify the cached version of the group relation map.
@@ -165,15 +165,7 @@ class GroupTypeManager {
   }
 
   /**
-   * Determines whether an entity type ID and bundle ID are group enabled.
-   *
-   * @param string $entity_type_id
-   *   The entity type name.
-   * @param string $bundle
-   *   The bundle name.
-   *
-   * @return bool
-   *   TRUE if a bundle is a group.
+   * {@inheritdoc}
    */
   public function isGroup($entity_type_id, $bundle) {
     $group_map = $this->getGroupMap();
@@ -181,31 +173,14 @@ class GroupTypeManager {
   }
 
   /**
-   * Checks if the given entity bundle is group content.
-   *
-   * This is provided as a convenient sister method to ::isGroup(). It is a
-   * simple wrapper for OgGroupAudienceHelperInterface::hasGroupAudienceField().
-   *
-   * @param string $entity_type_id
-   *   The entity type ID.
-   * @param string $bundle
-   *   The bundle name.
-   *
-   * @return bool
-   *   TRUE if the entity bundle is group content.
+   * {@inheritdoc}
    */
   public function isGroupContent($entity_type_id, $bundle) {
     return $this->groupAudienceHelper->hasGroupAudienceField($entity_type_id, $bundle);
   }
 
   /**
-   * Returns the group of an entity type.
-   *
-   * @param string $entity_type_id
-   *   The entity type name.
-   *
-   * @return \Drupal\Core\Entity\EntityInterface[]
-   *   Array of groups, or an empty array if none found
+   * {@inheritdoc}
    */
   public function getGroupsForEntityType($entity_type_id) {
     $group_map = $this->getGroupMap();
@@ -213,11 +188,7 @@ class GroupTypeManager {
   }
 
   /**
-   * Get all group bundles keyed by entity type.
-   *
-   * @return array
-   *   An associative array, keyed by entity type, each value an indexed array
-   *   of bundle IDs.
+   * {@inheritdoc}
    */
   public function getAllGroupBundles($entity_type = NULL) {
     $group_map = $this->getGroupMap();
@@ -225,17 +196,7 @@ class GroupTypeManager {
   }
 
   /**
-   * Returns a list of all group content bundles keyed by entity type.
-   *
-   * This will return a simple list of group content bundles. If you need
-   * information about the relations between groups and group content bundles
-   * then use getGroupRelationMap() instead.
-   *
-   * @return array
-   *   An associative array of group content bundle IDs, keyed by entity type
-   *   ID.
-   *
-   * @see \Drupal\og\GroupTypeManager::getGroupRelationMap()
+   * {@inheritdoc}
    */
   public function getAllGroupContentBundles() {
     $bundles = [];
@@ -250,23 +211,7 @@ class GroupTypeManager {
   }
 
   /**
-   * Returns a list of all group content bundles filtered by entity type.
-   *
-   * This will return a simple list of group content bundles. If you need
-   * information about the relations between groups and group content bundles
-   * then use getGroupRelationMap() instead.
-   *
-   * @param string $entity_type_id
-   *   Entity type ID to filter the bundles by.
-   *
-   * @return array
-   *   An array of group content bundle IDs.
-   *
-   * @throws \InvalidArgumentException
-   *   Thrown when the passed in entity type ID does not have any group content
-   *   bundles defined.
-   *
-   * @see \Drupal\og\GroupTypeManager::getGroupRelationMap()
+   * {@inheritdoc}
    */
   public function getAllGroupContentBundlesByEntityType($entity_type_id) {
     $bundles = $this->getAllGroupContentBundles();
@@ -277,17 +222,7 @@ class GroupTypeManager {
   }
 
   /**
-   * Returns all group bundles that are referenced by the given group content.
-   *
-   * @param string $group_content_entity_type_id
-   *   The entity type ID of the group content type for which to return
-   *   associated group bundle IDs.
-   * @param string $group_content_bundle_id
-   *   The bundle ID of the group content type for which to return associated
-   *   group bundle IDs.
-   *
-   * @return array
-   *   An array of group bundle IDs, keyed by group entity type ID.
+   * {@inheritdoc}
    */
   public function getGroupBundleIdsByGroupContentBundle($group_content_entity_type_id, $group_content_bundle_id) {
     $bundles = [];
@@ -312,18 +247,7 @@ class GroupTypeManager {
   }
 
   /**
-   * Returns group content bundles that are referencing the given group content.
-   *
-   * @param string $group_entity_type_id
-   *   The entity type ID of the group type for which to return associated group
-   *   content bundle IDs.
-   * @param string $group_bundle_id
-   *   The bundle ID of the group type for which to return associated group
-   *   content bundle IDs.
-   *
-   * @return array
-   *   An array of group content bundle IDs, keyed by group content entity type
-   *   ID.
+   * {@inheritdoc}
    */
   public function getGroupContentBundleIdsByGroupBundle($group_entity_type_id, $group_bundle_id) {
     $group_relation_map = $this->getGroupRelationMap();
@@ -331,15 +255,7 @@ class GroupTypeManager {
   }
 
   /**
-   * Declares a bundle of an entity type as being an OG group.
-   *
-   * @param string $entity_type_id
-   *   The entity type ID of the bundle to declare as being a group.
-   * @param string $bundle_id
-   *   The bundle ID of the bundle to declare as being a group.
-   *
-   * @throws \InvalidArgumentException
-   *   Thrown when the given bundle is already a group.
+   * {@inheritdoc}
    */
   public function addGroup($entity_type_id, $bundle_id) {
     // Throw an error if the entity type is already defined as a group.
@@ -368,7 +284,7 @@ class GroupTypeManager {
   }
 
   /**
-   * Removes an entity type instance as being an OG group.
+   * {@inheritdoc}
    */
   public function removeGroup($entity_type_id, $bundle_id) {
     $editable = $this->configFactory->getEditable('og.settings');
@@ -396,7 +312,7 @@ class GroupTypeManager {
   }
 
   /**
-   * Resets all locally stored data.
+   * {@inheritdoc}
    */
   public function reset() {
     $this->resetGroupMap();
@@ -404,19 +320,14 @@ class GroupTypeManager {
   }
 
   /**
-   * Resets the cached group map.
-   *
-   * Call this after adding or removing a group type.
+   * {@inheritdoc}
    */
   public function resetGroupMap() {
     $this->groupMap = [];
   }
 
   /**
-   * Resets the cached group relation map.
-   *
-   * Call this after making a change to the relationship between a group type
-   * and a group content type.
+   * {@inheritdoc}
    */
   public function resetGroupRelationMap() {
     $this->groupRelationMap = [];
@@ -424,10 +335,7 @@ class GroupTypeManager {
   }
 
   /**
-   * Returns the group map.
-   *
-   * @return array
-   *   The group map.
+   * {@inheritdoc}
    */
   public function getGroupMap() {
     if (empty($this->groupMap)) {

--- a/src/GroupTypeManagerInterface.php
+++ b/src/GroupTypeManagerInterface.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace Drupal\og;
+
+/**
+ * Interface for services intended to help managing groups.
+ */
+interface GroupTypeManagerInterface {
+
+  /**
+   * Determines whether an entity type ID and bundle ID are group enabled.
+   *
+   * @param string $entity_type_id
+   *   The entity type name.
+   * @param string $bundle
+   *   The bundle name.
+   *
+   * @return bool
+   *   TRUE if a bundle is a group.
+   */
+  public function isGroup($entity_type_id, $bundle);
+
+  /**
+   * Checks if the given entity bundle is group content.
+   *
+   * This is provided as a convenient sister method to ::isGroup(). It is a
+   * simple wrapper for OgGroupAudienceHelperInterface::hasGroupAudienceField().
+   *
+   * @param string $entity_type_id
+   *   The entity type ID.
+   * @param string $bundle
+   *   The bundle name.
+   *
+   * @return bool
+   *   TRUE if the entity bundle is group content.
+   */
+  public function isGroupContent($entity_type_id, $bundle);
+
+  /**
+   * Returns the group of an entity type.
+   *
+   * @param string $entity_type_id
+   *   The entity type name.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface[]
+   *   Array of groups, or an empty array if none found
+   */
+  public function getGroupsForEntityType($entity_type_id);
+
+  /**
+   * Get all group bundles keyed by entity type.
+   *
+   * @return array
+   *   An associative array, keyed by entity type, each value an indexed array
+   *   of bundle IDs.
+   */
+  public function getAllGroupBundles($entity_type = NULL);
+
+  /**
+   * Returns a list of all group content bundles keyed by entity type.
+   *
+   * This will return a simple list of group content bundles. If you need
+   * information about the relations between groups and group content bundles
+   * then use getGroupRelationMap() instead.
+   *
+   * @return array
+   *   An associative array of group content bundle IDs, keyed by entity type
+   *   ID.
+   *
+   * @see \Drupal\og\GroupTypeManager::getGroupRelationMap()
+   */
+  public function getAllGroupContentBundles();
+
+  /**
+   * Returns a list of all group content bundles filtered by entity type.
+   *
+   * This will return a simple list of group content bundles. If you need
+   * information about the relations between groups and group content bundles
+   * then use getGroupRelationMap() instead.
+   *
+   * @param string $entity_type_id
+   *   Entity type ID to filter the bundles by.
+   *
+   * @return array
+   *   An array of group content bundle IDs.
+   *
+   * @throws \InvalidArgumentException
+   *   Thrown when the passed in entity type ID does not have any group content
+   *   bundles defined.
+   *
+   * @see \Drupal\og\GroupTypeManager::getGroupRelationMap()
+   */
+  public function getAllGroupContentBundlesByEntityType($entity_type_id);
+
+  /**
+   * Returns all group bundles that are referenced by the given group content.
+   *
+   * @param string $group_content_entity_type_id
+   *   The entity type ID of the group content type for which to return
+   *   associated group bundle IDs.
+   * @param string $group_content_bundle_id
+   *   The bundle ID of the group content type for which to return associated
+   *   group bundle IDs.
+   *
+   * @return array
+   *   An array of group bundle IDs, keyed by group entity type ID.
+   */
+  public function getGroupBundleIdsByGroupContentBundle($group_content_entity_type_id, $group_content_bundle_id);
+
+  /**
+   * Returns group content bundles that are referencing the given group content.
+   *
+   * @param string $group_entity_type_id
+   *   The entity type ID of the group type for which to return associated group
+   *   content bundle IDs.
+   * @param string $group_bundle_id
+   *   The bundle ID of the group type for which to return associated group
+   *   content bundle IDs.
+   *
+   * @return array
+   *   An array of group content bundle IDs, keyed by group content entity type
+   *   ID.
+   */
+  public function getGroupContentBundleIdsByGroupBundle($group_entity_type_id, $group_bundle_id);
+
+  /**
+   * Declares a bundle of an entity type as being an OG group.
+   *
+   * @param string $entity_type_id
+   *   The entity type ID of the bundle to declare as being a group.
+   * @param string $bundle_id
+   *   The bundle ID of the bundle to declare as being a group.
+   *
+   * @throws \InvalidArgumentException
+   *   Thrown when the given bundle is already a group.
+   */
+  public function addGroup($entity_type_id, $bundle_id);
+
+  /**
+   * Removes an entity type instance as being an OG group.
+   */
+  public function removeGroup($entity_type_id, $bundle_id);
+
+  /**
+   * Resets all locally stored data.
+   */
+  public function reset();
+
+  /**
+   * Resets the cached group map.
+   *
+   * Call this after adding or removing a group type.
+   */
+  public function resetGroupMap();
+
+  /**
+   * Resets the cached group relation map.
+   *
+   * Call this after making a change to the relationship between a group type
+   * and a group content type.
+   */
+  public function resetGroupRelationMap();
+
+  /**
+   * Returns the group map.
+   *
+   * @return array
+   *   The group map.
+   */
+  public function getGroupMap();
+
+}

--- a/src/GroupTypeManagerInterface.php
+++ b/src/GroupTypeManagerInterface.php
@@ -67,7 +67,7 @@ interface GroupTypeManagerInterface {
    *   An associative array of group content bundle IDs, keyed by entity type
    *   ID.
    *
-   * @see \Drupal\og\GroupTypeManager::getGroupRelationMap()
+   * @see \Drupal\og\GroupTypeManagerInterface::getGroupRelationMap()
    */
   public function getAllGroupContentBundles();
 
@@ -88,7 +88,7 @@ interface GroupTypeManagerInterface {
    *   Thrown when the passed in entity type ID does not have any group content
    *   bundles defined.
    *
-   * @see \Drupal\og\GroupTypeManager::getGroupRelationMap()
+   * @see \Drupal\og\GroupTypeManagerInterface::getGroupRelationMap()
    */
   public function getAllGroupContentBundlesByEntityType($entity_type_id);
 

--- a/src/Og.php
+++ b/src/Og.php
@@ -299,7 +299,7 @@ class Og {
   /**
    * Returns the group manager instance.
    *
-   * @return \Drupal\og\GroupTypeManager
+   * @return \Drupal\og\GroupTypeManagerInterface
    *   Returns the group manager.
    */
   public static function groupTypeManager() {

--- a/src/OgAccess.php
+++ b/src/OgAccess.php
@@ -66,7 +66,7 @@ class OgAccess implements OgAccessInterface {
   /**
    * The group manager.
    *
-   * @var \Drupal\og\GroupTypeManager
+   * @var \Drupal\og\GroupTypeManagerInterface
    */
   protected $groupTypeManager;
 
@@ -100,7 +100,7 @@ class OgAccess implements OgAccessInterface {
    *   The service that contains the current active user.
    * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
    *   The module handler.
-   * @param \Drupal\og\GroupTypeManager $group_manager
+   * @param \Drupal\og\GroupTypeManagerInterface $group_manager
    *   The group manager.
    * @param \Drupal\og\PermissionManagerInterface $permission_manager
    *   The permission manager.
@@ -109,7 +109,7 @@ class OgAccess implements OgAccessInterface {
    * @param \Drupal\og\OgGroupAudienceHelperInterface $group_audience_helper
    *   The OG group audience helper.
    */
-  public function __construct(ConfigFactoryInterface $config_factory, AccountProxyInterface $account_proxy, ModuleHandlerInterface $module_handler, GroupTypeManager $group_manager, PermissionManagerInterface $permission_manager, MembershipManagerInterface $membership_manager, OgGroupAudienceHelperInterface $group_audience_helper) {
+  public function __construct(ConfigFactoryInterface $config_factory, AccountProxyInterface $account_proxy, ModuleHandlerInterface $module_handler, GroupTypeManagerInterface $group_manager, PermissionManagerInterface $permission_manager, MembershipManagerInterface $membership_manager, OgGroupAudienceHelperInterface $group_audience_helper) {
     $this->configFactory = $config_factory;
     $this->accountProxy = $account_proxy;
     $this->moduleHandler = $module_handler;

--- a/src/OgRouteGroupResolverBase.php
+++ b/src/OgRouteGroupResolverBase.php
@@ -30,7 +30,7 @@ abstract class OgRouteGroupResolverBase extends OgGroupResolverBase implements C
   /**
    * The group type manager.
    *
-   * @var \Drupal\og\GroupTypeManager
+   * @var \Drupal\og\GroupTypeManagerInterface
    */
   protected $groupTypeManager;
 
@@ -52,12 +52,12 @@ abstract class OgRouteGroupResolverBase extends OgGroupResolverBase implements C
    *   The plugin implementation definition.
    * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
    *   The route match service.
-   * @param \Drupal\og\GroupTypeManager $group_type_manager
+   * @param \Drupal\og\GroupTypeManagerInterface $group_type_manager
    *   The group type manager.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, RouteMatchInterface $route_match, GroupTypeManager $group_type_manager, EntityTypeManagerInterface $entity_type_manager) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, RouteMatchInterface $route_match, GroupTypeManagerInterface $group_type_manager, EntityTypeManagerInterface $entity_type_manager) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->routeMatch = $route_match;
     $this->groupTypeManager = $group_type_manager;

--- a/src/Plugin/Block/RecentGroupContentBlock.php
+++ b/src/Plugin/Block/RecentGroupContentBlock.php
@@ -10,7 +10,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\field\FieldStorageConfigInterface;
-use Drupal\og\GroupTypeManager;
+use Drupal\og\GroupTypeManagerInterface;
 use Drupal\og\OgContextInterface;
 use Drupal\og\OgGroupAudienceHelperInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -42,7 +42,7 @@ class RecentGroupContentBlock extends BlockBase implements ContainerFactoryPlugi
   /**
    * The OG group type manager.
    *
-   * @var \Drupal\og\GroupTypeManager
+   * @var \Drupal\og\GroupTypeManagerInterface
    */
   protected $groupTypeManager;
 
@@ -66,12 +66,12 @@ class RecentGroupContentBlock extends BlockBase implements ContainerFactoryPlugi
    *   The OG context provider.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
-   * @param \Drupal\og\GroupTypeManager $group_type_manager
+   * @param \Drupal\og\GroupTypeManagerInterface $group_type_manager
    *   The OG group type manager.
    * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entity_type_bundle_info
    *   The bundle info service.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, OgContextInterface $og_context, EntityTypeManagerInterface $entity_type_manager, GroupTypeManager $group_type_manager, EntityTypeBundleInfoInterface $entity_type_bundle_info) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, OgContextInterface $og_context, EntityTypeManagerInterface $entity_type_manager, GroupTypeManagerInterface $group_type_manager, EntityTypeBundleInfoInterface $entity_type_bundle_info) {
     $this->ogContext = $og_context;
     $this->entityTypeManager = $entity_type_manager;
     $this->groupTypeManager = $group_type_manager;

--- a/src/Plugin/Condition/GroupType.php
+++ b/src/Plugin/Condition/GroupType.php
@@ -7,7 +7,7 @@ use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Drupal\og\GroupTypeManager;
+use Drupal\og\GroupTypeManagerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -26,7 +26,7 @@ class GroupType extends ConditionPluginBase implements ContainerFactoryPluginInt
   /**
    * The group type manager.
    *
-   * @var \Drupal\og\GroupTypeManager
+   * @var \Drupal\og\GroupTypeManagerInterface
    */
   protected $groupTypeManager;
 
@@ -56,14 +56,14 @@ class GroupType extends ConditionPluginBase implements ContainerFactoryPluginInt
    *   The plugin_id for the plugin instance.
    * @param mixed $plugin_definition
    *   The plugin implementation definition.
-   * @param \Drupal\og\GroupTypeManager $group_type_manager
+   * @param \Drupal\og\GroupTypeManagerInterface $group_type_manager
    *   The group type manager.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
    * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entity_type_bundle_info
    *   The entity type bundle info service.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, GroupTypeManager $group_type_manager, EntityTypeManagerInterface $entity_type_manager, EntityTypeBundleInfoInterface $entity_type_bundle_info) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, GroupTypeManagerInterface $group_type_manager, EntityTypeManagerInterface $entity_type_manager, EntityTypeBundleInfoInterface $entity_type_bundle_info) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->groupTypeManager = $group_type_manager;
     $this->entityTypeManager = $entity_type_manager;

--- a/src/Plugin/Derivative/OgLocalTask.php
+++ b/src/Plugin/Derivative/OgLocalTask.php
@@ -6,7 +6,7 @@ use Drupal\Component\Plugin\Derivative\DeriverBase;
 use Drupal\Core\Plugin\Discovery\ContainerDeriverInterface;
 use Drupal\Core\Routing\RouteProvider;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
-use Drupal\og\GroupTypeManager;
+use Drupal\og\GroupTypeManagerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -19,7 +19,7 @@ class OgLocalTask extends DeriverBase implements ContainerDeriverInterface {
   /**
    * The group type manager.
    *
-   * @var \Drupal\og\GroupTypeManager
+   * @var \Drupal\og\GroupTypeManagerInterface
    */
   protected $groupTypeManager;
 
@@ -33,12 +33,12 @@ class OgLocalTask extends DeriverBase implements ContainerDeriverInterface {
   /**
    * Creates an OgLocalTask object.
    *
-   * @param \Drupal\og\GroupTypeManager $group_type_manager
+   * @param \Drupal\og\GroupTypeManagerInterface $group_type_manager
    *   The group type manager.
    * @param \Drupal\Core\Routing\RouteProvider $route_provider
    *   The route provider services.
    */
-  public function __construct(GroupTypeManager $group_type_manager, RouteProvider $route_provider) {
+  public function __construct(GroupTypeManagerInterface $group_type_manager, RouteProvider $route_provider) {
     $this->groupTypeManager = $group_type_manager;
     $this->routProvider = $route_provider;
   }

--- a/src/Plugin/OgGroupResolver/RequestQueryArgumentResolver.php
+++ b/src/Plugin/OgGroupResolver/RequestQueryArgumentResolver.php
@@ -5,7 +5,7 @@ namespace Drupal\og\Plugin\OgGroupResolver;
 use Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Drupal\og\GroupTypeManager;
+use Drupal\og\GroupTypeManagerInterface;
 use Drupal\og\OgGroupResolverBase;
 use Drupal\og\OgResolvedGroupCollectionInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -45,7 +45,7 @@ class RequestQueryArgumentResolver extends OgGroupResolverBase implements Contai
   /**
    * The group type manager.
    *
-   * @var \Drupal\og\GroupTypeManager
+   * @var \Drupal\og\GroupTypeManagerInterface
    */
   protected $groupTypeManager;
 
@@ -67,12 +67,12 @@ class RequestQueryArgumentResolver extends OgGroupResolverBase implements Contai
    *   The plugin implementation definition.
    * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
    *   The request stack.
-   * @param \Drupal\og\GroupTypeManager $group_type_manager
+   * @param \Drupal\og\GroupTypeManagerInterface $group_type_manager
    *   The group type manager.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, RequestStack $request_stack, GroupTypeManager $group_type_manager, EntityTypeManagerInterface $entity_type_manager) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, RequestStack $request_stack, GroupTypeManagerInterface $group_type_manager, EntityTypeManagerInterface $entity_type_manager) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->requestStack = $request_stack;
     $this->groupTypeManager = $group_type_manager;

--- a/src/Plugin/OgGroupResolver/RouteGroupContentResolver.php
+++ b/src/Plugin/OgGroupResolver/RouteGroupContentResolver.php
@@ -4,7 +4,7 @@ namespace Drupal\og\Plugin\OgGroupResolver;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
-use Drupal\og\GroupTypeManager;
+use Drupal\og\GroupTypeManagerInterface;
 use Drupal\og\MembershipManagerInterface;
 use Drupal\og\OgGroupAudienceHelperInterface;
 use Drupal\og\OgResolvedGroupCollectionInterface;
@@ -50,7 +50,7 @@ class RouteGroupContentResolver extends OgRouteGroupResolverBase {
    *   The plugin implementation definition.
    * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
    *   The route match service.
-   * @param \Drupal\og\GroupTypeManager $group_type_manager
+   * @param \Drupal\og\GroupTypeManagerInterface $group_type_manager
    *   The group type manager.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
@@ -59,7 +59,7 @@ class RouteGroupContentResolver extends OgRouteGroupResolverBase {
    * @param \Drupal\og\OgGroupAudienceHelperInterface $group_audience_helper
    *   The OG group audience helper.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, RouteMatchInterface $route_match, GroupTypeManager $group_type_manager, EntityTypeManagerInterface $entity_type_manager, MembershipManagerInterface $membership_manager, OgGroupAudienceHelperInterface $group_audience_helper) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, RouteMatchInterface $route_match, GroupTypeManagerInterface $group_type_manager, EntityTypeManagerInterface $entity_type_manager, MembershipManagerInterface $membership_manager, OgGroupAudienceHelperInterface $group_audience_helper) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $route_match, $group_type_manager, $entity_type_manager);
     $this->membershipManager = $membership_manager;
     $this->groupAudienceHelper = $group_audience_helper;

--- a/tests/src/Kernel/Action/ActionTestBase.php
+++ b/tests/src/Kernel/Action/ActionTestBase.php
@@ -70,7 +70,7 @@ abstract class ActionTestBase extends KernelTestBase {
   /**
    * The OG group type manager.
    *
-   * @var \Drupal\og\GroupTypeManager
+   * @var \Drupal\og\GroupTypeManagerInterface
    */
   protected $groupTypeManager;
 

--- a/tests/src/Kernel/Entity/GetBundleByBundleTest.php
+++ b/tests/src/Kernel/Entity/GetBundleByBundleTest.php
@@ -45,7 +45,7 @@ class GetBundleByBundleTest extends KernelTestBase {
   /**
    * The group manager.
    *
-   * @var \Drupal\og\GroupTypeManager
+   * @var \Drupal\og\GroupTypeManagerInterface
    */
   protected $groupTypeManager;
 

--- a/tests/src/Kernel/Entity/GroupTypeTest.php
+++ b/tests/src/Kernel/Entity/GroupTypeTest.php
@@ -20,7 +20,7 @@ class GroupTypeTest extends KernelTestBase {
   /**
    * The group type manager.
    *
-   * @var \Drupal\og\GroupTypeManager
+   * @var \Drupal\og\GroupTypeManagerInterface
    */
   protected $groupTypeManager;
 

--- a/tests/src/Kernel/Entity/OgRoleTest.php
+++ b/tests/src/Kernel/Entity/OgRoleTest.php
@@ -38,7 +38,7 @@ class OgRoleTest extends KernelTestBase {
   /**
    * The group type manager.
    *
-   * @var \Drupal\og\GroupTypeManager
+   * @var \Drupal\og\GroupTypeManagerInterface
    */
   protected $groupTypeManager;
 

--- a/tests/src/Kernel/GroupManagerSubscriptionTest.php
+++ b/tests/src/Kernel/GroupManagerSubscriptionTest.php
@@ -38,7 +38,7 @@ class GroupManagerSubscriptionTest extends KernelTestBase {
   /**
    * The group type manager.
    *
-   * @var \Drupal\og\GroupTypeManager
+   * @var \Drupal\og\GroupTypeManagerInterface
    */
   protected $groupTypeManager;
 

--- a/tests/src/Kernel/GroupTypeConditionTest.php
+++ b/tests/src/Kernel/GroupTypeConditionTest.php
@@ -43,7 +43,7 @@ class GroupTypeConditionTest extends KernelTestBase {
   /**
    * The group type manager.
    *
-   * @var \Drupal\og\GroupTypeManager
+   * @var \Drupal\og\GroupTypeManagerInterface
    */
   protected $groupTypeManager;
 

--- a/tests/src/Unit/GroupCheckTest.php
+++ b/tests/src/Unit/GroupCheckTest.php
@@ -10,7 +10,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\og\Access\GroupCheck;
-use Drupal\og\GroupTypeManager;
+use Drupal\og\GroupTypeManagerInterface;
 use Drupal\og\OgAccessInterface;
 use Drupal\Tests\UnitTestCase;
 use Symfony\Component\Routing\Route;
@@ -96,7 +96,7 @@ class GroupCheckTest extends UnitTestCase {
   /**
    * The group manager used in the test.
    *
-   * @var \Drupal\og\GroupTypeManager|\Prophecy\Prophecy\ObjectProphecy
+   * @var \Drupal\og\GroupTypeManagerInterface|\Prophecy\Prophecy\ObjectProphecy
    */
   protected $groupTypeManager;
 
@@ -128,7 +128,7 @@ class GroupCheckTest extends UnitTestCase {
     $this->entityTypeId = $this->randomMachineName();
     $this->bundle = $this->randomMachineName();
     $this->entityId = rand(10, 50);
-    $this->groupTypeManager = $this->prophesize(GroupTypeManager::class);
+    $this->groupTypeManager = $this->prophesize(GroupTypeManagerInterface::class);
     $this->user = $this->prophesize(AccountInterface::class);
     $this->group = $this->prophesize(EntityInterface::class);
     $this->accessResult = $this->prophesize(AccessResultInterface::class);

--- a/tests/src/Unit/GroupSubscribeFormatterTest.php
+++ b/tests/src/Unit/GroupSubscribeFormatterTest.php
@@ -11,7 +11,7 @@ use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Session\AccountProxyInterface;
-use Drupal\og\GroupTypeManager;
+use Drupal\og\GroupTypeManagerInterface;
 use Drupal\og\MembershipManagerInterface;
 use Drupal\og\OgAccessInterface;
 use Drupal\og\OgMembershipInterface;
@@ -86,7 +86,7 @@ class GroupSubscribeFormatterTest extends UnitTestCase {
   /**
    * The group manager.
    *
-   * @var \Drupal\og\GroupTypeManager|\Prophecy\Prophecy\ObjectProphecy
+   * @var \Drupal\og\GroupTypeManagerInterface|\Prophecy\Prophecy\ObjectProphecy
    */
   protected $groupTypeManager;
 
@@ -155,7 +155,7 @@ class GroupSubscribeFormatterTest extends UnitTestCase {
     $this->fieldDefinitionInterface = $this->prophesize(FieldDefinitionInterface::class);
     $this->fieldItemList = $this->prophesize(FieldItemListInterface::class);
     $this->group = $this->prophesize(EntityInterface::class);
-    $this->groupTypeManager = $this->prophesize(GroupTypeManager::class);
+    $this->groupTypeManager = $this->prophesize(GroupTypeManagerInterface::class);
     $this->membershipManager = $this->prophesize(MembershipManagerInterface::class);
     $this->ogAccess = $this->prophesize(OgAccessInterface::class);
     $this->user = $this->prophesize(AccountInterface::class);

--- a/tests/src/Unit/GroupTypeManagerTest.php
+++ b/tests/src/Unit/GroupTypeManagerTest.php
@@ -12,6 +12,7 @@ use Drupal\Core\State\StateInterface;
 use Drupal\og\Event\GroupCreationEvent;
 use Drupal\og\Event\GroupCreationEventInterface;
 use Drupal\og\GroupTypeManager;
+use Drupal\og\GroupTypeManagerInterface;
 use Drupal\og\OgGroupAudienceHelperInterface;
 use Drupal\og\PermissionManagerInterface;
 use Drupal\og\OgRoleManagerInterface;
@@ -148,7 +149,7 @@ class GroupTypeManagerTest extends UnitTestCase {
     // Just creating an instance should be lightweight, no methods should be
     // called.
     $group_manager = $this->createGroupManager();
-    $this->assertInstanceOf(GroupTypeManager::class, $group_manager);
+    $this->assertInstanceOf(GroupTypeManagerInterface::class, $group_manager);
   }
 
   /**
@@ -321,7 +322,7 @@ class GroupTypeManagerTest extends UnitTestCase {
   /**
    * Creates a group manager instance with a mock config factory.
    *
-   * @return \Drupal\og\GroupTypeManager
+   * @return \Drupal\og\GroupTypeManagerInterface
    *   Returns the group manager.
    */
   protected function createGroupManager() {

--- a/tests/src/Unit/OgAccessTestBase.php
+++ b/tests/src/Unit/OgAccessTestBase.php
@@ -16,7 +16,7 @@ use Drupal\og\MembershipManagerInterface;
 use Drupal\og\OgGroupAudienceHelperInterface;
 use Drupal\og\OgMembershipInterface;
 use Drupal\Tests\UnitTestCase;
-use Drupal\og\GroupTypeManager;
+use Drupal\og\GroupTypeManagerInterface;
 use Drupal\og\OgAccess;
 use Drupal\og\PermissionManager;
 use Drupal\user\EntityOwnerInterface;
@@ -73,7 +73,7 @@ class OgAccessTestBase extends UnitTestCase {
   /**
    * The mocked group manager.
    *
-   * @var \Drupal\og\GroupTypeManager|\Prophecy\Prophecy\ObjectProphecy
+   * @var \Drupal\og\GroupTypeManagerInterface|\Prophecy\Prophecy\ObjectProphecy
    */
   protected $groupTypeManager;
 
@@ -138,7 +138,7 @@ class OgAccessTestBase extends UnitTestCase {
     $this->membership = $this->prophesize(OgMembershipInterface::class);
     $this->ogRole = $this->prophesize(RoleInterface::class);
 
-    $this->groupTypeManager = $this->prophesize(GroupTypeManager::class);
+    $this->groupTypeManager = $this->prophesize(GroupTypeManagerInterface::class);
     $this->groupTypeManager->isGroup($this->entityTypeId, $this->bundle)->willReturn(TRUE);
 
     $cache_contexts_manager = $this->prophesize(CacheContextsManager::class);

--- a/tests/src/Unit/OgLocalTaskTest.php
+++ b/tests/src/Unit/OgLocalTaskTest.php
@@ -4,7 +4,7 @@ namespace Drupal\Tests\og\Unit;
 
 use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\Core\Routing\RouteProvider;
-use Drupal\og\GroupTypeManager;
+use Drupal\og\GroupTypeManagerInterface;
 use Drupal\og\Plugin\Derivative\OgLocalTask;
 use Drupal\Tests\UnitTestCase;
 use Symfony\Component\Routing\Route;
@@ -22,7 +22,7 @@ class OgLocalTaskTest extends UnitTestCase {
   /**
    * The group type manager.
    *
-   * @var \Drupal\og\GroupTypeManager|\Prophecy\Prophecy\ObjectProphecy
+   * @var \Drupal\og\GroupTypeManagerInterface|\Prophecy\Prophecy\ObjectProphecy
    */
   protected $groupTypeManager;
 
@@ -44,7 +44,7 @@ class OgLocalTaskTest extends UnitTestCase {
    * {@inheritdoc}
    */
   public function setUp() {
-    $this->groupTypeManager = $this->prophesize(GroupTypeManager::class);
+    $this->groupTypeManager = $this->prophesize(GroupTypeManagerInterface::class);
     $this->routeProvider = $this->prophesize(RouteProvider::class);
     $this->route = $this->prophesize(Route::class);
 

--- a/tests/src/Unit/Plugin/OgGroupResolver/OgGroupResolverTestBase.php
+++ b/tests/src/Unit/Plugin/OgGroupResolver/OgGroupResolverTestBase.php
@@ -4,7 +4,7 @@ namespace Drupal\Tests\og\Unit\Plugin\OgGroupResolver;
 
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\og\GroupTypeManager;
+use Drupal\og\GroupTypeManagerInterface;
 use Drupal\og\MembershipManagerInterface;
 use Drupal\og\OgGroupAudienceHelperInterface;
 use Drupal\Tests\UnitTestCase;
@@ -54,7 +54,7 @@ abstract class OgGroupResolverTestBase extends UnitTestCase {
   /**
    * The mocked OG group type manager.
    *
-   * @var \Drupal\og\GroupTypeManager|\Prophecy\Prophecy\ObjectProphecy
+   * @var \Drupal\og\GroupTypeManagerInterface|\Prophecy\Prophecy\ObjectProphecy
    */
   protected $groupTypeManager;
 
@@ -74,7 +74,7 @@ abstract class OgGroupResolverTestBase extends UnitTestCase {
     // Instantiate mocks of the classes that the plugins rely on.
     $this->entityTypeManager = $this->prophesize(EntityTypeManagerInterface::class);
     $this->groupAudienceHelper = $this->prophesize(OgGroupAudienceHelperInterface::class);
-    $this->groupTypeManager = $this->prophesize(GroupTypeManager::class);
+    $this->groupTypeManager = $this->prophesize(GroupTypeManagerInterface::class);
     $this->membershipManager = $this->prophesize(MembershipManagerInterface::class);
 
     // Create mocked test entities.


### PR DESCRIPTION
The `GroupTypeManager` service doesn't have an interface yet. It's interesting to add this so that developers can provide their own custom implementations that are adhering to the API that is expected by OG.