### PR TITLE
Start testing Drupal 8.7 and PHP 7.3. Stop testing deprecated versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,30 +2,27 @@ language: php
 sudo: true
 
 php:
-  - 5.6
-  - 7.0
   - 7.1
   - 7.2
+  - 7.3
 
 env:
   global:
     - COMPOSER_MEMORY_LIMIT=2G
   matrix:
-    - TEST_SUITE=8.5.x
     - TEST_SUITE=8.6.x
+    - TEST_SUITE=8.7.x
     - TEST_SUITE=PHP_CodeSniffer
 
 # Only run the coding standards check once.
 matrix:
   exclude:
-    - php: 5.6
-      env: TEST_SUITE=PHP_CodeSniffer
-    - php: 7.0
-      env: TEST_SUITE=PHP_CodeSniffer
     - php: 7.1
       env: TEST_SUITE=PHP_CodeSniffer
+    - php: 7.2
+      env: TEST_SUITE=PHP_CodeSniffer
   allow_failures:
-    - env: TEST_SUITE=8.6.x
+    - env: TEST_SUITE=8.7.x
 
 mysql:
   database: og

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "source": "https://cgit.drupalcode.org/og"
     },
     "require": {
-        "drupal/core": "~8.5"
+        "drupal/core": "~8.6"
     },
     "require-dev": {
         "drupal/coder": "~8.2"

--- a/src/Controller/SubscriptionController.php
+++ b/src/Controller/SubscriptionController.php
@@ -5,6 +5,7 @@ namespace Drupal\og\Controller;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Url;
 use Drupal\og\OgAccessInterface;
 use Drupal\og\OgMembershipInterface;
@@ -21,7 +22,6 @@ use Drupal\og\Og;
  */
 class SubscriptionController extends ControllerBase {
 
-
   /**
    * OG access service.
    *
@@ -30,13 +30,23 @@ class SubscriptionController extends ControllerBase {
   protected $ogAccess;
 
   /**
+   * The messenger service.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+  /**
    * Constructs a SubscriptionController object.
    *
    * @param \Drupal\og\OgAccessInterface $og_access
    *   The OG access service.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   The messenger service.
    */
-  public function __construct(OgAccessInterface $og_access) {
+  public function __construct(OgAccessInterface $og_access, MessengerInterface $messenger) {
     $this->ogAccess = $og_access;
+    $this->messenger = $messenger;
   }
 
   /**
@@ -44,7 +54,8 @@ class SubscriptionController extends ControllerBase {
    */
   public static function create(ContainerInterface $container) {
     return new static(
-      $container->get('og.access')
+      $container->get('og.access'),
+      $container->get('messenger')
     );
   }
 
@@ -83,12 +94,12 @@ class SubscriptionController extends ControllerBase {
 
       if ($this->config('user.settings')->get('register') === USER_REGISTER_ADMINISTRATORS_ONLY) {
         $params = [':login' => $user_login_url];
-        drupal_set_message($this->t('In order to join any group, you must <a href=":login">login</a>. After you have successfully done so, you will need to request membership again.', $params));
+        $this->messenger->addMessage($this->t('In order to join any group, you must <a href=":login">login</a>. After you have successfully done so, you will need to request membership again.', $params));
       }
       else {
         $user_register_url = Url::fromRoute('user.register', [], $destination)->toString();
         $params = [':register' => $user_register_url, ':login' => $user_login_url];
-        drupal_set_message($this->t('In order to join any group, you must <a href=":login">login</a> or <a href=":register">register</a> a new account. After you have successfully done so, you will need to request membership again.', $params));
+        $this->messenger->addMessage($this->t('In order to join any group, you must <a href=":login">login</a> or <a href=":register">register</a> a new account. After you have successfully done so, you will need to request membership again.', $params));
       }
 
       return new RedirectResponse(Url::fromRoute('user.page')->setAbsolute(TRUE)->toString());
@@ -119,7 +130,7 @@ class SubscriptionController extends ControllerBase {
     }
 
     if ($redirect) {
-      drupal_set_message($message, 'warning');
+      $this->messenger->addMessage($message, 'warning');
       return new RedirectResponse($group->toUrl()->setAbsolute(TRUE)->toString());
     }
 
@@ -164,7 +175,7 @@ class SubscriptionController extends ControllerBase {
 
     if ($group instanceof EntityOwnerInterface && $group->getOwnerId() == $user->id()) {
       // The user is the manager of the group.
-      drupal_set_message($this->t('As the manager of %group, you can not leave the group.', ['%group' => $group->label()]));
+      $this->messenger->addMessage($this->t('As the manager of %group, you can not leave the group.', ['%group' => $group->label()]));
 
       return new RedirectResponse($group->toUrl()
         ->setAbsolute()

--- a/src/Form/GroupSubscribeForm.php
+++ b/src/Form/GroupSubscribeForm.php
@@ -235,7 +235,7 @@ class GroupSubscribeForm extends ContentEntityForm {
     $group = $membership->getGroup();
 
     $message = $membership->isActive() ? $this->t('Your are now subscribed to the group.') : $this->t('Your subscription request was sent.');
-    drupal_set_message($message);
+    $this->messenger()->addMessage($message);
 
     // User doesn't have access to the group entity, so redirect to front page,
     // otherwise back to the group entity.

--- a/src/Form/GroupUnsubscribeConfirmForm.php
+++ b/src/Form/GroupUnsubscribeConfirmForm.php
@@ -62,7 +62,7 @@ class GroupUnsubscribeConfirmForm extends ContentEntityDeleteForm {
     $form_state->setRedirectUrl($redirect);
 
     $membership->delete();
-    drupal_set_message($this->t('You have unsubscribed from the group.'));
+    $this->messenger()->addMessage($this->t('You have unsubscribed from the group.'));
   }
 
 }

--- a/tests/src/Unit/SubscriptionControllerTest.php
+++ b/tests/src/Unit/SubscriptionControllerTest.php
@@ -5,6 +5,7 @@ namespace Drupal\Tests\og\Unit;
 use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityFormBuilderInterface;
+use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
 use Drupal\og\Controller\SubscriptionController;
@@ -51,6 +52,13 @@ class SubscriptionControllerTest extends UnitTestCase {
   protected $ogAccess;
 
   /**
+   * The mocked messenger service.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface|\Prophecy\Prophecy\ObjectProphecy
+   */
+  protected $messenger;
+
+  /**
    * The OG membership entity.
    *
    * @var \Drupal\og\OgMembershipInterface|\Prophecy\Prophecy\ObjectProphecy
@@ -79,6 +87,7 @@ class SubscriptionControllerTest extends UnitTestCase {
     $this->group = $this->prophesize(ContentEntityInterface::class);
     $this->membershipManager = $this->prophesize(MembershipManagerInterface::class);
     $this->ogAccess = $this->prophesize(OgAccessInterface::class);
+    $this->messenger = $this->prophesize(MessengerInterface::class);
     $this->ogMembership = $this->prophesize(OgMembershipInterface::class);
     $this->url = $this->prophesize(Url::class);
     $this->user = $this->prophesize(AccountInterface::class);
@@ -255,21 +264,8 @@ class SubscriptionControllerTest extends UnitTestCase {
    * Invoke the unsubscribe method.
    */
   protected function unsubscribe() {
-    $controller = new SubscriptionController($this->ogAccess->reveal());
+    $controller = new SubscriptionController($this->ogAccess->reveal(), $this->messenger->reveal());
     $controller->unsubscribe($this->group->reveal());
-  }
-
-}
-
-// @todo Delete after https://www.drupal.org/node/1858196 is in.
-namespace Drupal\og\Controller;
-
-if (!function_exists('drupal_set_message')) {
-
-  /**
-   * Mocking for drupal_set_message().
-   */
-  function drupal_set_message() {
   }
 
 }


### PR DESCRIPTION
- Disable deprecated versions of PHP and Drupal core.
- Start testing on Drupal 8.7.x and PHP 7.3, but still allow failures.
- We are already testing on 8.6.x but these are failing because `drupal_set_message()` is deprecated. Fix this.