### PR TITLE
7.x 2.x og fix head tests for various versions of php

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/Gizra/og.svg?branch=7.x-2.x)](https://travis-ci.org/Gizra/og)
+[![Build Status](https://travis-ci.org/Gizra/og.svg?branch=7.x-2.x)](https://travis-ci.org/Gizra/og/branches)
 
 DESCRIPTION
 --------------------------

--- a/og.test
+++ b/og.test
@@ -2166,7 +2166,10 @@ class OgNonMembersPublishingContentTestCase extends DrupalWebTestCase {
 
     $this->assertTrue(!empty($result['node']), 'The node was added to the group.');
 
-    $nid = reset(array_keys($result['node']));
+    // Avoid strict errors in php 5.4, 5.5, 5.6, 7.0, 7.1, 7.2, see https://drupal.org/node/3000030 patch 2.
+    $result_node = $result['node'];
+    $node_array_keys = array_keys($result_node);
+    $nid = reset($node_array_keys);
 
     $this->drupalLogin($this->adminUser);
 

--- a/og.test
+++ b/og.test
@@ -2166,7 +2166,6 @@ class OgNonMembersPublishingContentTestCase extends DrupalWebTestCase {
 
     $this->assertTrue(!empty($result['node']), 'The node was added to the group.');
 
-    // Avoid strict errors in php 5.4, 5.5, 5.6, 7.0, 7.1, 7.2, see https://drupal.org/node/3000030 patch 2.
     $result_node = $result['node'];
     $node_array_keys = array_keys($result_node);
     $nid = reset($node_array_keys);


### PR DESCRIPTION
Currently head on drupal.org is passing only on php 5.3.x but is failing on everything else.  The fix is very simple.  I am raising this issue because the next release of core (7.x-dev already supports it) will support php 7.2.x .  I've been running tests against contrib modules that I maintain and others, so far it's looking great.  For og (organic groups) we only need to make this small change.
For followup on drupal.org please see https://www.drupal.org/project/og/issues/3000030
