### PR TITLE
Add alter hook to modify whether the 'Other groups' field is visible

### DIFF
--- a/includes/og.field.inc
+++ b/includes/og.field.inc
@@ -50,15 +50,21 @@ function og_field_widget_form(&$form, &$form_state, $field, $instance, $langcode
   ctools_include('fields');
 
   $field_modes = array('default');
-  $has_admin = FALSE;
+  $has_admin = user_access('administer group');
+  $context = array(
+    'field' => $field,
+    'instance' => $instance,
+    'entity_type' => $entity_type,
+    'entity' => $entity,
+  );
+  drupal_alter('og_field_widget_has_admin', $has_admin, $context);
 
   // The group IDs that might not be accessible by the user, but we need
   // to keep even after saving.
   $element['#other_groups_ids'] = array();
   $element['#element_validate'][] = 'og_complex_widget_element_validate';
 
-  if (user_access('administer group')) {
-    $has_admin = TRUE;
+  if ($has_admin) {
     $field_modes[] = 'admin';
   }
 

--- a/og.api.php
+++ b/og.api.php
@@ -454,6 +454,23 @@ function hook_og_membership_delete(OgMembership $og_membership) {
     ->execute();
 }
 
+/**
+ * Alter whether the 'Other groups' field is visible for the current user.
+ *
+ * By default, this is determined using the 'administer group' permission, but
+ * using this hook it can be hidden or made visible based on the field,
+ * instance and form state.
+ *
+ * @param $has_admin
+ *   Boolean indicating whether the 'Other groups' field is visible.
+ * @param $context
+ *   Array containing field, instance, entity_type and entity.
+ */
+function hook_og_field_widget_has_admin(&$has_admin, $context) {
+  if ($context['field']['field_name'] === 'field_test' && user_access('select all groups in field_test')) {
+    $has_admin = TRUE;
+  }
+}
 
 /**
  * @} End of "addtogroup hooks".


### PR DESCRIPTION
I want to show the 'Other groups' field in a specific case. Adding an alter hook gives me the possibility to override the default behavior.