### PR TITLE
Avoid database lock timeouts when cleaning up orphans in long running Behat tests

### DIFF
--- a/og.behat.inc
+++ b/og.behat.inc
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * @file
+ * Contains \OgSubContext.
+ */
+
+use Drupal\DrupalExtension\Context\DrupalSubContextBase;
+use Drupal\DrupalExtension\Context\DrupalSubContextInterface;
+use Drupal\og\OgDeleteOrphansInterface;
+
+/**
+ * Behat step definitions and hook implementations for Organic Groups.
+ */
+class OgSubContext extends DrupalSubContextBase implements DrupalSubContextInterface {
+
+  /**
+   * Cleans up orphaned group content after each scenario.
+   *
+   * By default orphaned group content is cleaned up in a shutdown function that
+   * fires at the end of the Drupal page request. When Drupal is being
+   * bootstrapped to serve as a backend for a Behat test suite then this "page
+   * request" will only end after all scenarios are completed and the Behat test
+   * runner is deconstructed, which might be after several hours. If a large
+   * number of orphans have been accumulated in the meantime the cleaning up of
+   * all these orphans might cause database lock timeouts.
+   *
+   * By cleaning up the orphans after each scenario we can reduce the risk of
+   * timeouts.
+   *
+   * @see \Drupal\og\Plugin\OgDeleteOrphans\Simple::register()
+   *
+   * @AfterScenario
+   */
+  public function cleanOrphans() {
+    $callbacks = &drupal_register_shutdown_function();
+    foreach ($callbacks as $key => $callback) {
+      $callable = $callback['callback'];
+      if (is_array($callable) && $callable[0] instanceof OgDeleteOrphansInterface && $callable[1] === 'process') {
+        call_user_func_array($callback['callback'], $callback['arguments']);
+        unset($callbacks[$key]);
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
I'm working on a large project that is based on OG and uses Behat for validating user scenarios. Our current Behat test suite has grown to 9000+ steps in 500+ scenarios and takes around 90 minutes to complete.

Lately we are experiencing around a 20% failure rate in our suite due to database lock timeouts occurring when OG is cleaning up orphaned group content. We are using the default "simple" plugin for cleaning up orphans which works fine in a normal Drupal page request, but unfortunately during this 1.5 hour long test the "page request" remains active and accumulates a large number of orphans. Cleaning these up takes so long that database lock timeouts occur.

Here is an example of such a failing test: https://app.continuousphp.com/git-hub/ec-europa/joinup-dev/build/ea8af49d-8c49-4ff5-ba79-8c451bd4aa5c/logs/5945b8bb-d395-4aa1-b081-6046c9e2c29b#line-1678

This PR implements the `@AfterScenario` Behat hook and cleans up orphans after every test scenario rather than after the entire test suite.