### PR TITLE
Rename getAllGroupContentBundles into getAllGroupContentBundleIds

### DIFF
--- a/src/GroupTypeManager.php
+++ b/src/GroupTypeManager.php
@@ -198,7 +198,7 @@ class GroupTypeManager implements GroupTypeManagerInterface {
   /**
    * {@inheritdoc}
    */
-  public function getAllGroupContentBundles() {
+  public function getAllGroupContentBundleIds() {
     $bundles = [];
     foreach ($this->getGroupRelationMap() as $group_entity_type_id => $group_bundle_ids) {
       foreach ($group_bundle_ids as $group_content_entity_type_ids) {
@@ -214,7 +214,7 @@ class GroupTypeManager implements GroupTypeManagerInterface {
    * {@inheritdoc}
    */
   public function getAllGroupContentBundlesByEntityType($entity_type_id) {
-    $bundles = $this->getAllGroupContentBundles();
+    $bundles = $this->getAllGroupContentBundleIds();
     if (!isset($bundles[$entity_type_id])) {
       throw new \InvalidArgumentException("The '$entity_type_id' entity type has no group content bundles.");
     }

--- a/src/GroupTypeManagerInterface.php
+++ b/src/GroupTypeManagerInterface.php
@@ -57,9 +57,9 @@ interface GroupTypeManagerInterface {
   public function getAllGroupBundles($entity_type = NULL);
 
   /**
-   * Returns a list of all group content bundles keyed by entity type.
+   * Returns a list of all group content bundles IDs keyed by entity type.
    *
-   * This will return a simple list of group content bundles. If you need
+   * This will return a simple list of group content bundles IDs. If you need
    * information about the relations between groups and group content bundles
    * then use getGroupRelationMap() instead.
    *
@@ -69,7 +69,7 @@ interface GroupTypeManagerInterface {
    *
    * @see \Drupal\og\GroupTypeManagerInterface::getGroupRelationMap()
    */
-  public function getAllGroupContentBundles();
+  public function getAllGroupContentBundleIds();
 
   /**
    * Returns a list of all group content bundles filtered by entity type.

--- a/src/Plugin/Block/RecentGroupContentBlock.php
+++ b/src/Plugin/Block/RecentGroupContentBlock.php
@@ -99,7 +99,7 @@ class RecentGroupContentBlock extends BlockBase implements ContainerFactoryPlugi
    */
   public function defaultConfiguration() {
     // Default to the first entity type in the list.
-    $bundles = $this->groupTypeManager->getAllGroupContentBundles();
+    $bundles = $this->groupTypeManager->getAllGroupContentBundleIds();
     reset($bundles);
     $entity_type_default = key($bundles);
 
@@ -130,7 +130,7 @@ class RecentGroupContentBlock extends BlockBase implements ContainerFactoryPlugi
     ];
 
     $entity_type_options = [];
-    foreach ($this->groupTypeManager->getAllGroupContentBundles() as $entity_type_id => $bundle_ids) {
+    foreach ($this->groupTypeManager->getAllGroupContentBundleIds() as $entity_type_id => $bundle_ids) {
       $entity_definition = $this->entityTypeManager->getDefinition($entity_type_id);
       $entity_type_options[$entity_type_id] = $entity_definition->getLabel();
 


### PR DESCRIPTION
#372

> ::getAllGroupContentBundles() returns bundle IDs, but the method name implies that it returns objects of type EntityTypeInterface. Let's rename it to ::getAllGroupContentBundleIds().