### PR TITLE
Test against PHP 7.3 instead of 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: php
 
 php:
   - 5.6
-  - 7.0
+  - 7.3
 
 mysql:
   database: drupal


### PR DESCRIPTION
PHP 7.0 is no longer supported.  It would be good to test against a more recent version.
https://secure.php.net/supported-versions.php