### PR TITLE
Performance: Store the group bundle in the membership entity

### DIFF
--- a/og.install
+++ b/og.install
@@ -5,10 +5,60 @@
  * Install, update, and uninstall functions for the Organic groups module.
  */
 
+use Drupal\Core\Field\BaseFieldDefinition;
+
 /**
  * Implements hook_uninstall().
  */
 function og_uninstall() {
   \Drupal::queue('og_orphaned_group_content')->deleteQueue();
   \Drupal::queue('og_orphaned_group_content_cron')->deleteQueue();
+}
+
+/**
+ * Add a base field to store the group bundle in memberships.
+ */
+function og_update_8001(&$sandbox) {
+  $storage = \Drupal::entityTypeManager()->getStorage('og_membership');
+
+  if (!isset($sandbox['total'])) {
+    $storage_definition = BaseFieldDefinition::create('string')
+      ->setLabel(t('Group bundle id'))
+      ->setDescription(t("The bundle ID of the group."));
+    \Drupal::entityDefinitionUpdateManager()->installFieldStorageDefinition('entity_bundle', 'og_membership', 'og', $storage_definition);
+
+    $sandbox['#finished'] = 0;
+    $sandbox['current'] = 0;
+    $sandbox['total'] = $storage->getQuery()->count()->execute();
+    $sandbox['batch_size'] = 500;
+  }
+
+  // Update the existing memberships to include the group bundle ID.
+  $membership_ids = $storage->getQuery()
+    ->range($sandbox['current'], $sandbox['batch_size'])
+    ->sort('id')
+    ->execute();
+
+  /** @var \Drupal\og\Entity\OgMembership $membership */
+  foreach ($storage->loadMultiple($membership_ids) as $membership) {
+    $group = $membership->getGroup();
+    if (!empty($group)) {
+      $membership->set('entity_bundle', $group->bundle());
+      $membership->save();
+    }
+  }
+
+  $sandbox['current'] += $sandbox['batch_size'];
+  if ($sandbox['current'] >= $sandbox['total']) {
+    $sandbox['current'] = $sandbox['total'];
+  }
+  $sandbox['#finished'] = $sandbox['current'] / $sandbox['total'];
+
+  $message = t('Processed @current of @total memberships (@percentage% complete)', [
+    '@current' => $sandbox['current'],
+    '@total' => $sandbox['total'],
+    '@percentage' => number_format($sandbox['#finished'] * 100, 2),
+  ]);
+
+  return $message;
 }

--- a/og.install
+++ b/og.install
@@ -23,8 +23,8 @@ function og_update_8001(&$sandbox) {
 
   if (!isset($sandbox['total'])) {
     $storage_definition = BaseFieldDefinition::create('string')
-      ->setLabel(t('Group bundle id'))
-      ->setDescription(t("The bundle ID of the group."));
+      ->setLabel(t('Group bundle ID'))
+      ->setDescription(t('The bundle ID of the group.'));
     \Drupal::entityDefinitionUpdateManager()->installFieldStorageDefinition('entity_bundle', 'og_membership', 'og', $storage_definition);
 
     $sandbox['#finished'] = 0;
@@ -45,6 +45,16 @@ function og_update_8001(&$sandbox) {
     if (!empty($group)) {
       $membership->set('entity_bundle', $group->bundle());
       $membership->save();
+    }
+    else {
+      // The membership is for a group that no longer exists. We cannot no
+      // longer retrieve the group bundle ID so the membership cannot be
+      // updated. Delete the membership since it is invalid, and inform the
+      // user.
+      \Drupal::logger('og')->warning('Deleted orphaned membership with ID @id since the group it refers to no longer exists.', [
+        '@id' => $membership->id(),
+      ]);
+      $membership->delete();
     }
   }
 

--- a/src/Entity/OgMembership.php
+++ b/src/Entity/OgMembership.php
@@ -160,11 +160,17 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
    * a group is present when methods are called on a membership that is possibly
    * still under construction.
    *
+   * For performance reasons this avoids loading the full group entity just for
+   * this purpose, and relies only on the fact that the data for the entity is
+   * populated in the relevant fields. This should give us the same indication,
+   * but with a lower performance cost, especially for users that are a member
+   * of a large number of groups.
+   *
    * @return bool
    *   Whether or not the group is already present.
    */
   protected function hasGroup() {
-    return !empty($this->get('entity_type')->value) && !empty($this->get('entity_id')->value);
+    return !empty($this->get('entity_type')->value) && !empty($this->get('entity_bundle')->value) && !empty($this->get('entity_id')->value);
   }
 
   /**
@@ -359,12 +365,12 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
       ->setDescription(t('The entity type of the group.'));
 
     $fields['entity_bundle'] = BaseFieldDefinition::create('string')
-      ->setLabel(t('Group bundle id'))
-      ->setDescription(t("The bundle ID of the group."));
+      ->setLabel(t('Group bundle ID'))
+      ->setDescription(t('The bundle ID of the group.'));
 
     $fields['entity_id'] = BaseFieldDefinition::create('string')
-      ->setLabel(t('Group entity id'))
-      ->setDescription(t("The entity ID of the group."));
+      ->setLabel(t('Group entity ID'))
+      ->setDescription(t('The entity ID of the group.'));
 
     $fields['state'] = BaseFieldDefinition::create('string')
       ->setLabel(t('State'))

--- a/src/Entity/OgMembership.php
+++ b/src/Entity/OgMembership.php
@@ -164,7 +164,7 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
    *   Whether or not the group is already present.
    */
   protected function hasGroup() {
-    return !empty($this->get('entity_type')) && !empty($this->get('entity_id'));
+    return !empty($this->get('entity_type')->value) && !empty($this->get('entity_id')->value);
   }
 
   /**

--- a/src/OgMembershipInterface.php
+++ b/src/OgMembershipInterface.php
@@ -96,6 +96,14 @@ interface OgMembershipInterface extends ContentEntityInterface, EntityOwnerInter
   public function getGroupEntityType();
 
   /**
+   * Gets the group entity bundle.
+   *
+   * @return string
+   *   The bundle.
+   */
+  public function getGroupBundle();
+
+  /**
    * Gets the group entity ID.
    *
    * @return string

--- a/tests/src/Kernel/Entity/OgMembershipTest.php
+++ b/tests/src/Kernel/Entity/OgMembershipTest.php
@@ -471,6 +471,24 @@ class OgMembershipTest extends KernelTestBase {
   }
 
   /**
+   * Tests getting the bundle of the group that is associated with a membership.
+   *
+   * @covers ::getGroupBundle
+   */
+  public function testGetGroupBundle() {
+    $membership = OgMembership::create();
+
+    // When no group has been set yet, the method should return NULL.
+    $this->assertNull($membership->getGroupBundle());
+
+    // Set a group.
+    $membership->setGroup($this->group);
+
+    // Now the group bundle should be returned.
+    $this->assertEquals($this->group->bundle(), $membership->getGroupBundle());
+  }
+
+  /**
    * Tests that membership has "member" role when roles are retrieved.
    *
    * @covers ::getRoles


### PR DESCRIPTION
We got a report from a user that was experiencing very slow page loads throughout the entire website. This user is very active and is a member of 547 groups. She was experiencing page loading times of around 15+ seconds throughout the entire website.

After profiling it turned out that over 95% of the process time was spent in this line of code in `OgMembership`:

```
  public function getRoles() {
    $roles = [];

    // Add the member role. This is only possible if a group has been set on the
    // membership.
    if ($group = $this->getGroup()) { // <<< 95% of page load is spent executing this line.
      $roles = [
        OgRole::getRole($this->getGroupEntityType(), $group->bundle(), OgRoleInterface::AUTHENTICATED),
      ];
    }
    $roles = array_merge($roles, $this->get('roles')->referencedEntities());
    return $roles;
  }
```

This code gets executed through `OgRoleCacheContext::getContext()` which loads all the user memberships, and calls `::getRoles()` on them to compile a hash that identifies this user's memberships. Through this method call this was also doing full entity loads of all the groups this user is a member of.

In our projects we have two group types and both are very complex entities with many fields, and it turns out that loading 547 of them has a huge impact on the page load.

Now it is not even necessary for us to dynamically load the full group entity to be able to determine the roles of the membership. We only need to know the bundle.

This PR stores the group bundle in the membership table, so it sits along the entity type and ID which we were already storing. By doing this we can avoid the full entity loads.

The result is a huge performance increase. Here are the results from loading a page containing a simple configuration form for a user that is a member of 547 groups:

* without this PR: 15.56 seconds
* with this PR: 0.21 seconds (74x faster!)