### PR TITLE
Test on current versions of Drupal and PHP.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,12 @@ php:
   - 7.2
 
 env:
-  - TEST_SUITE=8.5.x
-  - TEST_SUITE=8.6.x
-  - TEST_SUITE=PHP_CodeSniffer
+  global:
+    - COMPOSER_MEMORY_LIMIT=2G
+  matrix:
+    - TEST_SUITE=8.5.x
+    - TEST_SUITE=8.6.x
+    - TEST_SUITE=PHP_CodeSniffer
 
 # Only run the coding standards check once.
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,11 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
 
 env:
-  - TEST_SUITE=8.3.x
-  - TEST_SUITE=8.4.x
+  - TEST_SUITE=8.5.x
+  - TEST_SUITE=8.6.x
   - TEST_SUITE=PHP_CodeSniffer
 
 # Only run the coding standards check once.
@@ -18,6 +19,10 @@ matrix:
       env: TEST_SUITE=PHP_CodeSniffer
     - php: 7.0
       env: TEST_SUITE=PHP_CodeSniffer
+    - php: 7.1
+      env: TEST_SUITE=PHP_CodeSniffer
+  allow_failures:
+    - env: TEST_SUITE=8.6.x
 
 mysql:
   database: og
@@ -54,12 +59,13 @@ before_script:
 
   # Download Drupal console so we can run the test for it. Skip this for the
   # coding standards test.
-  # Drupal console doesn't support Drupal 8.4.x so only require it on 8.3.x.
-  # See https://github.com/hechoendrupal/drupal-console-core/issues/151
-  - test ${TEST_SUITE} == "PHP_CodeSniffer" || test ${TEST_SUITE} == "8.3.x" && composer require --dev drupal/console:~1.0@rc --working-dir=$DRUPAL_DIR || true
+  - test ${TEST_SUITE} == "PHP_CodeSniffer" || composer require --dev drupal/console:~1.0 --working-dir=$DRUPAL_DIR
 
   # Install Composer dependencies for core. Skip this for the coding standards test.
   - test ${TEST_SUITE} == "PHP_CodeSniffer" || composer install --working-dir=$DRUPAL_DIR
+
+  # PHPUnit 6 is required when running tests on PHP 7.x.
+  - test ${TEST_SUITE} == "PHP_CodeSniffer" || test ${TRAVIS_PHP_VERSION:0:3} == "5.6" || composer require --dev phpunit/phpunit:~6 --update-with-dependencies --working-dir=$DRUPAL_DIR
 
   # Start a web server on port 8888 in the background.
   - test ${TEST_SUITE} == "PHP_CodeSniffer" || nohup php -S localhost:8888 --docroot $DRUPAL_DIR > /dev/null 2>&1 &

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,9 @@
         "irc": "irc://irc.freenode.org/drupal-og",
         "source": "https://cgit.drupalcode.org/og"
     },
+    "require": {
+        "drupal/core": "~8.5"
+    },
     "require-dev": {
         "drupal/coder": "~8.2"
     }

--- a/scripts/travis-ci/run-test.sh
+++ b/scripts/travis-ci/run-test.sh
@@ -20,8 +20,7 @@ case "$1" in
         ./vendor/bin/phpcs
         exit $?
         ;;
-    # Drupal console only works on Drupal 8.3.x.
-    8.3.x)
+    *)
         mysql_to_ramdisk
         ln -s $MODULE_DIR $DRUPAL_DIR/modules/og
         cd $DRUPAL_DIR
@@ -29,17 +28,6 @@ case "$1" in
         for i in ${TEST_DIRS[@]}; do
           echo " > Executing tests from $i"
           ./vendor/bin/phpunit -c ./core/phpunit.xml.dist $i || EXIT=1
-        done
-        exit $EXIT
-        ;;
-    *)
-        mysql_to_ramdisk
-        ln -s $MODULE_DIR $DRUPAL_DIR/modules/og
-        cd $DRUPAL_DIR
-        EXIT=0
-        for i in ${TEST_DIRS[@]}; do
-          echo " > Executing tests from $i (excluding console group)"
-          ./vendor/bin/phpunit -c ./core/phpunit.xml.dist --exclude-group=console $i || EXIT=1
         done
         exit $EXIT
 esac

--- a/src/Form/GroupSubscribeForm.php
+++ b/src/Form/GroupSubscribeForm.php
@@ -42,8 +42,11 @@ class GroupSubscribeForm extends ContentEntityForm {
    * @param \Drupal\Component\Datetime\TimeInterface $time
    *   The time service.
    *
-   * @todo Set the correct type hint on the second argument when Drupal 8.6.0 is
-   *   released. It is currently omitted to preserve backwards compatibility.
+   * @todo Set the `EntityRepositoryInterface` type hint on the second argument
+   *   once Drupal 8.6.0 is released. It is currently omitted to preserve
+   *   backwards compatibility with Drupal 8.5.x and earlier.
+   *
+   * @see https://github.com/Gizra/og/issues/397
    */
   public function __construct(OgAccessInterface $og_access, $entity_repository, EntityTypeBundleInfoInterface $entity_type_bundle_info = NULL, TimeInterface $time = NULL) {
     parent::__construct($entity_repository, $entity_type_bundle_info, $time);

--- a/src/Form/GroupSubscribeForm.php
+++ b/src/Form/GroupSubscribeForm.php
@@ -2,10 +2,13 @@
 
 namespace Drupal\og\Form;
 
+use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Entity\ContentEntityForm;
+use Drupal\Core\Entity\EntityRepositoryInterface;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
-use Drupal\og\OgAccess;
+use Drupal\og\OgAccessInterface;
 use Drupal\og\OgMembershipInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -23,23 +26,50 @@ class GroupSubscribeForm extends ContentEntityForm {
   /**
    * OG access service.
    *
-   * @var \Drupal\og\OgAccess
+   * @var \Drupal\og\OgAccessInterface
    */
   protected $ogAccess;
 
   /**
-   * Constructs a SubscriptionController object.
+   * Constructs a GroupSubscribeForm.
+   *
+   * @param \Drupal\og\OgAccessInterface $og_access
+   *   The OG access service.
+   * @param \Drupal\Core\Entity\EntityRepositoryInterface|\Drupal\Core\Entity\EntityManagerInterface $entity_repository
+   *   The entity repository service.
+   * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entity_type_bundle_info
+   *   The entity type bundle service.
+   * @param \Drupal\Component\Datetime\TimeInterface $time
+   *   The time service.
+   *
+   * @todo Set the correct type hint on the second argument when Drupal 8.6.0 is
+   *   released. It is currently omitted to preserve backwards compatibility.
    */
-  public function __construct(OgAccess $og_access) {
+  public function __construct(OgAccessInterface $og_access, $entity_repository, EntityTypeBundleInfoInterface $entity_type_bundle_info = NULL, TimeInterface $time = NULL) {
+    parent::__construct($entity_repository, $entity_type_bundle_info, $time);
     $this->ogAccess = $og_access;
   }
 
   /**
    * {@inheritdoc}
+   *
+   * @todo Remove the workaround for 8.5.x backwards compatibility when 8.6.0 is
+   *   released.
    */
   public static function create(ContainerInterface $container) {
+    // Starting with Drupal 8.6.0 the parent class is expecting that the
+    // entity repository service is passed in as the first argument. In older
+    // versions this was the entity manager. Detect the type hint of the first
+    // argument of the parent constructor and pass the right service.
+    $parent_constructor_parameters = (new \ReflectionClass(parent::class))->getMethod('__construct')->getParameters();
+    $entity_repository_class_name = $parent_constructor_parameters[0]->getClass()->getName();
+    $entity_repository_service = $entity_repository_class_name === EntityRepositoryInterface::class ? 'entity.repository' : 'entity.manager';
+
     return new static(
-      $container->get('og.access')
+      $container->get('og.access'),
+      $container->get($entity_repository_service),
+      $container->get('entity_type.bundle.info'),
+      $container->get('datetime.time')
     );
   }
 

--- a/src/Form/OgChangeMultipleRolesFormBase.php
+++ b/src/Form/OgChangeMultipleRolesFormBase.php
@@ -6,10 +6,10 @@ use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\TempStore\PrivateTempStoreFactory;
 use Drupal\og\Entity\OgMembership;
 use Drupal\og\Entity\OgRole;
 use Drupal\og\OgAccessInterface;
-use Drupal\user\PrivateTempStoreFactory;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -34,14 +34,14 @@ class OgChangeMultipleRolesFormBase extends FormBase {
   /**
    * The tempstore factory.
    *
-   * @var \Drupal\user\PrivateTempStoreFactory
+   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
    */
   protected $tempStoreFactory;
 
   /**
    * The temporary storage for the current user.
    *
-   * @var \Drupal\user\PrivateTempStore
+   * @var \Drupal\Core\TempStore\PrivateTempStore
    */
   protected $tempStore;
 
@@ -55,7 +55,7 @@ class OgChangeMultipleRolesFormBase extends FormBase {
   /**
    * Constructs a OgChangeMultipleRolesFormbase object.
    *
-   * @param \Drupal\user\PrivateTempStoreFactory $temp_store_factory
+   * @param \Drupal\Core\TempStore\PrivateTempStoreFactory $temp_store_factory
    *   The tempstore factory.
    * @param \Drupal\og\OgAccessInterface $og_access
    *   The OG access service.
@@ -70,7 +70,7 @@ class OgChangeMultipleRolesFormBase extends FormBase {
    */
   public static function create(ContainerInterface $container) {
     return new static(
-      $container->get('user.private_tempstore'),
+      $container->get('tempstore.private'),
       $container->get('og.access')
     );
   }
@@ -144,7 +144,7 @@ class OgChangeMultipleRolesFormBase extends FormBase {
   /**
    * Returns the temporary storage for the current user.
    *
-   * @return \Drupal\user\PrivateTempStore
+   * @return \Drupal\Core\TempStore\PrivateTempStore
    *   The temporary storage for the current user.
    */
   protected function getTempStore() {

--- a/src/Plugin/Action/ChangeMultipleOgMembershipRolesBase.php
+++ b/src/Plugin/Action/ChangeMultipleOgMembershipRolesBase.php
@@ -5,9 +5,9 @@ namespace Drupal\og\Plugin\Action;
 use Drupal\Core\Action\ActionBase;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\TempStore\PrivateTempStoreFactory;
 use Drupal\og\OgAccessInterface;
 use Drupal\og\OgMembershipInterface;
-use Drupal\user\PrivateTempStoreFactory;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -25,7 +25,7 @@ abstract class ChangeMultipleOgMembershipRolesBase extends ActionBase implements
   /**
    * The private temporary storage.
    *
-   * @var \Drupal\user\PrivateTempStore
+   * @var \Drupal\Core\TempStore\PrivateTempStore
    */
   protected $tempStore;
 
@@ -40,7 +40,7 @@ abstract class ChangeMultipleOgMembershipRolesBase extends ActionBase implements
    *   The plugin implementation definition.
    * @param \Drupal\og\OgAccessInterface $og_access
    *   The OG access service.
-   * @param \Drupal\user\PrivateTempStoreFactory $temp_store_factory
+   * @param \Drupal\Core\TempStore\PrivateTempStoreFactory $temp_store_factory
    *   The private temporary storage factory.
    */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, OgAccessInterface $og_access, PrivateTempStoreFactory $temp_store_factory) {
@@ -58,7 +58,7 @@ abstract class ChangeMultipleOgMembershipRolesBase extends ActionBase implements
       $plugin_id,
       $plugin_definition,
       $container->get('og.access'),
-      $container->get('user.private_tempstore')
+      $container->get('tempstore.private')
     );
   }
 

--- a/tests/src/Functional/GroupSubscribeFormatterTest.php
+++ b/tests/src/Functional/GroupSubscribeFormatterTest.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\Tests\og\Functional;
 
-use Drupal\Component\Utility\Unicode;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
 use Drupal\og\Og;
@@ -57,7 +56,7 @@ class GroupSubscribeFormatterTest extends BrowserTestBase {
     parent::setUp();
 
     // Create bundle.
-    $this->groupBundle = Unicode::strtolower($this->randomMachineName());
+    $this->groupBundle = mb_strtolower($this->randomMachineName());
 
     // Create a node type.
     $node_type = NodeType::create(['type' => $this->groupBundle, 'name' => $this->groupBundle]);

--- a/tests/src/Functional/GroupSubscribeTest.php
+++ b/tests/src/Functional/GroupSubscribeTest.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\Tests\og\Functional;
 
-use Drupal\Component\Utility\Unicode;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
 use Drupal\og\Entity\OgMembershipType;
@@ -94,13 +93,13 @@ class GroupSubscribeTest extends BrowserTestBase {
     parent::setUp();
 
     // Create bundles.
-    $this->groupBundle1 = Unicode::strtolower($this->randomMachineName());
+    $this->groupBundle1 = mb_strtolower($this->randomMachineName());
     NodeType::create(['type' => $this->groupBundle1])->save();
-    $this->groupBundle2 = Unicode::strtolower($this->randomMachineName());
+    $this->groupBundle2 = mb_strtolower($this->randomMachineName());
     NodeType::create(['type' => $this->groupBundle2])->save();
-    $this->nonGroupBundle = Unicode::strtolower($this->randomMachineName());
+    $this->nonGroupBundle = mb_strtolower($this->randomMachineName());
     NodeType::create(['type' => $this->nonGroupBundle])->save();
-    $this->membershipTypeBundle = Unicode::strtolower($this->randomMachineName());
+    $this->membershipTypeBundle = mb_strtolower($this->randomMachineName());
     NodeType::create(['type' => $this->membershipTypeBundle])->save();
 
     // Define the entities as groups.
@@ -186,7 +185,7 @@ class GroupSubscribeTest extends BrowserTestBase {
       [
         'entity' => $this->group1,
         // Set invalid membership type.
-        'membership_type' => Unicode::strtolower($this->randomMachineName()),
+        'membership_type' => mb_strtolower($this->randomMachineName()),
         'code' => 404,
       ],
       // Group with pending membership.
@@ -214,7 +213,7 @@ class GroupSubscribeTest extends BrowserTestBase {
       ],
       // A non existing entity type.
       [
-        'entity_type_id' => Unicode::strtolower($this->randomMachineName()),
+        'entity_type_id' => mb_strtolower($this->randomMachineName()),
         'entity_id' => 1,
         // @todo This currently returns a 500 error due to a bug in core. Change
         //   this to a 403 or 404 when the bug is fixed.

--- a/tests/src/Functional/GroupTabTest.php
+++ b/tests/src/Functional/GroupTabTest.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\Tests\og\Functional;
 
-use Drupal\Component\Utility\Unicode;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
 use Drupal\og\Og;
@@ -55,8 +54,8 @@ class GroupTabTest extends BrowserTestBase {
     parent::setUp();
 
     // Create bundles.
-    $this->bundle1 = Unicode::strtolower($this->randomMachineName());
-    $this->bundle2 = Unicode::strtolower($this->randomMachineName());
+    $this->bundle1 = mb_strtolower($this->randomMachineName());
+    $this->bundle2 = mb_strtolower($this->randomMachineName());
 
     // Create node types.
     $node_type1 = NodeType::create(['type' => $this->bundle1, 'name' => $this->bundle1]);

--- a/tests/src/Functional/OgComplexWidgetTest.php
+++ b/tests/src/Functional/OgComplexWidgetTest.php
@@ -89,7 +89,7 @@ class OgComplexWidgetTest extends BrowserTestBase {
 
     // Retrieve the post that was created from the database.
     /** @var QueryInterface $query */
-    $query = $this->container->get('entity.query')->get('node');
+    $query = $this->container->get('entity_type.manager')->getStorage('node')->getQuery();
     $result = $query
       ->condition('type', 'post')
       ->range(0, 1)

--- a/tests/src/Kernel/Access/OgEntityAccessTest.php
+++ b/tests/src/Kernel/Access/OgEntityAccessTest.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\Tests\og\Kernel\Access;
 
-use Drupal\Component\Utility\Unicode;
 use Drupal\entity_test\Entity\EntityTest;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\og\Entity\OgRole;
@@ -146,7 +145,7 @@ class OgEntityAccessTest extends KernelTestBase {
     $this->installEntitySchema('entity_test');
     $this->installSchema('system', 'sequences');
 
-    $this->groupBundle = Unicode::strtolower($this->randomMachineName());
+    $this->groupBundle = mb_strtolower($this->randomMachineName());
 
     // Create users, and make sure user ID 1 isn't used.
     User::create(['name' => $this->randomString()]);

--- a/tests/src/Kernel/Access/OgGroupContentOperationAccessTest.php
+++ b/tests/src/Kernel/Access/OgGroupContentOperationAccessTest.php
@@ -3,7 +3,6 @@
 namespace Drupal\Tests\og\Kernel\Access;
 
 use Drupal\comment\Entity\CommentType;
-use Drupal\Component\Utility\Unicode;
 use Drupal\entity_test\Entity\EntityTest;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\node\Entity\NodeType;
@@ -95,7 +94,7 @@ class OgGroupContentOperationAccessTest extends KernelTestBase {
 
     $this->entityTypeManager = $this->container->get('entity_type.manager');
 
-    $this->groupBundle = Unicode::strtolower($this->randomMachineName());
+    $this->groupBundle = mb_strtolower($this->randomMachineName());
 
     // Create a test user with UID 1. This user has universal access.
     $this->users['uid1'] = User::create(['name' => $this->randomString()]);

--- a/tests/src/Kernel/Action/ActionTestBase.php
+++ b/tests/src/Kernel/Action/ActionTestBase.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\Tests\og\Kernel\Action;
 
-use Drupal\Component\Utility\Unicode;
 use Drupal\Core\Access\AccessResultAllowed;
 use Drupal\Core\Session\AnonymousUserSession;
 use Drupal\KernelTests\KernelTestBase;
@@ -96,7 +95,7 @@ abstract class ActionTestBase extends KernelTestBase {
     $this->users['group_owner'] = $this->createUser();
 
     // Create a group entity type.
-    $group_bundle = Unicode::strtolower($this->randomMachineName());
+    $group_bundle = mb_strtolower($this->randomMachineName());
     NodeType::create([
       'type' => $group_bundle,
       'name' => $this->randomString(),

--- a/tests/src/Kernel/Action/ChangeMultipleOgMembershipRolesActionTestBase.php
+++ b/tests/src/Kernel/Action/ChangeMultipleOgMembershipRolesActionTestBase.php
@@ -10,7 +10,7 @@ class ChangeMultipleOgMembershipRolesActionTestBase extends ChangeOgMembershipAc
   /**
    * The factory for private temporary storage objects.
    *
-   * @var \Drupal\user\PrivateTempStoreFactory
+   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
    */
   protected $tempStorageFactory;
 
@@ -29,7 +29,7 @@ class ChangeMultipleOgMembershipRolesActionTestBase extends ChangeOgMembershipAc
 
     $this->installSchema('system', ['key_value_expire']);
 
-    $this->tempStorageFactory = $this->container->get('user.private_tempstore');
+    $this->tempStorageFactory = $this->container->get('tempstore.private');
 
     // Set up the group administrator as the user that will be logged in during
     // the tests.

--- a/tests/src/Kernel/Entity/FieldCreateTest.php
+++ b/tests/src/Kernel/Entity/FieldCreateTest.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\Tests\og\Kernel\Entity;
 
-use Drupal\Component\Utility\Unicode;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\node\Entity\NodeType;
 use Drupal\KernelTests\KernelTestBase;
@@ -52,7 +51,7 @@ class FieldCreateTest extends KernelTestBase {
     // Create several bundles.
     for ($i = 0; $i <= 4; $i++) {
       $bundle = NodeType::create([
-        'type' => Unicode::strtolower($this->randomMachineName()),
+        'type' => mb_strtolower($this->randomMachineName()),
         'name' => $this->randomString(),
       ]);
 

--- a/tests/src/Kernel/Entity/GetGroupContentTest.php
+++ b/tests/src/Kernel/Entity/GetGroupContentTest.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\Tests\og\Kernel\Entity;
 
-use Drupal\Component\Utility\Unicode;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\entity_test\Entity\EntityTest;
 use Drupal\node\Entity\Node;
@@ -74,7 +73,7 @@ class GetGroupContentTest extends KernelTestBase {
     $groups = [];
 
     // Create two groups of different entity types.
-    $bundle = Unicode::strtolower($this->randomMachineName());
+    $bundle = mb_strtolower($this->randomMachineName());
     NodeType::create([
       'name' => $this->randomString(),
       'type' => $bundle,
@@ -90,7 +89,7 @@ class GetGroupContentTest extends KernelTestBase {
 
     // The Entity Test entity doesn't have 'real' bundles, so we don't need to
     // create one, we can just add the group to the fake bundle.
-    $bundle = Unicode::strtolower($this->randomMachineName());
+    $bundle = mb_strtolower($this->randomMachineName());
     Og::groupTypeManager()->addGroup('entity_test', $bundle);
 
     $groups['entity_test'] = EntityTest::create([
@@ -107,7 +106,7 @@ class GetGroupContentTest extends KernelTestBase {
       foreach (['node', 'entity_test'] as $target_group_type) {
         // Create the group content bundle if it's a node. Entity Test doesn't
         // have real bundles.
-        $bundle = Unicode::strtolower($this->randomMachineName());
+        $bundle = mb_strtolower($this->randomMachineName());
         if ($entity_type === 'node') {
           NodeType::create([
             'type' => $bundle,
@@ -175,7 +174,7 @@ class GetGroupContentTest extends KernelTestBase {
     $groups = [];
 
     // Create two groups.
-    $bundle = Unicode::strtolower($this->randomMachineName());
+    $bundle = mb_strtolower($this->randomMachineName());
     NodeType::create([
       'name' => $this->randomString(),
       'type' => $bundle,
@@ -192,7 +191,7 @@ class GetGroupContentTest extends KernelTestBase {
     }
 
     // Create a group content type.
-    $bundle = Unicode::strtolower($this->randomMachineName());
+    $bundle = mb_strtolower($this->randomMachineName());
 
     $settings = [
       'field_storage_config' => [
@@ -233,7 +232,7 @@ class GetGroupContentTest extends KernelTestBase {
     $groups = [];
 
     // Create two groups of different entity types.
-    $bundle = Unicode::strtolower($this->randomMachineName());
+    $bundle = mb_strtolower($this->randomMachineName());
     NodeType::create([
       'name' => $this->randomString(),
       'type' => $bundle,
@@ -249,7 +248,7 @@ class GetGroupContentTest extends KernelTestBase {
 
     // The Entity Test entity doesn't have 'real' bundles, so we don't need to
     // create one, we can just add the group to the fake bundle.
-    $bundle = Unicode::strtolower($this->randomMachineName());
+    $bundle = mb_strtolower($this->randomMachineName());
     Og::groupTypeManager()->addGroup('entity_test', $bundle);
 
     $groups['entity_test'] = EntityTest::create([
@@ -261,7 +260,7 @@ class GetGroupContentTest extends KernelTestBase {
 
     // Create a group content type with two group audience fields, one for each
     // group.
-    $bundle = Unicode::strtolower($this->randomMachineName());
+    $bundle = mb_strtolower($this->randomMachineName());
     foreach (['entity_test', 'node'] as $target_type) {
       $settings = [
         'field_name' => 'group_audience_' . $target_type,

--- a/tests/src/Kernel/Entity/GetUserGroupsTest.php
+++ b/tests/src/Kernel/Entity/GetUserGroupsTest.php
@@ -4,7 +4,6 @@ namespace Drupal\Tests\og\Kernel\Entity;
 
 use Drupal\entity_test\Entity\EntityTest;
 use Drupal\KernelTests\KernelTestBase;
-use Drupal\Component\Utility\Unicode;
 use Drupal\og\Og;
 use Drupal\og\OgMembershipInterface;
 use Drupal\user\Entity\User;
@@ -88,8 +87,8 @@ class GetUserGroupsTest extends KernelTestBase {
     $this->installEntitySchema('entity_test');
     $this->installSchema('system', 'sequences');
 
-    $this->groupBundle = Unicode::strtolower($this->randomMachineName());
-    $this->groupContentBundle = Unicode::strtolower($this->randomMachineName());
+    $this->groupBundle = mb_strtolower($this->randomMachineName());
+    $this->groupContentBundle = mb_strtolower($this->randomMachineName());
 
     // Create users.
     $this->user1 = User::create(['name' => $this->randomString()]);

--- a/tests/src/Kernel/Entity/GroupAudienceTest.php
+++ b/tests/src/Kernel/Entity/GroupAudienceTest.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\Tests\og\Kernel\Entity;
 
-use Drupal\Component\Utility\Unicode;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\entity_test\Entity\EntityTest;
 use Drupal\og\Og;
@@ -58,7 +57,7 @@ class GroupAudienceTest extends KernelTestBase {
     // Create several bundles.
     for ($i = 0; $i <= 4; $i++) {
       $bundle = EntityTest::create([
-        'type' => Unicode::strtolower($this->randomMachineName()),
+        'type' => mb_strtolower($this->randomMachineName()),
         'name' => $this->randomString(),
       ]);
 
@@ -81,8 +80,8 @@ class GroupAudienceTest extends KernelTestBase {
     $this->assertEmpty($this->groupAudienceHelper->getAllGroupAudienceFields('entity_test', $bundle));
 
     // Set bundles as group content.
-    $field_name1 = Unicode::strtolower($this->randomMachineName());
-    $field_name2 = Unicode::strtolower($this->randomMachineName());
+    $field_name1 = mb_strtolower($this->randomMachineName());
+    $field_name2 = mb_strtolower($this->randomMachineName());
 
     Og::createField(OgGroupAudienceHelperInterface::DEFAULT_FIELD, 'entity_test', $bundle, ['field_name' => $field_name1]);
     Og::createField(OgGroupAudienceHelperInterface::DEFAULT_FIELD, 'entity_test', $bundle, ['field_name' => $field_name2]);
@@ -107,8 +106,8 @@ class GroupAudienceTest extends KernelTestBase {
     $bundle = $this->bundles[1];
 
     // Set bundle as group content.
-    $field_name1 = Unicode::strtolower($this->randomMachineName());
-    $field_name2 = Unicode::strtolower($this->randomMachineName());
+    $field_name1 = mb_strtolower($this->randomMachineName());
+    $field_name2 = mb_strtolower($this->randomMachineName());
 
     $overrides = [
       'field_name' => $field_name1,
@@ -141,8 +140,8 @@ class GroupAudienceTest extends KernelTestBase {
     $bundle = $this->bundles[2];
 
     // Set bundle as group content.
-    $field_name1 = Unicode::strtolower($this->randomMachineName());
-    $field_name2 = Unicode::strtolower($this->randomMachineName());
+    $field_name1 = mb_strtolower($this->randomMachineName());
+    $field_name2 = mb_strtolower($this->randomMachineName());
 
     // Add fields that explicitly references a bundle.
     $overrides = [

--- a/tests/src/Kernel/Entity/GroupMembershipManagerTest.php
+++ b/tests/src/Kernel/Entity/GroupMembershipManagerTest.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\Tests\og\Kernel\Entity;
 
-use Drupal\Component\Utility\Unicode;
 use Drupal\entity_test\Entity\EntityTestBundle;
 use Drupal\entity_test\Entity\EntityTestRev;
 use Drupal\entity_test\Entity\EntityTestWithBundle;
@@ -111,7 +110,7 @@ class GroupMembershipManagerTest extends KernelTestBase {
 
     // Create a group content type with two group audience fields, one for each
     // group.
-    $bundle = Unicode::strtolower($this->randomMachineName());
+    $bundle = mb_strtolower($this->randomMachineName());
     foreach (['entity_test', 'node'] as $target_type) {
       $settings = [
         'field_name' => 'group_audience_' . $target_type,
@@ -184,8 +183,8 @@ class GroupMembershipManagerTest extends KernelTestBase {
   public function testStaticCache() {
     /** @var \Drupal\og\MembershipManagerInterface $membership_manager */
     $membership_manager = \Drupal::service('og.membership_manager');
-    $bundle_rev = Unicode::strtolower($this->randomMachineName());
-    $bundle_with_bundle = Unicode::strtolower($this->randomMachineName());
+    $bundle_rev = mb_strtolower($this->randomMachineName());
+    $bundle_with_bundle = mb_strtolower($this->randomMachineName());
     EntityTestBundle::create(['id' => $bundle_with_bundle, 'label' => $bundle_with_bundle])->save();
     $field_settings = [
       'field_name' => 'group_audience_node',

--- a/tests/src/Kernel/Entity/OgMembershipRoleReferenceTest.php
+++ b/tests/src/Kernel/Entity/OgMembershipRoleReferenceTest.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\Tests\og\Kernel\Entity;
 
-use Drupal\Component\Utility\Unicode;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
@@ -63,7 +62,7 @@ class OgMembershipRoleReferenceTest extends KernelTestBase {
     $this->installSchema('system', 'sequences');
 
     // Create a "group" node type and turn it into a group type.
-    $this->groupBundle = Unicode::strtolower($this->randomMachineName());
+    $this->groupBundle = mb_strtolower($this->randomMachineName());
     NodeType::create([
       'type' => $this->groupBundle,
       'name' => $this->randomString(),

--- a/tests/src/Kernel/Entity/OgMembershipTest.php
+++ b/tests/src/Kernel/Entity/OgMembershipTest.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\Tests\og\Kernel\Entity;
 
-use Drupal\Component\Utility\Unicode;
 use Drupal\entity_test\Entity\EntityTest;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\node\Entity\Node;
@@ -89,7 +88,7 @@ class OgMembershipTest extends KernelTestBase {
 
     // Create a bundle and add as a group.
     $group = EntityTest::create([
-      'type' => Unicode::strtolower($this->randomMachineName()),
+      'type' => mb_strtolower($this->randomMachineName()),
       'name' => $this->randomString(),
       'user_id' => $owner->id(),
     ]);
@@ -166,7 +165,7 @@ class OgMembershipTest extends KernelTestBase {
   public function testMembershipStaticCache() {
     // Create a second bundle and add as a group.
     $another_group = EntityTest::create([
-      'type' => Unicode::strtolower($this->randomMachineName()),
+      'type' => mb_strtolower($this->randomMachineName()),
       'name' => $this->randomString(),
     ]);
     $another_group->save();
@@ -218,7 +217,7 @@ class OgMembershipTest extends KernelTestBase {
    */
   public function testNoOwnerException() {
     // Create a bundle and add as a group.
-    $bundle = Unicode::strtolower($this->randomMachineName());
+    $bundle = mb_strtolower($this->randomMachineName());
     $group = NodeType::create([
       'type' => $bundle,
       'label' => $this->randomString(),
@@ -242,7 +241,7 @@ class OgMembershipTest extends KernelTestBase {
    */
   public function testSetNonValidGroupException() {
     $non_group = EntityTest::create([
-      'type' => Unicode::strtolower($this->randomMachineName()),
+      'type' => mb_strtolower($this->randomMachineName()),
       'name' => $this->randomString(),
     ]);
 
@@ -260,7 +259,7 @@ class OgMembershipTest extends KernelTestBase {
    */
   public function testSaveExistingMembership() {
     $group = EntityTest::create([
-      'type' => Unicode::strtolower($this->randomMachineName()),
+      'type' => mb_strtolower($this->randomMachineName()),
       'name' => $this->randomString(),
     ]);
 
@@ -296,7 +295,7 @@ class OgMembershipTest extends KernelTestBase {
     $wrong_role = OgRole::create()
       ->setGroupType($group_entity_type_id)
       ->setGroupBundle($group_bundle_id)
-      ->setName(Unicode::strtolower($this->randomMachineName()));
+      ->setName(mb_strtolower($this->randomMachineName()));
     $wrong_role->save();
 
     Og::createMembership($group, $this->user)->addRole($wrong_role)->save();
@@ -417,7 +416,7 @@ class OgMembershipTest extends KernelTestBase {
    */
   public function testSaveSameMembershipTwice() {
     $group = EntityTest::create([
-      'type' => Unicode::strtolower($this->randomMachineName()),
+      'type' => mb_strtolower($this->randomMachineName()),
       'name' => $this->randomString(),
     ]);
 

--- a/tests/src/Kernel/Entity/OgStandardReferenceItemTest.php
+++ b/tests/src/Kernel/Entity/OgStandardReferenceItemTest.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\Tests\og\Kernel\Entity;
 
-use Drupal\Component\Utility\Unicode;
 use Drupal\entity_test\Entity\EntityTest;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\og\Og;
@@ -41,7 +40,7 @@ class OgStandardReferenceItemTest extends KernelTestBase {
     // Create several bundles.
     for ($i = 0; $i <= 2; $i++) {
       $bundle = EntityTest::create([
-        'type' => Unicode::strtolower($this->randomMachineName()),
+        'type' => mb_strtolower($this->randomMachineName()),
         'name' => $this->randomString(),
       ]);
 

--- a/tests/src/Kernel/Entity/OgStandardReferenceItemTest.php
+++ b/tests/src/Kernel/Entity/OgStandardReferenceItemTest.php
@@ -64,7 +64,7 @@ class OgStandardReferenceItemTest extends KernelTestBase {
    */
   public function testStandardReference() {
     $groups_query = function ($gid) {
-      return $this->container->get('entity.query')->get('entity_test')
+      return $this->container->get('entity_type.manager')->getStorage('entity_test')->getQuery()
         ->condition($this->fieldName, $gid)
         ->execute();
     };

--- a/tests/src/Kernel/Entity/ReferenceStringIdTest.php
+++ b/tests/src/Kernel/Entity/ReferenceStringIdTest.php
@@ -97,7 +97,7 @@ class ReferenceStringIdTest extends KernelTestBase {
     $entity->save();
 
     // Check that the group content entity is referenced.
-    $references = $this->container->get('entity.query')->get('entity_test_string_id')
+    $references = $this->container->get('entity_type.manager')->getStorage('entity_test_string_id')->getQuery()
       ->condition($this->fieldName, $this->group->id())
       ->execute();
     $this->assertEquals([$entity->id()], array_keys($references), 'The correct group is referenced.');

--- a/tests/src/Kernel/Entity/ReferenceStringIdTest.php
+++ b/tests/src/Kernel/Entity/ReferenceStringIdTest.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\Tests\og\Kernel\Entity;
 
-use Drupal\Component\Utility\Unicode;
 use Drupal\entity_test\Entity\EntityTestStringId;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\og\Og;
@@ -57,7 +56,7 @@ class ReferenceStringIdTest extends KernelTestBase {
     // Create two bundles, one will serve as group, the other as group content.
     for ($i = 0; $i < 2; $i++) {
       $bundle = EntityTestStringId::create([
-        'type' => Unicode::strtolower($this->randomMachineName()),
+        'type' => mb_strtolower($this->randomMachineName()),
         'name' => $this->randomString(),
         'id' => $this->randomMachineName(),
       ]);

--- a/tests/src/Kernel/Entity/SelectionHandlerTest.php
+++ b/tests/src/Kernel/Entity/SelectionHandlerTest.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\Tests\og\Kernel\Entity;
 
-use Drupal\Component\Utility\Unicode;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
@@ -86,8 +85,8 @@ class SelectionHandlerTest extends KernelTestBase {
     $this->installSchema('system', 'sequences');
 
     // Setting up variables.
-    $this->groupBundle = Unicode::strtolower($this->randomMachineName());
-    $this->groupContentBundle = Unicode::strtolower($this->randomMachineName());
+    $this->groupBundle = mb_strtolower($this->randomMachineName());
+    $this->groupContentBundle = mb_strtolower($this->randomMachineName());
 
     // Create a group.
     NodeType::create([

--- a/tests/src/Kernel/Form/GroupSubscribeFormTest.php
+++ b/tests/src/Kernel/Form/GroupSubscribeFormTest.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\Tests\og\Kernel\Form;
 
-use Drupal\Component\Utility\Unicode;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
@@ -75,7 +74,7 @@ class GroupSubscribeFormTest extends KernelTestBase {
     // Create 3 test bundles and declare them as groups.
     $bundle_names = [];
     for ($i = 0; $i < 3; $i++) {
-      $bundle_name = Unicode::strtolower($this->randomMachineName());
+      $bundle_name = mb_strtolower($this->randomMachineName());
       NodeType::create(['type' => $bundle_name])->save();
       Og::groupTypeManager()->addGroup('node', $bundle_name);
       $bundle_names[] = $bundle_name;

--- a/tests/src/Kernel/OgDeleteOrphansTest.php
+++ b/tests/src/Kernel/OgDeleteOrphansTest.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\Tests\og\Kernel;
 
-use Drupal\Component\Utility\Unicode;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
@@ -69,7 +68,7 @@ class OgDeleteOrphansTest extends KernelTestBase {
     $this->ogDeleteOrphansPluginManager = $plugin_manager;
 
     // Create a group entity type.
-    $group_bundle = Unicode::strtolower($this->randomMachineName());
+    $group_bundle = mb_strtolower($this->randomMachineName());
     NodeType::create([
       'type' => $group_bundle,
       'name' => $this->randomString(),
@@ -77,7 +76,7 @@ class OgDeleteOrphansTest extends KernelTestBase {
     Og::groupTypeManager()->addGroup('node', $group_bundle);
 
     // Create a group content entity type.
-    $group_content_bundle = Unicode::strtolower($this->randomMachineName());
+    $group_content_bundle = mb_strtolower($this->randomMachineName());
     NodeType::create([
       'type' => $group_content_bundle,
       'name' => $this->randomString(),

--- a/tests/src/Kernel/OgRoleManagerTest.php
+++ b/tests/src/Kernel/OgRoleManagerTest.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\Tests\og\Kernel;
 
-use Drupal\Component\Utility\Unicode;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\node\Entity\NodeType;
 use Drupal\og\Entity\OgRole;
@@ -63,8 +62,8 @@ class OgRoleManagerTest extends KernelTestBase {
     // Add membership and config schema.
     $this->installConfig(['og']);
     $this->installEntitySchema('node');
-    $this->bundle = Unicode::strtolower($this->randomMachineName());
-    $this->roleName = Unicode::strtolower($this->randomMachineName());
+    $this->bundle = mb_strtolower($this->randomMachineName());
+    $this->roleName = mb_strtolower($this->randomMachineName());
 
     $this->ogRoleManager = $this->container->get('og.role_manager');
 

--- a/tests/src/Kernel/PermissionEventTest.php
+++ b/tests/src/Kernel/PermissionEventTest.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\Tests\og\Kernel;
 
-use Drupal\Component\Utility\SafeMarkup;
+use Drupal\Component\Render\FormattableMarkup;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\node\Entity\NodeType;
 use Drupal\og\Event\PermissionEvent;
@@ -209,7 +209,7 @@ class PermissionEventTest extends KernelTestBase {
    * @see t()
    */
   public function t($string, array $args = [], array $options = []) {
-    return SafeMarkup::format($string, $args);
+    return new FormattableMarkup($string, $args);
   }
 
   /**

--- a/tests/src/Kernel/Views/OgAdminMembersViewTest.php
+++ b/tests/src/Kernel/Views/OgAdminMembersViewTest.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\Tests\og\Kernel\Views;
 
-use Drupal\Component\Utility\Unicode;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
 use Drupal\og\Og;
@@ -99,7 +98,7 @@ class OgAdminMembersViewTest extends ViewsKernelTestBase {
     $this->installEntitySchema('node');
 
     // Create a group entity type.
-    $group_bundle = Unicode::strtolower($this->randomMachineName());
+    $group_bundle = mb_strtolower($this->randomMachineName());
     NodeType::create([
       'type' => $group_bundle,
       'name' => $this->randomString(),

--- a/tests/src/Unit/CreateMembershipTest.php
+++ b/tests/src/Unit/CreateMembershipTest.php
@@ -4,9 +4,9 @@ namespace Drupal\Tests\og\Unit;
 
 use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\Entity\EntityManagerInterface;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\EntityTypeRepositoryInterface;
 use Drupal\og\MembershipManager;
 use Drupal\og\OgGroupAudienceHelperInterface;
 use Drupal\og\OgMembershipInterface;
@@ -23,18 +23,18 @@ use Prophecy\Argument;
 class CreateMembershipTest extends UnitTestCase {
 
   /**
-   * The entity manager used for testing.
-   *
-   * @var \Drupal\Core\Entity\EntityManagerInterface|\Prophecy\Prophecy\ObjectProphecy
-   */
-  protected $entityManager;
-
-  /**
    * The entity type manager.
    *
    * @var \Drupal\Core\Entity\EntityTypeManagerInterface|\Prophecy\Prophecy\ObjectProphecy
    */
   protected $entityTypeManager;
+
+  /**
+   * The mocked entity type repository.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeRepositoryInterface|\Prophecy\Prophecy\ObjectProphecy
+   */
+  protected $entityTypeRepository;
 
   /**
    * The OG group audience helper.
@@ -95,14 +95,14 @@ class CreateMembershipTest extends UnitTestCase {
     $this->bundle = $this->randomMachineName();
 
     $this->entityStorage = $this->prophesize(EntityStorageInterface::class);
-    $this->entityManager = $this->prophesize(EntityManagerInterface::class);
     $this->entityTypeManager = $this->prophesize(EntityTypeManagerInterface::class);
+    $this->entityTypeRepository = $this->prophesize(EntityTypeRepositoryInterface::class);
     $this->groupAudienceHelper = $this->prophesize(OgGroupAudienceHelperInterface::class);
 
-    $this->entityManager->getStorage('og_membership')
+    $this->entityTypeManager->getStorage('og_membership')
       ->willReturn($this->entityStorage->reveal());
 
-    $this->entityManager->getEntityTypeFromClass('Drupal\og\Entity\OgMembership')
+    $this->entityTypeRepository->getEntityTypeFromClass('Drupal\og\Entity\OgMembership')
       ->willReturn('og_membership');
 
     // Create a mocked Og Membership entity.
@@ -128,7 +128,8 @@ class CreateMembershipTest extends UnitTestCase {
       ->willReturn($membership_entity->reveal());
 
     $container = new ContainerBuilder();
-    $container->set('entity.manager', $this->entityManager->reveal());
+    $container->set('entity_type.manager', $this->entityTypeManager->reveal());
+    $container->set('entity_type.repository', $this->entityTypeRepository->reveal());
     \Drupal::setContainer($container);
   }
 

--- a/tests/src/Unit/GroupSubscribeFormatterTest.php
+++ b/tests/src/Unit/GroupSubscribeFormatterTest.php
@@ -7,6 +7,8 @@ use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityManagerInterface;
 use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\EntityTypeRepositoryInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Session\AccountInterface;
@@ -23,7 +25,7 @@ use Drupal\user\EntityOwnerInterface;
  * Tests the OG group formatter.
  *
  * @group og
- * @coversDefaultClass Drupal\og\Plugin\Field\FieldFormatter\GroupSubscribeFormatter
+ * @coversDefaultClass \Drupal\og\Plugin\Field\FieldFormatter\GroupSubscribeFormatter
  */
 class GroupSubscribeFormatterTest extends UnitTestCase {
 
@@ -40,6 +42,20 @@ class GroupSubscribeFormatterTest extends UnitTestCase {
    * @var \Drupal\Core\Entity\EntityStorageInterface|\Prophecy\Prophecy\ObjectProphecy
    */
   protected $entityStorage;
+
+  /**
+   * The mocked entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface|\Prophecy\Prophecy\ObjectProphecy
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The mocked entity type repository service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeRepositoryInterface|\Prophecy\Prophecy\ObjectProphecy
+   */
+  protected $entityTypeRepository;
 
   /**
    * A mocked test user.
@@ -152,6 +168,8 @@ class GroupSubscribeFormatterTest extends UnitTestCase {
     $this->entityManager = $this->prophesize(EntityManagerInterface::class);
     $this->entityStorage = $this->prophesize(EntityStorageInterface::class);
     $this->entityTypeId = $this->randomMachineName();
+    $this->entityTypeManager = $this->prophesize(EntityTypeManagerInterface::class);
+    $this->entityTypeRepository = $this->prophesize(EntityTypeRepositoryInterface::class);
     $this->fieldDefinitionInterface = $this->prophesize(FieldDefinitionInterface::class);
     $this->fieldItemList = $this->prophesize(FieldItemListInterface::class);
     $this->group = $this->prophesize(EntityInterface::class);
@@ -186,7 +204,7 @@ class GroupSubscribeFormatterTest extends UnitTestCase {
       ->willReturn($this->entityId);
 
     $this->groupTypeManager->isGroup($this->entityTypeId, $this->bundle)->willReturn(TRUE);
-    $this->entityManager->getStorage('user')
+    $this->entityTypeManager->getStorage('user')
       ->willReturn($this->entityStorage->reveal());
 
     $this
@@ -194,7 +212,7 @@ class GroupSubscribeFormatterTest extends UnitTestCase {
       ->id()
       ->willReturn($this->userId);
 
-    $this->entityManager->getEntityTypeFromClass('Drupal\user\Entity\User')
+    $this->entityTypeRepository->getEntityTypeFromClass('Drupal\user\Entity\User')
       ->willReturn('user');
 
     $this->entityStorage
@@ -212,7 +230,8 @@ class GroupSubscribeFormatterTest extends UnitTestCase {
       ->willReturn($this->userId);
 
     $container = new ContainerBuilder();
-    $container->set('entity.manager', $this->entityManager->reveal());
+    $container->set('entity_type.manager', $this->entityTypeManager->reveal());
+    $container->set('entity_type.repository', $this->entityTypeRepository->reveal());
     $container->set('og.membership_manager', $this->membershipManager->reveal());
     $container->set('string_translation', $this->getStringTranslationStub());
 


### PR DESCRIPTION
All our tests are running on deprecated versions of Drupal core. This PR updates the test matrix to the currently supported version 8.5.x and the upcoming 8.6.x.

I also enabled testing on PHP 7.2, curious how our code will run on this version.

To do:

- [x] PHPUnit 6 requires php ^7.0, use PHPUnit 4 when testing on PHP 5.6.
- [x] Error: Class 'Drupal\Console\Core\Style\DrupalStyle' not found.
- [x] ServiceNotFoundException: You have requested a non-existent service "entity_type.repository".
- [x] PrivateTempStoreFactory is scheduled for removal in Drupal 9.0.0. Use \Drupal\Core\TempStore\PrivateTempStoreFactory instead.
- [x] PrivateTempStore is scheduled for removal in Drupal 9.0.0. Use \Drupal\Core\TempStore\PrivateTempStore instead.
- [x] The "user.private_tempstore" service is deprecated. You should use the 'tempstore.private' service instead.
- [x] PHPUnit testing framework version 6 or greater is required when running on PHP 7.2 or greater.
- [x] The each() function is deprecated in PHP 7.2.
- [x] Fatal error:  Allowed memory size of 1610612736 bytes exhausted when installing Drupal console.
- [ ] Warning: call_user_func() expects parameter 1 to be a valid callback, class 'Drupal\dynamic_page_cache\EventSubscriber\DynamicPageCacheSubscriber' does not have a method 'onRouteMatch' -> related to https://www.drupal.org/node/2575841 ?
- [x] SafeMarkup::format() is scheduled for removal in Drupal 9.0.0. Use \Drupal\Component\Render\FormattableMarkup.
- [ ] The $memory_cache parameter was added in Drupal 8.6.x and will be required in 9.0.0.
- [ ] \Drupal\Component\Utility\Unicode::strlen() is deprecated in Drupal 8.6.0 and will be removed before Drupal 9.0.0. Use mb_strlen() instead.
- [x] \Drupal\Component\Utility\Unicode::strtolower() is deprecated in Drupal 8.6.0 and will be removed before Drupal 9.0.0. Use mb_strtolower() instead.
- [ ] The Drupal\Core\Entity\Query\QueryFactory class is deprecated in Drupal 8.3.0, will be removed before Drupal 9.0.0. Use \Drupal\Core\Entity\EntityStorageInterface::getQuery() or \Drupal\Core\Entity\EntityStorageInterface::getAggregateQuery() instead.
- [x] The "entity.query" service is deprecated. Use the 'entity_type.manager' service to get an entity type's storage object and then call \Drupal\Core\Entity\EntityStorageInterface::getQuery() or \Drupal\Core\Entity\EntityStorageInterface::getAggregateQuery() instead.