### PR TITLE
Deleted groups causes EntityMalformedException in og_is_group().

### DIFF
--- a/og.module
+++ b/og.module
@@ -1830,6 +1830,10 @@ function og_is_group($entity_type, $entity) {
   if (is_numeric($entity)) {
     $entity = entity_load_single($entity_type, $entity);
   }
+  if (!$entity) {
+    // The entity does not exist.
+    return FALSE;
+  }
   list(,, $bundle) = entity_extract_ids($entity_type, $entity);
   if (!field_info_instance($entity_type, OG_GROUP_FIELD, $bundle)) {
     return variable_get("og_is_group__{$entity_type}__{$bundle}", FALSE);

--- a/og.test
+++ b/og.test
@@ -2083,6 +2083,82 @@ class OgDeleteOrphansTestCase extends DrupalWebTestCase {
 
     $this->assertEqual($gid, $second_group->nid, 'The group content moved to another group.');
   }
+
+  /**
+   * Tests editing content that belongs to a deleted group.
+   *
+   * Tests if content belonging to multiple groups can be edited without issues
+   * after deleting one of the groups.
+   */
+  public function testEditGroupContentAfterDeletingGroup() {
+    $account = $this->drupalCreateUser(array('edit own ' . $this->node_type . ' content'));
+    $this->drupalLogin($account);
+
+    // Create two groups.
+    $first_group = $this->drupalCreateNode(array('type' => $this->group_type));
+    $second_group = $this->drupalCreateNode(array('type' => $this->group_type));
+
+    // Create group content, assign it to both groups.
+    $group_content = $this->drupalCreateNode(array(
+      'type' => $this->node_type,
+      'title' => 'Lorem ipsum',
+      'uid' => $account->uid,
+    ));
+    og_group('node', $first_group, array('entity_type' => 'node', 'entity' => $group_content));
+    og_group('node', $second_group, array('entity_type' => 'node', 'entity' => $group_content));
+
+    // Try to edit the group content node, using the UI.
+    $this->drupalPost('node/' . $group_content->nid . '/edit', array(), 'Save');
+    $this->assertText($this->node_type . ' Lorem ipsum has been updated.');
+
+    // Delete the first group.
+    node_delete($first_group->nid);
+
+    // Try again to edit the group content node.
+    $this->drupalPost('node/' . $group_content->nid . '/edit', array(), 'Save');
+    $this->assertText($this->node_type . ' Lorem ipsum has been updated.');
+  }
+
+  /**
+   * Tests calling node_access() on content that belongs to a deleted group.
+   *
+   * Tests if node_access() can be called for content that has a reference to a
+   * no longer existing group when OG is configured to use the delete queue.
+   */
+  public function testGroupContentNodeAccessAfterDeletingGroupAndWhenUsingQueue() {
+    // Configure OG to use queue for deleting pending content.
+    variable_set('og_use_queue', TRUE);
+
+    $account = $this->drupalCreateUser(array('access content', 'edit own ' . $this->node_type . ' content'));
+    $this->drupalLogin($account);
+
+    // Create two groups.
+    $first_group = $this->drupalCreateNode(array('type' => $this->group_type));
+    $second_group = $this->drupalCreateNode(array('type' => $this->group_type));
+
+    // Create group content, assign it to both groups.
+    $group_content = $this->drupalCreateNode(array(
+      'type' => $this->node_type,
+      'title' => 'Lorem ipsum',
+      'uid' => $account->uid,
+    ));
+    og_group('node', $first_group, array('entity_type' => 'node', 'entity' => $group_content));
+    og_group('node', $second_group, array('entity_type' => 'node', 'entity' => $group_content));
+
+    // Display a list of my nodes, that uses node_access() to check if links may
+    // be displayed.
+    $this->drupalGet('og_test/my_content');
+    $this->assertText('Lorem ipsum');
+
+    // Delete the first group.
+    node_delete($first_group->nid);
+
+    // Display a list of my nodes again, to ensure nothing changed.
+    $this->drupalGet('og_test/my_content');
+    $this->assertNoText('EntityMalformedException');
+    $this->assertText('Lorem ipsum');
+  }
+
 }
 
 /**

--- a/tests/og_test.module
+++ b/tests/og_test.module
@@ -6,6 +6,19 @@
  */
 
 /**
+ * Implements hook_menu().
+ */
+function og_test_menu() {
+  return array(
+    'og_test/my_content' => array(
+      'page callback' => 'og_test_my_content',
+      'access arguments' => array('access content'),
+      'type' => MENU_CALLBACK,
+    ),
+  );
+}
+
+/**
  * Implements hook_node_presave().
  */
 function og_test_node_presave($node) {
@@ -62,6 +75,45 @@ function og_test_entity_delete($entity, $type) {
       'gid' => $nid,
     ),
   );
+}
+
+/**
+ * Page callback for displaying nodes for the current user.
+ */
+function og_test_my_content() {
+  global $user;
+
+  $nodes = node_load_multiple(array(), array('uid' => $user->uid));
+
+  $table = array(
+    '#theme' => 'table',
+    '#header' => array(
+      t('Title'),
+      t('Operations'),
+    ),
+    '#rows' => array(),
+  );
+
+  foreach ($nodes as $node) {
+    $operations = array();
+
+    if (node_access('view', $node)) {
+      $operations['view'] = l(t('view'), 'node/' . $node->nid);
+    }
+    if (node_access('update', $node)) {
+      $operations['update'] = l(t('edit'), 'node/' . $node->nid . '/edit');
+    }
+    if (node_access('delete', $node)) {
+      $operations['delete'] = l(t('delete'), 'node/' . $node->nid . '/delete');
+    }
+
+    $table['#rows'][$node->nid] = array(
+      check_plain($node->title),
+      implode(' | ', $operations),
+    );
+  }
+
+  return $table;
 }
 
 /**


### PR DESCRIPTION
When a group is deleted, other entities can still hold a reference to this group. For example: group content. This can cause exceptions of type EntityMalformedException in various situations. One of them - which is addressed here - is when you have a single group content assigned to multiple groups and then one of the groups is deleted. When you then try to update the group content an EntityMalformedException is thrown.

Steps to reproduce:

1. Enable modules og, og_ui, og_access.
2. Create a node type used as group.
3. Create a node type used as group content.
4. Create a role with permissions to create, edit and delete own group and group content nodes.
5. Log in as an user with this role.
6. Create two group nodes.
7. Create group content node, assign to both groups.
8. Delete the first created group.
9. Go to the node edit page of the group content.
10. Click "Save".

An other way to reproduce the issue:

1. Enable modules og, og_ui, og_access.
2. On the OG settings page (/admin/config/group/settings), enable the "Use queue" option.
3. Create a node type used as group.
4. Create a node type used as group content.
5. Create a role with permissions to create, edit and delete own group and group content nodes.
6. Log in as an user with this role.
7. Create two group nodes.
8. Create group content node, assign to both groups.
9. Delete the first created group.
10. Do something that checks if the current user may update the group content, using a node_access() call. For example a View with your own nodes that includes a Views edit link (views_handler_field_node_link_edit).

See also this issue on drupal.org to see that the included tests fail without the fix:
https://www.drupal.org/project/og/issues/2900273