### PR TITLE
Fix Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,4 @@ before_script:
   # Export database variable for kernel tests.
   - export SIMPLETEST_DB=mysql://root:@127.0.0.1/og
 
-  # Disable all deprecations
-  - export SYMFONY_DEPRECATIONS_HELPER=disabled
-
 script: DRUPAL_DIR=$DRUPAL_DIR MODULE_DIR=$MODULE_DIR $MODULE_DIR/scripts/travis-ci/run-test.sh $TEST_SUITE

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,13 +36,10 @@ before_script:
   - phpenv config-rm xdebug.ini || true
 
   # Make sure Composer is up to date.
-  - composer self-update
+  - composer -vvv self-update
 
   # Remember the current directory for later use in the Drupal installation.
   - MODULE_DIR=$(pwd)
-
-  # Install Composer dependencies for OG.
-  - composer install
 
   # Navigate out of module directory to prevent blown stack by recursive module
   # lookup.
@@ -59,13 +56,13 @@ before_script:
 
   # Download Drupal console so we can run the test for it. Skip this for the
   # coding standards test.
-  - test ${TEST_SUITE} == "PHP_CodeSniffer" || composer require --dev drupal/console:~1.0 --working-dir=$DRUPAL_DIR
+  - test ${TEST_SUITE} == "PHP_CodeSniffer" || composer -vvv require --dev drupal/console:~1.0 --working-dir=$DRUPAL_DIR
 
   # Install Composer dependencies for core. Skip this for the coding standards test.
-  - test ${TEST_SUITE} == "PHP_CodeSniffer" || composer install --working-dir=$DRUPAL_DIR
+  - test ${TEST_SUITE} == "PHP_CodeSniffer" || composer -vvv install --working-dir=$DRUPAL_DIR
 
   # PHPUnit 6 is required when running tests on PHP 7.x.
-  - test ${TEST_SUITE} == "PHP_CodeSniffer" || test ${TRAVIS_PHP_VERSION:0:3} == "5.6" || composer require --dev phpunit/phpunit:~6 --update-with-dependencies --working-dir=$DRUPAL_DIR
+  - test ${TEST_SUITE} == "PHP_CodeSniffer" || test ${TRAVIS_PHP_VERSION:0:3} == "5.6" || composer -vvv require --dev phpunit/phpunit:~6 --update-with-dependencies --working-dir=$DRUPAL_DIR
 
   # Start a web server on port 8888 in the background.
   - test ${TEST_SUITE} == "PHP_CodeSniffer" || nohup php -S localhost:8888 --docroot $DRUPAL_DIR > /dev/null 2>&1 &

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,12 @@ matrix:
   exclude:
     - php: 7.1
       env: TEST_SUITE=PHP_CodeSniffer
-    - php: 7.2
-      env: TEST_SUITE=PHP_CodeSniffer
+    - php: 5.6
+      env: TEST_SUITE=8.7.x
+    - php: 7.0
+      env: TEST_SUITE=8.7.x
+    - php: 7.1
+      env: TEST_SUITE=8.7.x
   allow_failures:
     - env: TEST_SUITE=8.7.x
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,18 @@ env:
 # Only run the coding standards check once.
 matrix:
   exclude:
-    - php: 7.1
-      env: TEST_SUITE=PHP_CodeSniffer
     - php: 5.6
       env: TEST_SUITE=8.7.x
     - php: 7.0
       env: TEST_SUITE=8.7.x
     - php: 7.1
       env: TEST_SUITE=8.7.x
+    - php: 5.6
+      env: TEST_SUITE=PHP_CodeSniffer
+    - php: 7.0
+      env: TEST_SUITE=PHP_CodeSniffer
+    - php: 7.1
+      env: TEST_SUITE=PHP_CodeSniffer
   allow_failures:
     - env: TEST_SUITE=8.7.x
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,17 +17,9 @@ env:
 # Only run the coding standards check once.
 matrix:
   exclude:
-    - php: 5.6
-      env: TEST_SUITE=8.7.x
-    - php: 7.0
-      env: TEST_SUITE=8.7.x
     - php: 7.1
-      env: TEST_SUITE=8.7.x
-    - php: 5.6
       env: TEST_SUITE=PHP_CodeSniffer
-    - php: 7.0
-      env: TEST_SUITE=PHP_CodeSniffer
-    - php: 7.1
+    - php: 7.2
       env: TEST_SUITE=PHP_CodeSniffer
   allow_failures:
     - env: TEST_SUITE=8.7.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ before_script:
   - phpenv config-rm xdebug.ini || true
 
   # Make sure Composer is up to date.
-  - composer -vvv self-update
+  - composer self-update
 
   # Remember the current directory for later use in the Drupal installation.
   - MODULE_DIR=$(pwd)
@@ -64,13 +64,13 @@ before_script:
 
   # Download Drupal console so we can run the test for it. Skip this for the
   # coding standards test.
-  - test ${TEST_SUITE} == "PHP_CodeSniffer" || composer -vvv require --dev drupal/console:~1.0 --working-dir=$DRUPAL_DIR
+  - test ${TEST_SUITE} == "PHP_CodeSniffer" || composer require --dev drupal/console:~1.0 --working-dir=$DRUPAL_DIR
 
   # Install Composer dependencies for core. Skip this for the coding standards test.
-  - test ${TEST_SUITE} == "PHP_CodeSniffer" || composer -vvv install --working-dir=$DRUPAL_DIR
+  - test ${TEST_SUITE} == "PHP_CodeSniffer" || composer install --working-dir=$DRUPAL_DIR
 
   # PHPUnit 6 is required when running tests on PHP 7.x.
-  - test ${TEST_SUITE} == "PHP_CodeSniffer" || test ${TRAVIS_PHP_VERSION:0:3} == "5.6" || composer -vvv require --dev phpunit/phpunit:~6 --update-with-dependencies --working-dir=$DRUPAL_DIR
+  - test ${TEST_SUITE} == "PHP_CodeSniffer" || test ${TRAVIS_PHP_VERSION:0:3} == "5.6" || composer require --dev phpunit/phpunit:~6 --update-with-dependencies --working-dir=$DRUPAL_DIR
 
   # Start a web server on port 8888 in the background.
   - test ${TEST_SUITE} == "PHP_CodeSniffer" || nohup php -S localhost:8888 --docroot $DRUPAL_DIR > /dev/null 2>&1 &

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,4 +76,7 @@ before_script:
   # Export database variable for kernel tests.
   - export SIMPLETEST_DB=mysql://root:@127.0.0.1/og
 
+  # Disable all deprecations
+  - export SYMFONY_DEPRECATIONS_HELPER=disabled
+
 script: DRUPAL_DIR=$DRUPAL_DIR MODULE_DIR=$MODULE_DIR $MODULE_DIR/scripts/travis-ci/run-test.sh $TEST_SUITE

--- a/scripts/travis-ci/run-test.sh
+++ b/scripts/travis-ci/run-test.sh
@@ -11,7 +11,7 @@ mysql_to_ramdisk() {
   sudo service mysql start
 }
 
-TEST_DIRS=($MODULE_DIR/tests $MODULE_DIR/og_ui/tests)
+TEST_DIRS=($DRUPAL_DIR/modules/og/tests $DRUPAL_DIR/modules/og/og_ui/tests)
 
 case "$1" in
     PHP_CodeSniffer)


### PR DESCRIPTION
Hi, i tried to fix the Travis CI Integration. You can see the debugging process in my commits. The additional ``composer install`` inside the og Repo caused some issue. The class loader in this folder is picked up by the test-runner oder Drupal?

It was not problem in the past, because the code inside the module and /drupal/vendor was similar. But the diff between multiple versions of Drupal gets bigger over time.