### PR TITLE
Use cache api to store the group relation map

### DIFF
--- a/og.services.yml
+++ b/og.services.yml
@@ -42,7 +42,7 @@ services:
     arguments: ['@entity_type.manager', '@entity_field.manager']
   og.group_type_manager:
     class: Drupal\og\GroupTypeManager
-    arguments: ['@config.factory', '@entity_type.manager', '@entity_type.bundle.info', '@event_dispatcher', '@state', '@og.permission_manager', '@og.role_manager', '@router.builder', '@og.group_audience_helper']
+    arguments: ['@config.factory', '@entity_type.manager', '@entity_type.bundle.info', '@event_dispatcher', '@cache.data', '@og.permission_manager', '@og.role_manager', '@router.builder', '@og.group_audience_helper']
   og.membership_manager:
     class: Drupal\og\MembershipManager
     arguments: ['@entity_type.manager', '@og.group_audience_helper']

--- a/src/GroupTypeManager.php
+++ b/src/GroupTypeManager.php
@@ -6,7 +6,7 @@ use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Routing\RouteBuilderInterface;
-use Drupal\Core\State\StateInterface;
+use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\og\Event\GroupCreationEvent;
 use Drupal\og\Event\GroupCreationEventInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -57,11 +57,11 @@ class GroupTypeManager implements GroupTypeManagerInterface {
   protected $eventDispatcher;
 
   /**
-   * The state service.
+   * The cache backend.
    *
-   * @var \Drupal\Core\State\StateInterface
+   * @var \Drupal\Core\Cache\CacheBackendInterface
    */
-  protected $state;
+  protected $cache;
 
   /**
    * The OG permission manager.
@@ -142,8 +142,8 @@ class GroupTypeManager implements GroupTypeManagerInterface {
    *   The service providing information about bundles.
    * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $event_dispatcher
    *   The event dispatcher.
-   * @param \Drupal\Core\State\StateInterface $state
-   *   The state service.
+   * @param \Drupal\Core\Cache\CacheBackendInterface $cache
+   *   The cache backend.
    * @param \Drupal\og\PermissionManagerInterface $permission_manager
    *   The OG permission manager.
    * @param \Drupal\og\OgRoleManagerInterface $og_role_manager
@@ -153,11 +153,11 @@ class GroupTypeManager implements GroupTypeManagerInterface {
    * @param \Drupal\og\OgGroupAudienceHelperInterface $group_audience_helper
    *   The OG group audience helper.
    */
-  public function __construct(ConfigFactoryInterface $config_factory, EntityTypeManagerInterface $entity_type_manager, EntityTypeBundleInfoInterface $entity_type_bundle_info, EventDispatcherInterface $event_dispatcher, StateInterface $state, PermissionManagerInterface $permission_manager, OgRoleManagerInterface $og_role_manager, RouteBuilderInterface $route_builder, OgGroupAudienceHelperInterface $group_audience_helper) {
+  public function __construct(ConfigFactoryInterface $config_factory, EntityTypeManagerInterface $entity_type_manager, EntityTypeBundleInfoInterface $entity_type_bundle_info, EventDispatcherInterface $event_dispatcher, CacheBackendInterface $cache, PermissionManagerInterface $permission_manager, OgRoleManagerInterface $og_role_manager, RouteBuilderInterface $route_builder, OgGroupAudienceHelperInterface $group_audience_helper) {
     $this->configFactory = $config_factory;
     $this->entityTypeBundleInfo = $entity_type_bundle_info;
     $this->eventDispatcher = $event_dispatcher;
-    $this->state = $state;
+    $this->cache = $cache;
     $this->permissionManager = $permission_manager;
     $this->ogRoleManager = $og_role_manager;
     $this->routeBuilder = $route_builder;
@@ -331,7 +331,7 @@ class GroupTypeManager implements GroupTypeManagerInterface {
    */
   public function resetGroupRelationMap() {
     $this->groupRelationMap = [];
-    $this->state->delete(self::GROUP_RELATION_MAP_CACHE_KEY);
+    $this->cache->delete(self::GROUP_RELATION_MAP_CACHE_KEY);
   }
 
   /**
@@ -370,7 +370,7 @@ class GroupTypeManager implements GroupTypeManagerInterface {
    */
   protected function refreshGroupRelationMap() {
     // Retrieve a cached version of the map if it exists.
-    if ($group_relation_map = $this->state->get(self::GROUP_RELATION_MAP_CACHE_KEY)) {
+    if ($group_relation_map = $this->cache->get(self::GROUP_RELATION_MAP_CACHE_KEY)) {
       $this->groupRelationMap = $group_relation_map;
       return;
     }
@@ -395,7 +395,7 @@ class GroupTypeManager implements GroupTypeManagerInterface {
       }
     }
     // Cache the map.
-    $this->state->set(self::GROUP_RELATION_MAP_CACHE_KEY, $this->groupRelationMap);
+    $this->cache->set(self::GROUP_RELATION_MAP_CACHE_KEY, $this->groupRelationMap);
   }
 
 }

--- a/tests/src/Unit/GroupTypeManagerTest.php
+++ b/tests/src/Unit/GroupTypeManagerTest.php
@@ -331,7 +331,7 @@ class GroupTypeManagerTest extends UnitTestCase {
       $this->entityTypeManager->reveal(),
       $this->entityTypeBundleInfo->reveal(),
       $this->eventDispatcher->reveal(),
-      $this->state->reveal(),
+      $this->cache->reveal(),
       $this->permissionManager->reveal(),
       $this->ogRoleManager->reveal(),
       $this->routeBuilder->reveal(),

--- a/tests/src/Unit/GroupTypeManagerTest.php
+++ b/tests/src/Unit/GroupTypeManagerTest.php
@@ -2,13 +2,13 @@
 
 namespace Drupal\Tests\og\Unit;
 
+use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Config\Config;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Routing\RouteBuilderInterface;
-use Drupal\Core\State\StateInterface;
 use Drupal\og\Event\GroupCreationEvent;
 use Drupal\og\Event\GroupCreationEventInterface;
 use Drupal\og\GroupTypeManager;
@@ -87,11 +87,11 @@ class GroupTypeManagerTest extends UnitTestCase {
   protected $permissionEvent;
 
   /**
-   * The state prophecy used in the test.
+   * The cache prophecy used in the test.
    *
-   * @var \Drupal\Core\State\StateInterface|\Prophecy\Prophecy\ObjectProphecy
+   * @var \Drupal\Core\Cache\CacheBackendInterface|\Prophecy\Prophecy\ObjectProphecy
    */
-  protected $state;
+  protected $cache;
 
   /**
    * The OG permission manager prophecy used in the test.
@@ -135,7 +135,7 @@ class GroupTypeManagerTest extends UnitTestCase {
     $this->ogRoleManager = $this->prophesize(OgRoleManagerInterface::class);
     $this->permissionEvent = $this->prophesize(PermissionEventInterface::class);
     $this->permissionManager = $this->prophesize(PermissionManagerInterface::class);
-    $this->state = $this->prophesize(StateInterface::class);
+    $this->cache = $this->prophesize(CacheBackendInterface::class);
     $this->routeBuilder = $this->prophesize(RouteBuilderInterface::class);
     $this->groupAudienceHelper = $this->prophesize(OgGroupAudienceHelperInterface::class);
   }


### PR DESCRIPTION
This should fix #440.

I used simple Cache API but it may be useful to add cache tags and invalidations here.