### PR TITLE
OG 7.x 2.10 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
   - cd ../..
 
   # Install Drush
-  - composer global require drush/drush
+  - composer global require drush/drush:8
   - export PATH=$PATH:~/.composer/vendor/bin
 
   # Install php packages required for running Drupal

--- a/og.api.php
+++ b/og.api.php
@@ -12,7 +12,28 @@
  */
 
 /**
- * Add group permissions.
+ * Define permissions specific to organic groups.
+ *
+ * This hook can supply permissions that the module defines, so that they can be
+ * selected on the group permissions page and used to grant or restrict access
+ * to actions pertaining to groups.
+ *
+ * Permissions are checked using og_user_access().
+ *
+ * @return array
+ *   An array whose keys are permission names and whose corresponding values are
+ *   arrays containg the following key-value pairs:
+ *   - title: The human-readable name of the permission, to be shown on group
+ *     permissions pages. This should be wrapped in the t() function so it can
+ *     be translated.
+ *   - description: (optional) A description of what the permission does. This
+ *     should be wrapped in the t() function so it can be translated.
+ *   - roles: (optional) An array of OG roles to which it is possible to assign
+ *     this permission. The default value is an array containg OG_ANONYMOUS_ROLE
+ *     and OG_AUTHENTICATED_ROLE.
+ *   - default role: (optional) An array of OG roles that should be assigned
+ *     this permission by default. If omitted then no role will receive the
+ *     permission by default.
  */
 function hook_og_permission() {
   return array(

--- a/og.info
+++ b/og.info
@@ -24,7 +24,6 @@ files[] = includes/views/handlers/og_plugin_argument_validate_group.inc
 files[] = includes/views/handlers/og_plugin_argument_default_user_groups.inc
 
 ; Views fields
-files[] = includes/views/handlers/og_handler_field_group_member_count.inc
 files[] = includes/views/handlers/og_handler_field_group_audience_state.inc
 files[] = includes/views/handlers/og_handler_field_prerender_list.inc
 files[] = includes/views/handlers/og_handler_field_user_roles.inc

--- a/og.module
+++ b/og.module
@@ -81,8 +81,8 @@ function og_help($path, $arg) {
   switch ($path) {
     case 'admin/help#og':
       $path = drupal_get_path('module', 'og');
-      $output  = '<p>' . t("Read the <a href='@url'>README.txt</a> file in the Organic groups module directory.", array('@url' => "/$path/README.txt")) . '</p>';
-      $output .= '<p>' . t("Information about Organic Groups can also be found on the module's<a href='@og'>documentation page</a>.", array('@og' => 'http://drupal.org/documentation/modules/og')) . '</p>';
+      $output  = '<p>' . t("Read the <a href='@url'>README.md</a> file in the Organic groups module directory.", array('@url' => "/$path/README.md")) . '</p>';
+      $output .= '<p>' . t("Information about Organic Groups can also be found on the module's <a href='@og'>documentation page</a>.", array('@og' => 'http://drupal.org/documentation/modules/og')) . '</p>';
       return $output;
   }
 }

--- a/og.module
+++ b/og.module
@@ -671,7 +671,15 @@ function og_field_create_instance($instance) {
 
   $og_field = og_fields_info(OG_AUDIENCE_FIELD);
   $og_field['field']['settings']['target_type'] = $entity_type;
-  $og_field['instance']['label'] = t('Group membership');
+  if ($entity_type == 'node') {
+    $og_field['instance']['label'] = t('Group membership');
+  }
+  else {
+    $entity_info = entity_get_info($entity_type);
+    $og_field['instance']['label'] = t('@label group membership', array(
+      '@label' => $entity_info['label'],
+    ));
+  }
 
   // If the user entity type has multiple bundles, make sure to attach a field
   // instance to all of them.

--- a/og.module
+++ b/og.module
@@ -3553,7 +3553,10 @@ function og_node_create_links($group_type, $gid, $field_name, $destination = NUL
  *   types will be fetched.
  *
  * @return
- *   An array with the group IDs or an empty array.
+ *   If $group_type is provided then an array of group IDs matching the
+ *   specified group type. If $group_type is not provided then an associative
+ *   array is returned containing arrays of group IDs keyed by group type. If
+ *   no results are found an empty array is returned.
  */
 function og_get_groups_by_user($account = NULL, $group_type = NULL) {
   if (empty($account)) {
@@ -3581,12 +3584,10 @@ function og_get_groups_by_user($account = NULL, $group_type = NULL) {
     }
   }
 
-  if (empty($group_type)) {
-    return $gids;
+  if (isset($group_type)) {
+    return isset($gids[$group_type]) ? $gids[$group_type] : array();
   }
-  elseif (!empty($gids[$group_type])) {
-    return $gids[$group_type];
-  }
+  return $gids;
 }
 
 /**

--- a/og.module
+++ b/og.module
@@ -874,7 +874,7 @@ function og_entity_update($entity, $entity_type) {
   }
 
   list($id, , $bundle) = entity_extract_ids($entity_type, $entity);
-  if (!empty($entity->uid) && !og_is_member($entity_type, $id, 'user', $entity->uid)) {
+  if (!empty($entity->uid) && !og_is_member($entity_type, $id, 'user', $entity->uid, array())) {
     // Subscribe the group manager, in case the owner changed.
     og_group($entity_type, $id, array('entity' => $entity->uid));
     // Assign roles to group manager.

--- a/og.module
+++ b/og.module
@@ -2305,9 +2305,9 @@ function og_user_access_entity($perm, $entity_type, $entity, $account = NULL, $s
  *   (optional) The field name associated with the group.
  *
  * @return
- *  An array with the group's entity type as the key, and array - keyed by
- *  the OG membership ID and the group ID as the value. If nothing found,
- *  then an empty array.
+ *   An associative array keyed by the group's entity type. Each value is itself
+ *   an array, where each item has for its key the OG membership ID and for its
+ *   value the group ID.
  */
 function og_get_entity_groups($entity_type = 'user', $entity = NULL, $states = array(OG_STATE_ACTIVE), $field_name = NULL) {
   $cache = &drupal_static(__FUNCTION__, array());

--- a/og.module
+++ b/og.module
@@ -786,7 +786,7 @@ function og_form_group_manager_validate($form, &$form_state) {
     return;
   }
   $entity = $form_state[$entity_type];
-  $langcode = $form_state['values']['language'];
+  $langcode = isset($form_state['values']['language']) ? $form_state['values']['language'] : LANGUAGE_NONE;
 
   if (!isset($form_state['values']['uid']) || !isset($entity->uid)) {
     // There is no user ID property on the entity.

--- a/og.module
+++ b/og.module
@@ -3561,18 +3561,18 @@ function og_get_groups_by_user($account = NULL, $group_type = NULL) {
     $account = $user;
   }
 
+  $gids = array();
+
   if (!og_get_group_audience_fields()) {
     // User entity doesn't have group audience fields.
-    return;
+    return $gids;
   }
-
-  $gids = array();
 
   // Get all active OG membership that belong to the user.
   $wrapper = entity_metadata_wrapper('user', $account->uid);
   $og_memberships = $wrapper->{'og_membership__' . OG_STATE_ACTIVE}->value();
   if (!$og_memberships) {
-    return;
+    return $gids;
   }
 
   foreach ($og_memberships as $og_membership) {

--- a/og.module
+++ b/og.module
@@ -2572,8 +2572,8 @@ function og_get_all_group_content_bundle() {
  * @param $entity
  *   The entity object. If empty the current user will be used.
  * @param $states
- *   (optional) Array with the state to return. If empty groups of all state will
- *   return.
+ *   (optional) Array with the membership states to check against. If omitted
+ *   then only active (OG_STATE_ACTIVE) memberships will be checked.
  *
  * @return
  *   TRUE if the entity (e.g. the user) belongs to a group and is not pending or

--- a/og.test
+++ b/og.test
@@ -649,6 +649,41 @@ class OgGroupAndUngroup extends DrupalWebTestCase {
     $user_roles = og_get_user_roles('entity_test', $entity1->pid, $user1->uid, FALSE);
     $this->assertEqual($og_roles, $user_roles, t('Group manager was granted default role.'));
   }
+
+  /**
+   * Test group behaviour when the group owner is not active.
+   */
+  public function testGroupManagerNotActive() {
+    // Create the user.
+    $user1 = $this->drupalCreateUser();
+
+    // Create the group; the group owner is the previously created user.
+    $entity1 = entity_create('entity_test', array('name' => 'main', 'uid' => $user1->uid));
+    $wrapper = entity_metadata_wrapper('entity_test', $entity1);
+    $wrapper->{OG_GROUP_FIELD}->set(1);
+    $wrapper->save();
+
+    // Ensure that the user owner membership for the group has active status.
+    $og_membership = og_get_membership('entity_test', $entity1->pid, 'user', $user1->uid);
+    $this->assertEqual($og_membership->state, OG_STATE_ACTIVE, 'Owner Membership status is Active');
+
+    // Move the user owner membership to blocked.
+    $og_membership->state = OG_STATE_BLOCKED;
+    $og_membership->save();
+
+    $og_membership = og_membership_load($og_membership->identifier());
+    $this->assertEqual($og_membership->state, OG_STATE_BLOCKED, 'Owner Membership status is Blocked');
+
+    // Save the group entity.
+    $wrapper = entity_metadata_wrapper('entity_test', $entity1);
+    $wrapper->save();
+
+    // Ensure that the user owner membership for the group still has blocked
+    // status.
+    $og_membership = og_membership_load($og_membership->identifier());
+    $this->assertEqual($og_membership->state, OG_STATE_BLOCKED, 'Owner Membership status is Blocked');
+  }
+
 }
 
 class OgPermissionsTestCase extends DrupalWebTestCase {

--- a/og_access/og_access.info
+++ b/og_access/og_access.info
@@ -4,8 +4,6 @@ package = "Organic groups"
 dependencies[] = og
 core = 7.x
 version = VERSION
-files[] = og_access.module
-files[] = og_access.install
 
 ; Tests
 files[] = og_access.test

--- a/og_context/og_context.info
+++ b/og_context/og_context.info
@@ -3,8 +3,6 @@ description = "Get a group from a viewed page."
 package = "Organic groups"
 dependencies[] = og
 core = 7.x
-files[] = og_context.module
-files[] = og_context.install
 
 ; Views default arguments
 files[] = includes/views/handlers/og_context_plugin_argument_default_group_context.inc

--- a/og_field_access/og_field_access.info
+++ b/og_field_access/og_field_access.info
@@ -3,7 +3,6 @@ description = "Provide field access based on group."
 package = "Organic groups"
 dependencies[] = og
 core = 7.x
-files[] = og_field_access.module
 
 ; Tests
 files[] = og_field_access.test

--- a/og_register/og_register.info
+++ b/og_register/og_register.info
@@ -4,5 +4,3 @@ description = "Allow subscribing to groups during the user registration."
 package = "Organic groups"
 dependencies[] = og
 core = 7.x
-files[] = og_register.module
-files[] = og_register.install

--- a/og_ui/og_ui.admin.inc
+++ b/og_ui/og_ui.admin.inc
@@ -311,6 +311,7 @@ function og_ui_edit_membership($form, &$form_state, $group_type, $gid, $og_membe
       '#options' => $og_roles,
       '#title' => t('Roles'),
       '#default_value' => array_keys(og_get_user_roles($group_type, $gid, $account->uid)),
+      '#disabled' => $og_membership->state != OG_STATE_ACTIVE,
     );
   }
 

--- a/og_ui/og_ui.module
+++ b/og_ui/og_ui.module
@@ -328,12 +328,7 @@ function og_ui_user_access_group($perm, $group_type, $gid) {
     return FALSE;
   }
 
-  $entity_info = entity_get_info($group_type);
-  if (!$group_type || !$entity_info) {
-    // Not a valid entity type.
-    return FALSE;
-  }
-  return og_is_group($group_type, $group) && og_user_access($group_type, $gid, $perm);
+  return og_user_access($group_type, $gid, $perm);
 }
 
 /**

--- a/og_ui/og_ui.pages.inc
+++ b/og_ui/og_ui.pages.inc
@@ -36,7 +36,7 @@ function og_ui_subscribe($entity_type, $etid, $field_name = NULL) {
 
   $account = user_load($user->uid);
   if (empty($field_name)) {
-    $field_name = og_get_best_group_audience_field('user', $account, $entity_type, $bundle);
+    $field_name = og_get_best_group_audience_field('user', $account, $entity_type, $bundle, TRUE);
     if (empty($field_name)) {
       // User entity has no group audience field.
       drupal_not_found();

--- a/og_ui/og_ui.pages.inc
+++ b/og_ui/og_ui.pages.inc
@@ -237,7 +237,7 @@ function og_ui_confirm_unsubscribe($form, &$form_state, $group_type, $group) {
 
   $label = entity_label($group_type, $group);
   $url = entity_uri($group_type, $group);
-  return confirm_form($form, t('Are you sure you want to unsubscribe from the group %title?', array('%title' => $label)), $url, NULL, t('Remove'), t('Cancel'));
+  return confirm_form($form, t('Are you sure you want to unsubscribe from the group %title?', array('%title' => $label)), $url, NULL, t('Unsubscribe'), t('Cancel'));
 }
 
 /**

--- a/og_ui/og_ui.test
+++ b/og_ui/og_ui.test
@@ -199,7 +199,7 @@ class OgUiSubscribeTestCase extends DrupalWebTestCase {
     $this->drupalGet('node/' . $node->nid);
     $this->assertText(t('Unsubscribe from group'), t('Member gets correct unsubscribe text.'));
     $this->clickLink(t('Unsubscribe from group'));
-    $this->drupalPost(NULL, array() , t('Remove'));
+    $this->drupalPost(NULL, array() , t('Unsubscribe'));
 
     $this->assertFalse(og_is_member('node', $node->nid, 'user', $user2, array(OG_STATE_ACTIVE, OG_STATE_PENDING)), t('User unsubscribed from group.'));
 

--- a/plugins/entityreference/behavior/OgBehaviorHandler.class.php
+++ b/plugins/entityreference/behavior/OgBehaviorHandler.class.php
@@ -203,26 +203,20 @@ class OgBehaviorHandler extends EntityReference_BehaviorHandler_Abstract {
       // that this field is attached to.
       foreach ($entity_types as $entity_type) {
         $entity_info = entity_get_info($entity_type);
-        $data['og_membership'] = array(
-          'table' => array(
-            'join' => array(
-              $entity_info['base table'] => array(
-                // Join entity base table on its id field with left_field.
-                'left_field' => $entity_info['entity keys']['id'],
-                'field' => 'etid',
-                'extra' => array(
-                  0 => array(
-                    'field' => 'entity_type',
-                    'value' => $entity_type,
-                  ),
-                ),
-              ),
+        $data['og_membership']['table']['join'][$entity_info['base table']] = array(
+          // Join entity base table on its id field with left_field.
+          'left_field' => $entity_info['entity keys']['id'],
+          'field' => 'etid',
+          'extra' => array(
+            0 => array(
+              'field' => 'entity_type',
+              'value' => $entity_type,
             ),
           ),
-          // Copy the original config from the table definition.
-          $field['field_name'] => $data['field_data_' . $field['field_name']][$field['field_name']],
-          $field['field_name'] . '_target_id' => $data['field_data_' . $field['field_name']][$field['field_name'] . '_target_id'],
         );
+          // Copy the original config from the table definition.
+        $data['og_membership'][$field['field_name']] = $data['field_data_' . $field['field_name']][$field['field_name']];
+        $data['og_membership'][$field['field_name'] . '_target_id'] = $data['field_data_' . $field['field_name']][$field['field_name'] . '_target_id'];
 
         // Change config with settings from og_membership table.
         foreach (array('filter', 'argument', 'sort', 'relationship') as $op) {

--- a/plugins/entityreference/selection/OgSelectionHandler.class.php
+++ b/plugins/entityreference/selection/OgSelectionHandler.class.php
@@ -105,7 +105,6 @@ class OgSelectionHandler extends EntityReference_SelectionHandler_Generic {
 
     $field_mode = $this->instance['field_mode'];
     $user_groups = og_get_groups_by_user(NULL, $group_type);
-    $user_groups = $user_groups ? $user_groups : array();
     $user_groups = array_merge($user_groups, $this->getGidsForCreate());
 
 


### PR DESCRIPTION
**Commits between 7.x-2.9 and 7.x-2.10-rc1**

 * #2057025 OG subscribe / join page not working with field permissions on group field.
 * #1865852 og_form_group_manager_validate() assumes the entity form has a language.
 * #2831715 Unsubscribe confirm firm uses 'Remove' as button text.
 * #2338665 Remove unnecessary files[] from .info file.
 * #2542856 og_is_member() documentation incorrectly inform about  parameter.
 * #2575833 OG entityreference field breaks Views when the field is attached to multiple entity types..
 * #1997274 Return docs for og_get_entity_groups() unclear.
 * #1865860 Issues with multiple entity types as groups.
 * #2158477 hook_og_permission() does not document its @return.
 * Issue #2792031: Undefined property in og_entity_update when updating group
 * Fix tests: core-quick-drupal not available in Drush 9
 * Fix return value of og_get_groups_by_user() when $group_type is provided and results are empty
 * Issue #2569471 by robertom, jacob.embree: og_get_groups_by_user don't respect @return documentation
 * Remove duplicate checks in og_ui_user_access_group
 * Optimize some calls to og_is_group()
 * Revert "Revert "temporarily downgrade Travis image to confirm the problem""
 * Revert "line-by-line variables"
 * line-by-line variables
 * Revert "temporarily downgrade Travis image to confirm the problem"
 * temporarily downgrade Travis image to confirm the problem
 * Group owner membership is activated on every group save
 * og_ui edit_membership_form disable checkboxes if member is not active.
 * Issue #2380967 by rbayliss, criznach: Edit Group membership of a user and changing the status
 * Wrong references for og_ui_admin_roles validate and submit functions.
 * Issue #121: Changed form element type for check_access from select to checkbox and changed description to match the change.
 * og_ui: fix non-existing group test
 * og_ui.test: aside 403 group admin page tests, add a regular 404 response test too
 * Revert "og_ui/og_ui.test: temporary test break to test Travis error detection"
 * og_ui/og_ui.test: temporary test break to test Travis error detection
 * .travis.yml: quote bash commands to preserve special characters
 * .travis.yml: negate the result of the egrep simply when checking the result of simpletest
 * .travis.yml: fix error checking
 * .travis.yml: fix mysql server has gone away, from https://github.com/piwik/piwik/pull/6963/files
 * removed unreachable code in OgBehaviorHandler.class.php . If the $user has group admin permission, we should not set new membership to pending. But if he is not an admin, we exit early from the membership Crud. Adapted the test to test admin permission check of the Crud itself
 * og_ui/og_ui.test: fixed failing access test. Drush + built-in PHP webserver causes whatever/10.00/group path a 404, it does not reach Drupal. Instead of patching Drush, rewrote the test to check similar, but a bit different scenario
 * .travis.yml: fix sendmail stubbing for newer Drush
 * .travis.yml: fix Drush path, add PHP7 to the matrix
 * .travis.yml: switch to Composer-based Drush due to https://github.com/drush-ops/drush/issues/2090
 * .travis.yml: move the launch of the webserver to the proper location
 * .travis.yml: restore local webserver
 * .travis.yml: use testing script's --php version, path to php is not trivial due to phpenv
 * .travis.yml: assume that before_script change directory applies to script too
 * .travis.yml: restore sendmail stubbing
 * .travis.yml: download Drupal 7.x, not 8.x
 * .travis.yml: do not alter sendmail_path for site install
 * .travis.yml: initial attempt to fix the test logic for 7.x
 * Issue #2451857 by justanothermark: Extend og_user_access_entity to support skip_alter and ignore_admin
 * Issue #2411041 by hefox, mpotter, filsterjisah: Group manager always given default default role as og_is_member arguments wrong
 * Issue #2143733 by czigor, Angry Dan, dobe: EntityMalformedException with select og_audience widget if group content has no other fields
 * Issue #2471581 by Chewie, shelane: Missed asterisk for required Group audience field
 * Issue #1781386 by robertom, milos.kroulik: Context only set on primary node view page, nothing else
 * Fix tests by adding a missing new Drupal core permission
 * Fixed: og_help function in og.module refers now README.md.
 * Issue #2250177 by joelpittet, Devin Carlson, ezra-g: Improve performance of og_is_group()
 * Issue #121: Added option_definition for ['check_access'].
 * Issue #121: Added option in og_context_plugin_argument_default_group_context.inc to accompany the permission rewrite in og_context().
 * Fixed #125: Behavior for og_membership_delete_action
 * Fixed #120: New member state is pending, should be active when Admin adds user via profile widget
 * Issue #2151015 by hass, tmckeown, iaminawe: Migrate warnings