### PR TITLE
Provide a way to retrieve all group memberships by role

### DIFF
--- a/src/MembershipManager.php
+++ b/src/MembershipManager.php
@@ -401,6 +401,10 @@ class MembershipManager implements MembershipManagerInterface {
    *   The membership entities.
    */
   protected function loadMemberships(array $ids) {
+    if (empty($ids)) {
+      return [];
+    }
+
     return $this->entityTypeManager
       ->getStorage('og_membership')
       ->loadMultiple($ids);

--- a/src/MembershipManager.php
+++ b/src/MembershipManager.php
@@ -83,17 +83,13 @@ class MembershipManager implements MembershipManagerInterface {
   public function getMemberships(AccountInterface $user, array $states = [OgMembershipInterface::STATE_ACTIVE]) {
     // When an empty array is passed, retrieve memberships with all possible
     // states.
-    $states = $states ?: OgMembership::ALL_STATES;
-
-    // Get a string identifier of the states, so we can retrieve it from cache.
-    sort($states);
-    $states_identifier = implode('|', array_unique($states));
+    $states = $this->prepareConditionArray($states, OgMembership::ALL_STATES);
 
     $identifier = [
       __METHOD__,
       'user',
       $user->id(),
-      $states_identifier,
+      implode('|', $states),
     ];
     $identifier = implode(':', $identifier);
 
@@ -108,9 +104,7 @@ class MembershipManager implements MembershipManagerInterface {
       $this->cache[$identifier] = $query->execute();
     }
 
-    return $this->entityTypeManager
-      ->getStorage('og_membership')
-      ->loadMultiple($this->cache[$identifier]);
+    return $this->loadMemberships($this->cache[$identifier]);
   }
 
   /**
@@ -125,6 +119,59 @@ class MembershipManager implements MembershipManagerInterface {
 
     // No membership matches the request.
     return NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getGroupMembershipsByRoleNames(EntityInterface $group, array $role_names, array $states = [OgMembershipInterface::STATE_ACTIVE]) {
+    if (empty($role_names)) {
+      throw new \InvalidArgumentException('The array of role names should not be empty.');
+    }
+
+    // In case the 'member' role is one of the requested roles, we just need to
+    // return all memberships. We can safely ignore all other roles.
+    $retrieve_all_memberships = FALSE;
+    if (in_array(OgRoleInterface::AUTHENTICATED, $role_names)) {
+      $retrieve_all_memberships = TRUE;
+      $role_names = [OgRoleInterface::AUTHENTICATED];
+    }
+
+    $role_names = $this->prepareConditionArray($role_names);
+    $states = $this->prepareConditionArray($states, OgMembership::ALL_STATES);
+
+    $identifier = [
+      __METHOD__,
+      $group->id(),
+      implode('|', $role_names),
+      implode('|', $states),
+    ];
+    $identifier = implode(':', $identifier);
+
+    // Only query the database if no cached result exists.
+    if (!isset($this->cache[$identifier])) {
+      $entity_type_id = $group->getEntityTypeId();
+
+      $query = $this->entityTypeManager
+        ->getStorage('og_membership')
+        ->getQuery()
+        ->condition('entity_type', $entity_type_id)
+        ->condition('entity_id', $group->id())
+        ->condition('state', $states, 'IN');
+
+      if (!$retrieve_all_memberships) {
+        $bundle_id = $group->bundle();
+        $role_ids = array_map(function ($role_name) use ($entity_type_id, $bundle_id) {
+          return implode('-', [$entity_type_id, $bundle_id, $role_name]);
+        }, $role_names);
+
+        $query->condition('roles', $role_ids, 'IN');
+      }
+
+      $this->cache[$identifier] = $query->execute();
+    }
+
+    return $this->loadMemberships($this->cache[$identifier]);
   }
 
   /**
@@ -316,6 +363,47 @@ class MembershipManager implements MembershipManagerInterface {
    */
   public function reset() {
     $this->cache = [];
+  }
+
+  /**
+   * Prepares a conditional array for use in a cache identifier and query.
+   *
+   * This will filter out any duplicate values from the array and sort the
+   * values so that a consistent cache identifier can be generated. Optionally
+   * it can substitute an empty array with a default value.
+   *
+   * @param array $value
+   *   The array to prepare.
+   * @param array|null $default
+   *   An optional default value to use in case the passed in value is empty. If
+   *   set to NULL this will be ignored.
+   *
+   * @return array
+   *   The prepared array.
+   */
+  protected function prepareConditionArray(array $value, array $default = NULL) {
+    // Fall back to the default value if the passed in value is empty and a
+    // default value is given.
+    if (empty($value) && $default !== NULL) {
+      $value = $default;
+    }
+    sort($value);
+    return array_unique($value);
+  }
+
+  /**
+   * Returns the full membership entities with the given memberships IDs.
+   *
+   * @param array $ids
+   *   The IDs of the memberships to load.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface[]
+   *   The membership entities.
+   */
+  protected function loadMemberships(array $ids) {
+    return $this->entityTypeManager
+      ->getStorage('og_membership')
+      ->loadMultiple($ids);
   }
 
 }

--- a/src/MembershipManagerInterface.php
+++ b/src/MembershipManagerInterface.php
@@ -89,6 +89,23 @@ interface MembershipManagerInterface {
   public function getMembership(EntityInterface $group, AccountInterface $user, array $states = [OgMembershipInterface::STATE_ACTIVE]);
 
   /**
+   * Returns the memberships of the given group filtered by role name.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $group
+   *   The group entity for which to return the memberships.
+   * @param array $role_names
+   *   An array of role names to filter by.
+   * @param array $states
+   *   (optional) Array with the states to return. Defaults to only returning
+   *   active memberships. In order to retrieve all memberships regardless of
+   *   state, pass `OgMembershipInterface::ALL_STATES`.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface[]
+   *   The membership entities.
+   */
+  public function getGroupMembershipsByRoleNames(EntityInterface $group, array $role_names, array $states = [OgMembershipInterface::STATE_ACTIVE]);
+
+  /**
    * Creates an OG membership.
    *
    * @param \Drupal\Core\Entity\EntityInterface $group

--- a/tests/src/Kernel/Entity/GroupMembershipManagerTest.php
+++ b/tests/src/Kernel/Entity/GroupMembershipManagerTest.php
@@ -9,8 +9,12 @@ use Drupal\KernelTests\KernelTestBase;
 use Drupal\entity_test\Entity\EntityTest;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
+use Drupal\og\Entity\OgRole;
 use Drupal\og\Og;
 use Drupal\og\OgGroupAudienceHelperInterface;
+use Drupal\og\OgMembershipInterface;
+use Drupal\og\OgRoleInterface;
+use Drupal\Tests\og\Traits\OgMembershipCreationTrait;
 use Drupal\user\Entity\User;
 
 /**
@@ -20,6 +24,8 @@ use Drupal\user\Entity\User;
  * @coversDefaultClass \Drupal\og\MembershipManager
  */
 class GroupMembershipManagerTest extends KernelTestBase {
+
+  use OgMembershipCreationTrait;
 
   /**
    * {@inheritdoc}
@@ -48,11 +54,25 @@ class GroupMembershipManagerTest extends KernelTestBase {
   protected $groupContent;
 
   /**
+   * Test users.
+   *
+   * @var \Drupal\user\UserInterface[]
+   */
+  protected $users;
+
+  /**
    * The entity type manager.
    *
    * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
   protected $entityTypeManager;
+
+  /**
+   * The membership manager. This is the system under test.
+   *
+   * @var \Drupal\og\MembershipManagerInterface
+   */
+  protected $membershipManager;
 
   /**
    * {@inheritdoc}
@@ -70,12 +90,14 @@ class GroupMembershipManagerTest extends KernelTestBase {
     $this->installSchema('system', 'sequences');
 
     $this->entityTypeManager = $this->container->get('entity_type.manager');
+    $this->membershipManager = $this->container->get('og.membership_manager');
 
     $this->groups = [];
 
     // Create group admin user.
     $group_admin = User::create(['name' => $this->randomString()]);
     $group_admin->save();
+    $this->users[0] = $group_admin;
 
     // Create four groups of two different entity types.
     for ($i = 0; $i < 2; $i++) {
@@ -156,10 +178,7 @@ class GroupMembershipManagerTest extends KernelTestBase {
    * @dataProvider groupContentProvider
    */
   public function testGetGroupIds($group_type_id, $group_bundle, array $expected) {
-    /** @var \Drupal\og\MembershipManagerInterface $membership_manager */
-    $membership_manager = \Drupal::service('og.membership_manager');
-
-    $result = $membership_manager->getGroupIds($this->groupContent, $group_type_id, $group_bundle);
+    $result = $this->membershipManager->getGroupIds($this->groupContent, $group_type_id, $group_bundle);
 
     // Check that the correct number of results is returned.
     $this->assertEquals(count($expected, COUNT_RECURSIVE), count($result, COUNT_RECURSIVE));
@@ -181,8 +200,6 @@ class GroupMembershipManagerTest extends KernelTestBase {
    * @covers ::getGroups
    */
   public function testStaticCache() {
-    /** @var \Drupal\og\MembershipManagerInterface $membership_manager */
-    $membership_manager = \Drupal::service('og.membership_manager');
     $bundle_rev = mb_strtolower($this->randomMachineName());
     $bundle_with_bundle = mb_strtolower($this->randomMachineName());
     EntityTestBundle::create(['id' => $bundle_with_bundle, 'label' => $bundle_with_bundle])->save();
@@ -222,11 +239,11 @@ class GroupMembershipManagerTest extends KernelTestBase {
     // ensure that the next assertions are addressing the proper issue.
     $this->assertEquals($group_content_rev->id(), $group_content_with_bundle->id());
 
-    $group_content_rev_group = $membership_manager->getGroups($group_content_rev);
+    $group_content_rev_group = $this->membershipManager->getGroups($group_content_rev);
     /** @var \Drupal\node\NodeInterface $group */
     $group = reset($group_content_rev_group['node']);
     $this->assertEquals($this->groups['node'][0]->id(), $group->id());
-    $group_content_with_bundle_group = $membership_manager->getGroups($group_content_with_bundle);
+    $group_content_with_bundle_group = $this->membershipManager->getGroups($group_content_with_bundle);
     $group = reset($group_content_with_bundle_group['node']);
     $this->assertEquals($this->groups['node'][1]->id(), $group->id());
   }
@@ -247,10 +264,7 @@ class GroupMembershipManagerTest extends KernelTestBase {
    * @dataProvider groupContentProvider
    */
   public function testGetGroups($group_type_id, $group_bundle, array $expected) {
-    /** @var \Drupal\og\MembershipManagerInterface $membership_manager */
-    $membership_manager = \Drupal::service('og.membership_manager');
-
-    $result = $membership_manager->getGroups($this->groupContent, $group_type_id, $group_bundle);
+    $result = $this->membershipManager->getGroups($this->groupContent, $group_type_id, $group_bundle);
 
     // Check that the correct number of results is returned.
     $this->assertEquals(count($expected, COUNT_RECURSIVE), count($result, COUNT_RECURSIVE));
@@ -289,10 +303,7 @@ class GroupMembershipManagerTest extends KernelTestBase {
    * @dataProvider groupContentProvider
    */
   public function testGetGroupCount($group_type_id, $group_bundle, array $expected) {
-    /** @var \Drupal\og\MembershipManagerInterface $membership_manager */
-    $membership_manager = \Drupal::service('og.membership_manager');
-
-    $result = $membership_manager->getGroupCount($this->groupContent, $group_type_id, $group_bundle);
+    $result = $this->membershipManager->getGroupCount($this->groupContent, $group_type_id, $group_bundle);
 
     // Check that the correct results is returned.
     $this->assertEquals(count($expected, COUNT_RECURSIVE) - count($expected), $result);
@@ -316,6 +327,317 @@ class GroupMembershipManagerTest extends KernelTestBase {
       ['node', 'node_0', ['node' => [0]]],
       ['entity_test', 'entity_test_1', ['entity_test' => [1]]],
     ];
+  }
+
+  /**
+   * Tests retrieval of group memberships filtered by role names.
+   *
+   * @covers ::getGroupMembershipsByRoleNames
+   */
+  public function testGetGroupMembershipsByRoleNames() {
+    $this->createTestMemberships();
+
+    // Check that an exception is thrown if no role names are passed.
+    try {
+      $this->membershipManager->getGroupMembershipsByRoleNames($this->groups['node'][0], []);
+      $this->fail('MembershipManager::getGroupsMembershipsByRoleNames() throws an exception when called without passing any role names.');
+    }
+    catch (\InvalidArgumentException $e) {
+      // Expected result.
+    }
+
+    // Define a test matrix to iterate over. We're not using a data provider
+    // because the large number of test cases would slow down the test too much.
+    $matrix = [
+      'node' => [
+        0 => [
+          // All memberships with all possible states. The authenticated role
+          // covers all memberships.
+          [
+            'roles' => [OgRoleInterface::AUTHENTICATED],
+            'states' => OgMembershipInterface::ALL_STATES,
+            'expected_memberships' => [0, 1, 4, 7],
+          ],
+          // All memberships with all possible states, by passing an empty
+          // states array, and passing all defined roles.
+          [
+            'roles' => [
+              OgRoleInterface::AUTHENTICATED,
+              OgRoleInterface::ADMINISTRATOR,
+              'moderator',
+            ],
+            'states' => [],
+            'expected_memberships' => [0, 1, 4, 7],
+          ],
+          // Pending members.
+          [
+            'roles' => [OgRoleInterface::AUTHENTICATED],
+            'states' => [OgMembershipInterface::STATE_PENDING],
+            'expected_memberships' => [4],
+          ],
+        ],
+        1 => [
+          // All administrators.
+          [
+            'roles' => [OgRoleInterface::ADMINISTRATOR],
+            'states' => [],
+            'expected_memberships' => [2, 6],
+          ],
+          // Pending administrators.
+          [
+            'roles' => [OgRoleInterface::ADMINISTRATOR],
+            'states' => [OgMembershipInterface::STATE_PENDING],
+            'expected_memberships' => [2],
+          ],
+          // Blocked administrators. There are none.
+          [
+            'roles' => [OgRoleInterface::ADMINISTRATOR],
+            'states' => [OgMembershipInterface::STATE_BLOCKED],
+            'expected_memberships' => [],
+          ],
+          // Pending and blocked administrators and moderators. Should be the
+          // same result as the pending administrators, since there are no
+          // moderators or blocked users.
+          [
+            'roles' => [OgRoleInterface::ADMINISTRATOR, 'moderator'],
+            'states' => [
+              OgMembershipInterface::STATE_BLOCKED,
+              OgMembershipInterface::STATE_PENDING,
+            ],
+            'expected_memberships' => [2],
+          ],
+          // Switch the order of the arguments, this should not affect the
+          // result.
+          [
+            'roles' => ['moderator', OgRoleInterface::ADMINISTRATOR],
+            'states' => [
+              OgMembershipInterface::STATE_PENDING,
+              OgMembershipInterface::STATE_BLOCKED,
+            ],
+            'expected_memberships' => [2],
+          ],
+          // There are no pending or blocked moderators.
+          [
+            'roles' => ['moderator'],
+            'states' => [
+              OgMembershipInterface::STATE_BLOCKED,
+              OgMembershipInterface::STATE_PENDING,
+            ],
+            'expected_memberships' => [],
+          ],
+        ],
+      ],
+      'entity_test' => [
+        0 => [
+          // The first test entity group doesn't have any moderators or admins.
+          // Check that duplicated array values doesn't affect the result.
+          [
+            'roles' => [
+              'moderator',
+              OgRoleInterface::ADMINISTRATOR,
+              'moderator',
+              'moderator',
+              OgRoleInterface::ADMINISTRATOR,
+            ],
+            'states' => [
+              OgMembershipInterface::STATE_ACTIVE,
+              OgMembershipInterface::STATE_BLOCKED,
+              OgMembershipInterface::STATE_PENDING,
+              OgMembershipInterface::STATE_PENDING,
+              OgMembershipInterface::STATE_BLOCKED,
+              OgMembershipInterface::STATE_ACTIVE,
+            ],
+            'expected_memberships' => [],
+          ],
+        ],
+        // Check active members.
+        [
+          'roles' => [
+            OgRoleInterface::AUTHENTICATED,
+          ],
+          'states' => [
+            OgMembershipInterface::STATE_ACTIVE,
+          ],
+          'expected_memberships' => [0, 3],
+        ],
+        1 => [
+          // There are two blocked users in the second test entity group.
+          [
+            'roles' => [
+              OgRoleInterface::AUTHENTICATED,
+              OgRoleInterface::ADMINISTRATOR,
+              'moderator',
+            ],
+            'states' => [
+              OgMembershipInterface::STATE_BLOCKED,
+            ],
+            'expected_memberships' => [4, 7],
+          ],
+          // There is one blocked moderator.
+          [
+            'roles' => [
+              OgRoleInterface::ADMINISTRATOR,
+              'moderator',
+            ],
+            'states' => [
+              OgMembershipInterface::STATE_BLOCKED,
+            ],
+            'expected_memberships' => [4],
+          ],
+        ],
+      ],
+    ];
+
+    foreach ($matrix as $entity_type_id => $groups) {
+      foreach ($groups as $group_key => $test_cases) {
+        foreach ($test_cases as $test_case) {
+          $group = $this->groups[$entity_type_id][$group_key];
+          $role_names = $test_case['roles'];
+          $states = $test_case['states'];
+          $expected_memberships = $test_case['expected_memberships'];
+
+          /** @var \Drupal\og\OgMembershipInterface[] $actual_memberships */
+          $actual_memberships = $this->membershipManager->getGroupMembershipsByRoleNames($group, $role_names, $states);
+
+          $this->assertEquals(count($expected_memberships), count($actual_memberships));
+
+          foreach ($expected_memberships as $expected_membership_key) {
+            $expected_user_id = $this->users[$expected_membership_key]->id();
+            foreach ($actual_memberships as $actual_membership) {
+              if ($actual_membership->getOwnerId() == $expected_user_id) {
+                // Match found.
+                continue 2;
+              }
+            }
+            // The expected membership was not returned. Fail the test.
+            $this->fail("The membership for user $expected_membership_key is present in the result.");
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Creates a number of users that are members of the test groups.
+   */
+  protected function createTestMemberships() {
+    // Create a 'moderator' role in each of the test group types.
+    foreach (['node', 'entity_test'] as $entity_type_id) {
+      for ($i = 0; $i < 2; $i++) {
+        $bundle = "${entity_type_id}_$i";
+        $og_role = OgRole::create();
+        $og_role
+          ->setName('moderator')
+          ->setGroupType($entity_type_id)
+          ->setGroupBundle($bundle)
+          ->save();
+      }
+    }
+
+    // Create test users with different membership states in the various groups.
+    // Note that the group admin (test user 0) is also a member of all groups.
+    $matrix = [
+      // A user which is an active member of the first node group.
+      1 => [
+        'node' => [
+          0 => [
+            'state' => OgMembershipInterface::STATE_ACTIVE,
+            'roles' => [OgRoleInterface::AUTHENTICATED],
+          ],
+        ],
+      ],
+
+      // A user which is a pending administrator of the second node group.
+      2 => [
+        'node' => [
+          1 => [
+            'state' => OgMembershipInterface::STATE_PENDING,
+            'roles' => [OgRoleInterface::ADMINISTRATOR],
+          ],
+        ],
+      ],
+
+      // A user which is an active member of both test entity groups.
+      3 => [
+        'entity_test' => [
+          0 => [
+            'state' => OgMembershipInterface::STATE_ACTIVE,
+            'roles' => [OgRoleInterface::AUTHENTICATED],
+          ],
+          1 => [
+            'state' => OgMembershipInterface::STATE_ACTIVE,
+            'roles' => [OgRoleInterface::AUTHENTICATED],
+          ],
+        ],
+      ],
+
+      // A user which is a pending member of the first node group and a blocked
+      // moderator in the second test entity group.
+      4 => [
+        'node' => [
+          0 => [
+            'state' => OgMembershipInterface::STATE_PENDING,
+            'roles' => [OgRoleInterface::AUTHENTICATED],
+          ],
+        ],
+        'entity_test' => [
+          1 => [
+            'state' => OgMembershipInterface::STATE_BLOCKED,
+            'roles' => ['moderator'],
+          ],
+        ],
+      ],
+
+      // A user which is not subscribed to any of the groups.
+      5 => [],
+
+      // A user which is both an administrator and a moderator in the second
+      // node group.
+      6 => [
+        'node' => [
+          1 => [
+            'state' => OgMembershipInterface::STATE_ACTIVE,
+            'roles' => [OgRoleInterface::ADMINISTRATOR, 'moderator'],
+          ],
+        ],
+      ],
+
+      // A troll who is banned everywhere.
+      7 => [
+        'node' => [
+          0 => [
+            'state' => OgMembershipInterface::STATE_BLOCKED,
+            'roles' => [OgRoleInterface::AUTHENTICATED],
+          ],
+          1 => [
+            'state' => OgMembershipInterface::STATE_BLOCKED,
+            'roles' => [OgRoleInterface::AUTHENTICATED],
+          ],
+        ],
+        'entity_test' => [
+          0 => [
+            'state' => OgMembershipInterface::STATE_BLOCKED,
+            'roles' => [OgRoleInterface::AUTHENTICATED],
+          ],
+          1 => [
+            'state' => OgMembershipInterface::STATE_BLOCKED,
+            'roles' => [OgRoleInterface::AUTHENTICATED],
+          ],
+        ],
+      ],
+    ];
+
+    foreach ($matrix as $user_key => $entity_types) {
+      $user = User::create(['name' => $this->randomString()]);
+      $user->save();
+      $this->users[$user_key] = $user;
+      foreach ($entity_types as $entity_type_id => $groups) {
+        foreach ($groups as $group_key => $membership_info) {
+          $group = $this->groups[$entity_type_id][$group_key];
+          $this->createOgMembership($group, $user, $membership_info['roles'], $membership_info['state']);
+        }
+      }
+    }
   }
 
 }

--- a/tests/src/Kernel/Entity/GroupMembershipManagerTest.php
+++ b/tests/src/Kernel/Entity/GroupMembershipManagerTest.php
@@ -499,7 +499,7 @@ class GroupMembershipManagerTest extends KernelTestBase {
           /** @var \Drupal\og\OgMembershipInterface[] $actual_memberships */
           $actual_memberships = $this->membershipManager->getGroupMembershipsByRoleNames($group, $role_names, $states);
 
-          $this->assertEquals(count($expected_memberships), count($actual_memberships));
+          $this->assertSameSize($expected_memberships, $actual_memberships);
 
           foreach ($expected_memberships as $expected_membership_key) {
             $expected_user_id = $this->users[$expected_membership_key]->id();


### PR DESCRIPTION
Programmatically getting a list of all group memberships filtered by a certain role can be non-trivial to implement (for example getting a list of all administrators of a group).

Because all memberships are getting the "member" role by default this data is not saved in the database. This is implemented similarly to how core deals with user roles, but it means a simple entity query that filters by the role reference will not return any "member" roles.

The trick is to omit the condition when filtering by role. This might sound easy enough, but this is not obvious if you are not familiar with the inner workings of OG. To illustrate this, in my project I found a method that solved it by retrieving the full list of memberships and then filtering it down to get the required role. For one large group this was loading 23000 memberships to find 1 administrator :sweat_smile:

Let's help out by adding a convenient method to the `MembershipManager` that retrieves the memberships efficiently and caches the results.