### PR TITLE
Use correct class name in exception message

### DIFF
--- a/src/MembershipManager.php
+++ b/src/MembershipManager.php
@@ -151,7 +151,7 @@ class MembershipManager implements MembershipManagerInterface {
   public function getGroupIds(EntityInterface $entity, $group_type_id = NULL, $group_bundle = NULL) {
     // This does not work for user entities.
     if ($entity->getEntityTypeId() === 'user') {
-      throw new \InvalidArgumentException('\Drupal\og\GroupMembership::getGroupIds() cannot be used for user entities. Use \Drupal\og\GroupMembership::getUserGroups() instead.');
+      throw new \InvalidArgumentException('\Drupal\og\MembershipManager::getGroupIds() cannot be used for user entities. Use \Drupal\og\MembershipManager::getUserGroups() instead.');
     }
 
     $identifier = [


### PR DESCRIPTION
When we renamed `GroupMembership` to `MembershipManager` it appears we had forgotten to update it in this exception message.