### PR TITLE
Make referenec to GroupTypeManagerInterface and not the class.

### DIFF
--- a/og.module
+++ b/og.module
@@ -289,8 +289,8 @@ function og_field_widget_info_alter(array &$info) {
  * Add link template to groups. We add it to all the entity types, and later on
  * return the correct access, depending if the bundle is indeed a group and
  * accessible. We do not filter here the entity type by groups, so whenever
- * GroupTypeManager::addGroup is called, it's enough to mark route to be rebuilt
- * via RouteBuilder::setRebuildNeeded.
+ * GroupTypeManagerInterface::addGroup is called, it's enough to mark route to
+ * be rebuilt via RouteBuilder::setRebuildNeeded.
  */
 function og_entity_type_alter(array &$entity_types) {
   /** @var \Drupal\Core\Entity\EntityTypeInterface $entity_type */

--- a/tests/src/Kernel/Entity/GetBundleByBundleTest.php
+++ b/tests/src/Kernel/Entity/GetBundleByBundleTest.php
@@ -83,9 +83,10 @@ class GetBundleByBundleTest extends KernelTestBase {
    *
    * This tests the retrieval of the relations between groups and group content
    * and vice versa. The retrieval of groups that are referenced by group
-   * content is done by GroupTypeManager::getGroupBundleIdsByGroupContenBundle()
-   * while GroupTypeManager::getGroupContentBundleIdsByGroupBundle() handles the
-   * opposite case.
+   * content is done by
+   * GroupTypeManagerInterface::getGroupBundleIdsByGroupContenBundle()
+   * while GroupTypeManagerInterface::getGroupContentBundleIdsByGroupBundle()
+   * handles the opposite case.
    *
    * Both methods are tested here in a single test since they are very similar,
    * and not having to set up the entire relationship structure twice reduces


### PR DESCRIPTION
#372 

> Let's check if every time we refer to the group type manager in the code, we are referring to the GroupTypeManagerInterface and not to the class itself.

I searched for `egrep -unr 'GroupTypeManager[^I]' .` to see what needed to be changed,