### PR TITLE
Provide a trait for creating memberships in tests

### DIFF
--- a/tests/src/Functional/GroupSubscribeTest.php
+++ b/tests/src/Functional/GroupSubscribeTest.php
@@ -10,6 +10,7 @@ use Drupal\og\Og;
 use Drupal\og\OgMembershipInterface;
 use Drupal\og\OgRoleInterface;
 use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\og\Traits\OgMembershipCreationTrait;
 
 /**
  * Tests subscribe and un-subscribe to groups.
@@ -17,6 +18,8 @@ use Drupal\Tests\BrowserTestBase;
  * @group og
  */
 class GroupSubscribeTest extends BrowserTestBase {
+
+  use OgMembershipCreationTrait;
 
   /**
    * {@inheritdoc}
@@ -278,8 +281,7 @@ class GroupSubscribeTest extends BrowserTestBase {
    * Tests access to un-subscribe page.
    */
   public function testUnSubscribeAccess() {
-    $membership = Og::createMembership($this->group1, $this->normalUser);
-    $membership->save();
+    $this->createOgMembership($this->group1, $this->normalUser);
 
     $this->drupalLogin($this->normalUser);
 

--- a/tests/src/Functional/GroupUpdateTest.php
+++ b/tests/src/Functional/GroupUpdateTest.php
@@ -2,15 +2,15 @@
 
 namespace Drupal\Tests\og\Functional;
 
+use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\node\Traits\ContentTypeCreationTrait;
+use Drupal\Tests\node\Traits\NodeCreationTrait;
 use Drupal\Tests\og\Traits\OgMembershipCreationTrait;
 use Drupal\entity_test\Entity\EntityTest;
 use Drupal\node\Entity\Node;
 use Drupal\og\Entity\OgRole;
 use Drupal\og\Og;
 use Drupal\og\OgAccess;
-use Drupal\simpletest\ContentTypeCreationTrait;
-use Drupal\simpletest\NodeCreationTrait;
-use Drupal\Tests\BrowserTestBase;
 
 /**
  * Tests the special permission 'update group'.

--- a/tests/src/Functional/GroupUpdateTest.php
+++ b/tests/src/Functional/GroupUpdateTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\og\Functional;
 
+use Drupal\Tests\og\Traits\OgMembershipCreationTrait;
 use Drupal\entity_test\Entity\EntityTest;
 use Drupal\node\Entity\Node;
 use Drupal\og\Entity\OgRole;
@@ -20,6 +21,7 @@ class GroupUpdateTest extends BrowserTestBase {
 
   use ContentTypeCreationTrait;
   use NodeCreationTrait;
+  use OgMembershipCreationTrait;
 
   /**
    * {@inheritdoc}
@@ -105,10 +107,7 @@ class GroupUpdateTest extends BrowserTestBase {
     $this->contentGroup->save();
 
     // Subscribe the editor user to the groups.
-    $membership = Og::createMembership($this->contentGroup, $this->groupEditor);
-    $membership
-      ->setRoles([$content_editor_role])
-      ->save();
+    $this->createOgMembership($this->contentGroup, $this->groupEditor, ['content_editor']);
   }
 
   /**
@@ -139,10 +138,7 @@ class GroupUpdateTest extends BrowserTestBase {
     $this->entityGroup = EntityTest::create($values);
     $this->entityGroup->save();
 
-    $membership = Og::createMembership($this->entityGroup, $this->groupEditor);
-    $membership
-      ->setRoles([$entity_editor_role])
-      ->save();
+    $this->createOgMembership($this->entityGroup, $this->groupEditor, ['entity_editor']);
   }
 
   /**

--- a/tests/src/Kernel/Access/AccessByOgMembershipTest.php
+++ b/tests/src/Kernel/Access/AccessByOgMembershipTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\og\Kernel\Access;
 
 use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\node\Traits\ContentTypeCreationTrait;
 use Drupal\Tests\og\Traits\OgMembershipCreationTrait;
 use Drupal\block_content\Entity\BlockContent;
 use Drupal\block_content\Entity\BlockContentType;
@@ -14,7 +15,6 @@ use Drupal\og\Og;
 use Drupal\og\OgGroupAudienceHelperInterface;
 use Drupal\og\OgMembershipInterface;
 use Drupal\og\OgRoleInterface;
-use Drupal\simpletest\ContentTypeCreationTrait;
 use Drupal\user\Entity\Role;
 use Drupal\user\Entity\User;
 

--- a/tests/src/Kernel/Access/AccessByOgMembershipTest.php
+++ b/tests/src/Kernel/Access/AccessByOgMembershipTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\og\Kernel\Access;
 
 use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\og\Traits\OgMembershipCreationTrait;
 use Drupal\block_content\Entity\BlockContent;
 use Drupal\block_content\Entity\BlockContentType;
 use Drupal\node\Entity\Node;
@@ -25,6 +26,7 @@ use Drupal\user\Entity\User;
 class AccessByOgMembershipTest extends KernelTestBase {
 
   use ContentTypeCreationTrait;
+  use OgMembershipCreationTrait;
 
   /**
    * {@inheritdoc}
@@ -143,14 +145,7 @@ class AccessByOgMembershipTest extends KernelTestBase {
     // Subscribe the normal member and the blocked member to the group.
     foreach (['member', 'blocked'] as $membership_type) {
       $state = $membership_type === 'member' ? OgMembershipInterface::STATE_ACTIVE : OgMembershipInterface::STATE_BLOCKED;
-      /** @var \Drupal\og\Entity\OgMembership $membership */
-      $membership = OgMembership::create();
-      $membership
-        ->setOwner($this->users[$membership_type])
-        ->setGroup($this->group)
-        ->addRole($role)
-        ->setState($state)
-        ->save();
+      $this->createOgMembership($this->group, $this->users[$membership_type], NULL, $state);
     }
 
     // Create three group content items, one owned by the group owner, one by

--- a/tests/src/Kernel/Access/OgAccessHookTest.php
+++ b/tests/src/Kernel/Access/OgAccessHookTest.php
@@ -8,9 +8,11 @@ use Drupal\block_content\Entity\BlockContent;
 use Drupal\block_content\Entity\BlockContentType;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
+use Drupal\og\Entity\OgRole;
 use Drupal\og\Og;
 use Drupal\og\OgGroupAudienceHelperInterface;
 use Drupal\og\OgMembershipInterface;
+use Drupal\og\OgRoleInterface;
 use Drupal\user\Entity\Role;
 use Drupal\user\Entity\User;
 
@@ -148,9 +150,7 @@ class OgAccessHookTest extends KernelTestBase {
 
     // Grant members permission to edit their own content.
     /** @var \Drupal\og\Entity\OgRole $role */
-    $role = $this->container->get('entity_type.manager')
-      ->getStorage('og_role')
-      ->load('block_content-group-member');
+    $role = OgRole::getRole('block_content', 'group', OgRoleInterface::AUTHENTICATED);
     $role->grantPermission('edit own group_content content');
     $role->save();
 

--- a/tests/src/Kernel/Access/OgAccessHookTest.php
+++ b/tests/src/Kernel/Access/OgAccessHookTest.php
@@ -3,11 +3,11 @@
 namespace Drupal\Tests\og\Kernel\Access;
 
 use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\og\Traits\OgMembershipCreationTrait;
 use Drupal\block_content\Entity\BlockContent;
 use Drupal\block_content\Entity\BlockContentType;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
-use Drupal\og\Entity\OgMembership;
 use Drupal\og\Og;
 use Drupal\og\OgGroupAudienceHelperInterface;
 use Drupal\og\OgMembershipInterface;
@@ -20,6 +20,8 @@ use Drupal\user\Entity\User;
  * @group og
  */
 class OgAccessHookTest extends KernelTestBase {
+
+  use OgMembershipCreationTrait;
 
   /**
    * {@inheritdoc}
@@ -155,14 +157,7 @@ class OgAccessHookTest extends KernelTestBase {
     // Subscribe the normal member and the blocked member to the group.
     foreach (['member', 'blocked'] as $membership_type) {
       $state = $membership_type === 'member' ? OgMembershipInterface::STATE_ACTIVE : OgMembershipInterface::STATE_BLOCKED;
-      /** @var \Drupal\og\Entity\OgMembership $membership */
-      $membership = OgMembership::create();
-      $membership
-        ->setOwner($this->users[$membership_type])
-        ->setGroup($this->group)
-        ->addRole($role)
-        ->setState($state)
-        ->save();
+      $this->createOgMembership($this->group, $this->users[$membership_type], NULL, $state);
     }
 
     // Create three group content items, one owned by the group owner, one by

--- a/tests/src/Kernel/Access/OgGroupContentOperationAccessTest.php
+++ b/tests/src/Kernel/Access/OgGroupContentOperationAccessTest.php
@@ -6,12 +6,12 @@ use Drupal\comment\Entity\CommentType;
 use Drupal\entity_test\Entity\EntityTest;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\node\Entity\NodeType;
-use Drupal\og\Entity\OgMembership;
 use Drupal\og\Entity\OgRole;
 use Drupal\og\Og;
 use Drupal\og\OgGroupAudienceHelperInterface;
 use Drupal\og\OgMembershipInterface;
 use Drupal\og\OgRoleInterface;
+use Drupal\Tests\og\Traits\OgMembershipCreationTrait;
 use Drupal\user\Entity\User;
 
 /**
@@ -20,6 +20,8 @@ use Drupal\user\Entity\User;
  * @group og
  */
 class OgGroupContentOperationAccessTest extends KernelTestBase {
+
+  use OgMembershipCreationTrait;
 
   /**
    * {@inheritdoc}
@@ -167,14 +169,7 @@ class OgGroupContentOperationAccessTest extends KernelTestBase {
       // fine to save this membership, but in the most common use case this
       // membership will not exist in the database.
       if ($role_name !== OgRoleInterface::ANONYMOUS) {
-        /** @var \Drupal\og\Entity\OgMembership $membership */
-        $membership = OgMembership::create();
-        $membership
-          ->setOwner($this->users[$role_name])
-          ->setGroup($this->group)
-          ->addRole($this->roles[$role_name])
-          ->setState(OgMembershipInterface::STATE_ACTIVE)
-          ->save();
+        $this->createOgMembership($this->group, $this->users[$role_name], [$role_name]);
       }
     }
 
@@ -182,13 +177,7 @@ class OgGroupContentOperationAccessTest extends KernelTestBase {
     // 'authenticated' member, except that she has the 'blocked' state.
     $this->users['blocked'] = User::create(['name' => $this->randomString()]);
     $this->users['blocked']->save();
-    $membership = OgMembership::create();
-    $membership
-      ->setOwner($this->users['blocked'])
-      ->setGroup($this->group)
-      ->addRole($this->roles[OgRoleInterface::AUTHENTICATED])
-      ->setState(OgMembershipInterface::STATE_BLOCKED)
-      ->save();
+    $this->createOgMembership($this->group, $this->users['blocked'], NULL, OgMembershipInterface::STATE_BLOCKED);
 
     // Create a 'newsletter' group content type. We are using the Comment entity
     // for this to verify that this functionality works for all entity types. We

--- a/tests/src/Kernel/Action/ActionTestBase.php
+++ b/tests/src/Kernel/Action/ActionTestBase.php
@@ -6,12 +6,12 @@ use Drupal\Core\Access\AccessResultAllowed;
 use Drupal\Core\Session\AnonymousUserSession;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\Tests\og\Traits\OgMembershipCreationTrait;
+use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
 use Drupal\og\Entity\OgRole;
 use Drupal\og\OgMembershipInterface;
 use Drupal\og\OgRoleInterface;
-use Drupal\simpletest\UserCreationTrait;
 
 /**
  * Base class for testing action plugins.

--- a/tests/src/Kernel/Action/ActionTestBase.php
+++ b/tests/src/Kernel/Action/ActionTestBase.php
@@ -5,6 +5,7 @@ namespace Drupal\Tests\og\Kernel\Action;
 use Drupal\Core\Access\AccessResultAllowed;
 use Drupal\Core\Session\AnonymousUserSession;
 use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\og\Traits\OgMembershipCreationTrait;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
 use Drupal\og\Entity\OgRole;
@@ -17,6 +18,7 @@ use Drupal\simpletest\UserCreationTrait;
  */
 abstract class ActionTestBase extends KernelTestBase {
 
+  use OgMembershipCreationTrait;
   use UserCreationTrait;
 
   /**
@@ -145,29 +147,24 @@ abstract class ActionTestBase extends KernelTestBase {
 
     // A normal member of the test group.
     $this->users['member'] = $this->createUser();
-    $this->memberships['member'] = $this->membershipManager->createMembership($this->group, $this->users['member']);
-    $this->memberships['member']->save();
+    $this->memberships['member'] = $this->createOgMembership($this->group, $this->users['member']);
 
     // A pending member of the test group.
     $this->users['pending'] = $this->createUser();
-    $this->memberships['pending'] = $this->membershipManager->createMembership($this->group, $this->users['pending'])->setState(OgMembershipInterface::STATE_PENDING);
-    $this->memberships['pending']->save();
+    $this->memberships['pending'] = $this->createOgMembership($this->group, $this->users['pending'], NULL, OgMembershipInterface::STATE_PENDING);
 
     // A blocked member of the test group.
     $this->users['blocked'] = $this->createUser();
-    $this->memberships['blocked'] = $this->membershipManager->createMembership($this->group, $this->users['blocked'])->setState(OgMembershipInterface::STATE_BLOCKED);
-    $this->memberships['blocked']->save();
+    $this->memberships['blocked'] = $this->createOgMembership($this->group, $this->users['blocked'], NULL, OgMembershipInterface::STATE_BLOCKED);
 
     // A group administrator. This is a special case since this role is
     // considered to have all permissions.
     $this->users['group_administrator'] = $this->createUser();
-    $this->memberships['group_administrator'] = $this->membershipManager->createMembership($this->group, $this->users['group_administrator'])->addRole($this->roles['administrator']);
-    $this->memberships['group_administrator']->save();
+    $this->memberships['group_administrator'] = $this->createOgMembership($this->group, $this->users['group_administrator'], [OgRoleInterface::AUTHENTICATED, OgRoleInterface::ADMINISTRATOR]);
 
     // A group moderator that has the right to administer group members.
     $this->users['group_moderator'] = $this->createUser();
-    $this->memberships['group_moderator'] = $this->membershipManager->createMembership($this->group, $this->users['group_moderator'])->addRole($this->roles['moderator']);
-    $this->memberships['group_moderator']->save();
+    $this->memberships['group_moderator'] = $this->createOgMembership($this->group, $this->users['group_moderator'], [OgRoleInterface::AUTHENTICATED, 'moderator']);
   }
 
   /**

--- a/tests/src/Kernel/Entity/GetMembershipsTest.php
+++ b/tests/src/Kernel/Entity/GetMembershipsTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\og\Kernel\Entity;
 
 use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\og\Traits\OgMembershipCreationTrait;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
 use Drupal\og\Og;
@@ -16,6 +17,8 @@ use Drupal\user\Entity\User;
  * @coversDefaultClass \Drupal\og\Og
  */
 class GetMembershipsTest extends KernelTestBase {
+
+  use OgMembershipCreationTrait;
 
   /**
    * {@inheritdoc}
@@ -113,10 +116,7 @@ class GetMembershipsTest extends KernelTestBase {
       foreach ($statuses as $group_key => $status) {
         $group = $this->groups[$group_key];
         if ($status) {
-          $membership = Og::createMembership($group, $user);
-          $membership
-            ->setState($status)
-            ->save();
+          $this->createOgMembership($group, $user, NULL, $status);
         }
       }
     }

--- a/tests/src/Kernel/Entity/GetMembershipsTest.php
+++ b/tests/src/Kernel/Entity/GetMembershipsTest.php
@@ -90,7 +90,7 @@ class GetMembershipsTest extends KernelTestBase {
       $this->groups[] = $group;
     }
 
-    // Create test users with different membership statuses in the two groups.
+    // Create test users with different membership states in the two groups.
     $matrix = [
       // A user which is an active member of the first group.
       [OgMembershipInterface::STATE_ACTIVE, NULL],
@@ -109,14 +109,14 @@ class GetMembershipsTest extends KernelTestBase {
       [NULL, NULL],
     ];
 
-    foreach ($matrix as $user_key => $statuses) {
+    foreach ($matrix as $user_key => $states) {
       $user = User::create(['name' => $this->randomString()]);
       $user->save();
       $this->users[$user_key] = $user;
-      foreach ($statuses as $group_key => $status) {
+      foreach ($states as $group_key => $state) {
         $group = $this->groups[$group_key];
-        if ($status) {
-          $this->createOgMembership($group, $user, NULL, $status);
+        if ($state) {
+          $this->createOgMembership($group, $user, NULL, $state);
         }
       }
     }

--- a/tests/src/Kernel/Entity/GetUserGroupsTest.php
+++ b/tests/src/Kernel/Entity/GetUserGroupsTest.php
@@ -2,8 +2,9 @@
 
 namespace Drupal\Tests\og\Kernel\Entity;
 
-use Drupal\entity_test\Entity\EntityTest;
 use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\og\Traits\OgMembershipCreationTrait;
+use Drupal\entity_test\Entity\EntityTest;
 use Drupal\og\Og;
 use Drupal\og\OgMembershipInterface;
 use Drupal\user\Entity\User;
@@ -14,6 +15,8 @@ use Drupal\user\Entity\User;
  * @group og
  */
 class GetUserGroupsTest extends KernelTestBase {
+
+  use OgMembershipCreationTrait;
 
   /**
    * {@inheritdoc}
@@ -163,7 +166,7 @@ class GetUserGroupsTest extends KernelTestBase {
     Og::invalidateCache();
 
     // Add user to group 1 should now return that group only.
-    $this->createMembership($this->user3, $this->group1);
+    $this->createOgMembership($this->group1, $this->user3);
 
     $actual = $membership_manager->getUserGroups($this->user3);
 
@@ -176,7 +179,7 @@ class GetUserGroupsTest extends KernelTestBase {
     Og::invalidateCache();
 
     // Add to group 2 should also return that.
-    $this->createMembership($this->user3, $this->group2);
+    $this->createOgMembership($this->group2, $this->user3);
 
     $actual = $membership_manager->getUserGroups($this->user3);
 
@@ -193,7 +196,7 @@ class GetUserGroupsTest extends KernelTestBase {
    */
   public function testIsMemberStates() {
     // Add user to group 1 should now return that group only.
-    $membership = $this->createMembership($this->user3, $this->group1);
+    $membership = $this->createOgMembership($this->group1, $this->user3);
 
     // Default param is ACTIVE.
     $this->assertTrue(Og::isMember($this->group1, $this->user3));
@@ -229,30 +232,6 @@ class GetUserGroupsTest extends KernelTestBase {
     $this->assertFalse(Og::isMember($this->group1, $this->user3));
     $this->assertFalse(Og::isMember($this->group1, $this->user3, [OgMembershipInterface::STATE_PENDING]));
     $this->assertFalse(Og::isMemberPending($this->group1, $this->user3));
-  }
-
-  /**
-   * Creates an Og membership entity.
-   *
-   * @todo This is a temp function, which will be later replaced by Og::group().
-   *
-   * @param \Drupal\user\Entity\User $user
-   *   The user object to create membership for.
-   * @param \Drupal\entity_test\Entity\EntityTest $group
-   *   The entity to create the membership for.
-   * @param int $state
-   *   The state of the membership.
-   *
-   * @return \Drupal\og\OgMembershipInterface
-   *   The saved OG membership entity.
-   */
-  protected function createMembership(User $user, EntityTest $group, $state = OgMembershipInterface::STATE_ACTIVE) {
-    $membership = Og::createMembership($group, $user);
-    $membership
-      ->setState($state)
-      ->save();
-
-    return $membership;
   }
 
   /**

--- a/tests/src/Traits/OgMembershipCreationTrait.php
+++ b/tests/src/Traits/OgMembershipCreationTrait.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Drupal\Tests\og\Traits;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\og\Entity\OgMembership;
+use Drupal\og\Entity\OgRole;
+use Drupal\og\OgMembershipInterface;
+use Drupal\og\OgRoleInterface;
+
+/**
+ * Provides a method to create memberships for testing purposes.
+ *
+ * This trait is meant to be used only by test classes.
+ */
+trait OgMembershipCreationTrait {
+
+  /**
+   * Creates a test membership.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $group
+   *   The group for which to create the membership.
+   * @param \Drupal\Core\Session\AccountInterface $user
+   *   The user for which to create the membership.
+   * @param array $role_names
+   *   Optional array of role names to assign to the membership. Defaults to the
+   *   'member' role.
+   * @param string $state
+   *   Optional membership state. Can be one of the following constants:
+   *   - OgMembershipInterface::STATE_ACTIVE
+   *   - OgMembershipInterface::STATE_PENDING
+   *   - OgMembershipInterface::STATE_BLOCKED
+   *   Defaults to OgMembershipInterface::STATE_ACTIVE.
+   * @param string $membership_type
+   *   The membership type. Defaults to 'default'.
+   *
+   * @return \Drupal\og\OgMembershipInterface
+   *   The membership.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   *   Thrown when the membership cannot be created.
+   */
+  protected function createOgMembership(EntityInterface $group, AccountInterface $user, array $role_names = NULL, $state = NULL, $membership_type = NULL) {
+    // Provide default values.
+    $role_names = $role_names ?: [OgRoleInterface::AUTHENTICATED];
+    $state = $state ?: OgMembershipInterface::STATE_ACTIVE;
+    $membership_type = $membership_type ?: OgMembershipInterface::TYPE_DEFAULT;
+
+    $group_entity_type = $group->getEntityTypeId();
+    $group_bundle = $group->bundle();
+
+    $roles = array_map(function ($role_name) use ($group_entity_type, $group_bundle) {
+      return OgRole::getRole($group_entity_type, $group_bundle, $role_name);
+    }, $role_names);
+
+    /** @var \Drupal\og\OgMembershipInterface $membership */
+    $membership = OgMembership::create(['type' => $membership_type]);
+    $membership
+      ->setRoles($roles)
+      ->setState($state)
+      ->setOwner($user)
+      ->setGroup($group)
+      ->save();
+
+    return $membership;
+  }
+
+}


### PR DESCRIPTION
This PR adds a `OgMembershipCreationTrait` which contains a reusable method to create memberships during tests. This is similar to test traits provided in core (`ContentTypeCreationTrait` etc). It helps to reduce verbosity in setting up our functional tests and kernel tests.

I applied the trait wherever applicable, but I did not update any tests that are directly testing methods such as `MembershipManager::createMembership()` and `OgMembership::create()`, as well as tests that deal with unsaved memberships.

During the refactoring I also performed a few small cleanups of the test code.