### PR TITLE
We can update the generic @return array type hints to more precise da…

### DIFF
--- a/src/GroupTypeManagerInterface.php
+++ b/src/GroupTypeManagerInterface.php
@@ -50,7 +50,7 @@ interface GroupTypeManagerInterface {
   /**
    * Get all group bundles keyed by entity type.
    *
-   * @return array
+   * @return string[]
    *   An associative array, keyed by entity type, each value an indexed array
    *   of bundle IDs.
    */
@@ -63,7 +63,7 @@ interface GroupTypeManagerInterface {
    * information about the relations between groups and group content bundles
    * then use getGroupRelationMap() instead.
    *
-   * @return array
+   * @return string[]
    *   An associative array of group content bundle IDs, keyed by entity type
    *   ID.
    *
@@ -81,7 +81,7 @@ interface GroupTypeManagerInterface {
    * @param string $entity_type_id
    *   Entity type ID to filter the bundles by.
    *
-   * @return array
+   * @return string[]
    *   An array of group content bundle IDs.
    *
    * @throws \InvalidArgumentException
@@ -102,7 +102,7 @@ interface GroupTypeManagerInterface {
    *   The bundle ID of the group content type for which to return associated
    *   group bundle IDs.
    *
-   * @return array
+   * @return string[]
    *   An array of group bundle IDs, keyed by group entity type ID.
    */
   public function getGroupBundleIdsByGroupContentBundle($group_content_entity_type_id, $group_content_bundle_id);
@@ -117,7 +117,7 @@ interface GroupTypeManagerInterface {
    *   The bundle ID of the group type for which to return associated group
    *   content bundle IDs.
    *
-   * @return array
+   * @return string[]
    *   An array of group content bundle IDs, keyed by group content entity type
    *   ID.
    */
@@ -164,7 +164,7 @@ interface GroupTypeManagerInterface {
   /**
    * Returns the group map.
    *
-   * @return array
+   * @return string[]
    *   The group map.
    */
   public function getGroupMap();

--- a/src/GroupTypeManagerInterface.php
+++ b/src/GroupTypeManagerInterface.php
@@ -50,7 +50,7 @@ interface GroupTypeManagerInterface {
   /**
    * Get all group bundles keyed by entity type.
    *
-   * @return string[]
+   * @return string[][]
    *   An associative array, keyed by entity type, each value an indexed array
    *   of bundle IDs.
    */
@@ -63,7 +63,7 @@ interface GroupTypeManagerInterface {
    * information about the relations between groups and group content bundles
    * then use getGroupRelationMap() instead.
    *
-   * @return string[]
+   * @return string[][]
    *   An associative array of group content bundle IDs, keyed by entity type
    *   ID.
    *
@@ -102,7 +102,7 @@ interface GroupTypeManagerInterface {
    *   The bundle ID of the group content type for which to return associated
    *   group bundle IDs.
    *
-   * @return string[]
+   * @return string[][]
    *   An array of group bundle IDs, keyed by group entity type ID.
    */
   public function getGroupBundleIdsByGroupContentBundle($group_content_entity_type_id, $group_content_bundle_id);
@@ -117,7 +117,7 @@ interface GroupTypeManagerInterface {
    *   The bundle ID of the group type for which to return associated group
    *   content bundle IDs.
    *
-   * @return string[]
+   * @return string[][]
    *   An array of group content bundle IDs, keyed by group content entity type
    *   ID.
    */
@@ -164,7 +164,7 @@ interface GroupTypeManagerInterface {
   /**
    * Returns the group map.
    *
-   * @return string[]
+   * @return string[][]
    *   The group map.
    */
   public function getGroupMap();


### PR DESCRIPTION
…ta types like @return string[] and @return string[][]. This will help developers understand at a glance what they are dealing with.