### PR TITLE
Fix config import of og role actions

### DIFF
--- a/og.module
+++ b/og.module
@@ -374,8 +374,13 @@ function og_og_role_insert(OgRoleInterface $role) {
     return;
   }
 
+  // Do not create config while config import is in progress.
+  if (\Drupal::isConfigSyncing()) {
+    return;
+  }
+
   $add_id = 'og_membership_add_single_role_action.' . $role->getName();
-  if (!Action::load($add_id) && !\Drupal::isConfigSyncing()) {
+  if (!Action::load($add_id)) {
     $action = Action::create([
       'id' => $add_id,
       'type' => 'og_membership',
@@ -388,7 +393,7 @@ function og_og_role_insert(OgRoleInterface $role) {
     $action->trustData()->save();
   }
   $remove_id = 'og_membership_remove_single_role_action.' . $role->getName();
-  if (!Action::load($remove_id) && !\Drupal::isConfigSyncing()) {
+  if (!Action::load($remove_id)) {
     $action = Action::create([
       'id' => $remove_id,
       'type' => 'og_membership',

--- a/og.module
+++ b/og.module
@@ -379,7 +379,7 @@ function og_og_role_insert(OgRoleInterface $role) {
   }
 
   $add_id = 'og_membership_add_single_role_action.' . $role->getName();
-  if (!Action::load($add_id)) {
+  if (!Action::load($add_id) && !\Drupal::isConfigSyncing()) {
     $action = Action::create([
       'id' => $add_id,
       'type' => 'og_membership',
@@ -392,7 +392,7 @@ function og_og_role_insert(OgRoleInterface $role) {
     $action->trustData()->save();
   }
   $remove_id = 'og_membership_remove_single_role_action.' . $role->getName();
-  if (!Action::load($remove_id)) {
+  if (!Action::load($remove_id) && !\Drupal::isConfigSyncing()) {
     $action = Action::create([
       'id' => $remove_id,
       'type' => 'og_membership',


### PR DESCRIPTION
Config import fails when og_og_role_insert() tries to create actions:
                                                                               
```
In ConfigImportCommands.php line 259:

  The import failed due to the following reasons:                              

  Deleted and replaced configuration entity "system.action.og_membership_add_single_role_action.administrator"

  Deleted and replaced configuration entity "system.action.og_membership_remove_single_role_action.administrator"
```

See #441.