### PR TITLE
Rename getGroupsForEntityType into getGroupBundleIdsByEntityType

### DIFF
--- a/src/GroupTypeManager.php
+++ b/src/GroupTypeManager.php
@@ -182,7 +182,7 @@ class GroupTypeManager implements GroupTypeManagerInterface {
   /**
    * {@inheritdoc}
    */
-  public function getGroupsForEntityType($entity_type_id) {
+  public function getGroupBundleIdsByEntityType($entity_type_id) {
     $group_map = $this->getGroupMap();
     return isset($group_map[$entity_type_id]) ? $group_map[$entity_type_id] : [];
   }

--- a/src/GroupTypeManagerInterface.php
+++ b/src/GroupTypeManagerInterface.php
@@ -45,7 +45,7 @@ interface GroupTypeManagerInterface {
    * @return \Drupal\Core\Entity\EntityInterface[]
    *   Array of groups, or an empty array if none found
    */
-  public function getGroupsForEntityType($entity_type_id);
+  public function getGroupBundleIdsByEntityType($entity_type_id);
 
   /**
    * Get all group bundles keyed by entity type.

--- a/tests/src/Unit/GroupTypeManagerTest.php
+++ b/tests/src/Unit/GroupTypeManagerTest.php
@@ -204,7 +204,7 @@ class GroupTypeManagerTest extends UnitTestCase {
   /**
    * Tests getting all the groups of an entity type.
    *
-   * @covers ::getGroupsForEntityType
+   * @covers ::getGroupBundleIdsByEntityType
    */
   public function testGetGroupsForEntityType() {
     // It is expected that the group map will be retrieved from config.
@@ -213,8 +213,8 @@ class GroupTypeManagerTest extends UnitTestCase {
 
     $manager = $this->createGroupManager();
 
-    $this->assertSame($groups['test_entity'], $manager->getGroupsForEntityType('test_entity'));
-    $this->assertSame([], $manager->getGroupsForEntityType('test_entity_non_existent'));
+    $this->assertSame($groups['test_entity'], $manager->getGroupBundleIdsByEntityType('test_entity'));
+    $this->assertSame([], $manager->getGroupBundleIdsByEntityType('test_entity_non_existent'));
   }
 
   /**
@@ -239,7 +239,7 @@ class GroupTypeManagerTest extends UnitTestCase {
     // Add to existing.
     $manager->addGroup('test_entity', 'c');
 
-    $this->assertSame(['a', 'b', 'c'], $manager->getGroupsForEntityType('test_entity'));
+    $this->assertSame(['a', 'b', 'c'], $manager->getGroupBundleIdsByEntityType('test_entity'));
     $this->assertTrue($manager->isGroup('test_entity', 'c'));
   }
 
@@ -280,7 +280,7 @@ class GroupTypeManagerTest extends UnitTestCase {
 
     // Add a new entity type.
     $manager->addGroup('test_entity_new', 'a');
-    $this->assertSame(['a'], $manager->getGroupsForEntityType('test_entity_new'));
+    $this->assertSame(['a'], $manager->getGroupBundleIdsByEntityType('test_entity_new'));
     $this->assertTrue($manager->isGroup('test_entity_new', 'a'));
   }
 
@@ -314,7 +314,7 @@ class GroupTypeManagerTest extends UnitTestCase {
 
     // Add to existing.
     $manager->removeGroup('test_entity', 'b');
-    $this->assertSame(['a'], $manager->getGroupsForEntityType('test_entity'));
+    $this->assertSame(['a'], $manager->getGroupBundleIdsByEntityType('test_entity'));
     $this->assertFalse($manager->isGroup('test_entity', 'b'));
     $this->assertTrue($manager->isGroup('test_entity', 'a'));
   }

--- a/tests/src/Unit/GroupTypeManagerTest.php
+++ b/tests/src/Unit/GroupTypeManagerTest.php
@@ -202,11 +202,11 @@ class GroupTypeManagerTest extends UnitTestCase {
   }
 
   /**
-   * Tests getting all the groups of an entity type.
+   * Tests getting all the groups IDs of an entity type.
    *
    * @covers ::getGroupBundleIdsByEntityType
    */
-  public function testGetGroupsForEntityType() {
+  public function testGetGroupBundleIdsByEntityType() {
     // It is expected that the group map will be retrieved from config.
     $groups = ['test_entity' => ['a', 'b']];
     $this->expectGroupMapRetrieval($groups);


### PR DESCRIPTION
#372 

> ::getGroupsForEntityType() is badly named, and has incorrect documentation. This doesn't return any groups, but it returns group bundle IDs. So to be consistent with the sister method for group content, we should call this ::getGroupBundleIdsByEntityType().