### PR TITLE
Show uid in LogicException for existing membership

### DIFF
--- a/src/Entity/OgMembership.php
+++ b/src/Entity/OgMembership.php
@@ -463,7 +463,7 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
       ->execute();
 
     if ($count) {
-      throw new \LogicException(sprintf('An OG membership already exists for group of entity-type %s and ID: %s', $entity_type_id, $this->getGroup()->id()));
+      throw new \LogicException(sprintf('An OG membership already exists for uid %s in group of entity-type %s and ID: %s', $this->get('uid')->target_id, $entity_type_id, $this->getGroup()->id()));
     }
 
     parent::preSave($storage);


### PR DESCRIPTION
When using OG with migrations, the module can generate a series of import failures with exceptions that could be more useful.

    [error]  LogicException: An OG membership already exists for group of entity-type node and ID: 8553 in Drupal\og\Entity\OgMembership->preSave() (line 466 of /var/www/localhost/drupal/web/modules/contrib/og/src/Entity/OgMembership.php). 
    [error]  An OG membership already exists for group of entity-type node and ID: 8553 (/var/www/localhost/drupal/web/core/lib/Drupal/Core/Entity/Sql/SqlContentEntityStorage.php:783) 
    [error]  LogicException: An OG membership already exists for group of entity-type node and ID: 11100 in Drupal\og\Entity\OgMembership->preSave() (line 466 of /var/www/localhost/drupal/web/modules/contrib/og/src/Entity/OgMembership.php). 
    [error]  An OG membership already exists for group of entity-type node and ID: 11100 (/var/www/localhost/drupal/web/core/lib/Drupal/Core/Entity/Sql/SqlContentEntityStorage.php:783) 
    [error]  LogicException: An OG membership already exists for group of entity-type node and ID: 11113 in Drupal\og\Entity\OgMembership->preSave() (line 466 of /var/www/localhost/drupal/web/modules/contrib/og/src/Entity/OgMembership.php). 
    [error]  An OG membership already exists for group of entity-type node and ID: 11113 (/var/www/localhost/drupal/web/core/lib/Drupal/Core/Entity/Sql/SqlContentEntityStorage.php:783) 

Including the uid in these exceptions will make the reported error more actionable; that information probably would be implicit when the exception is surfaced through a subscribe UI but is not apparent when migrating thousands of user memberships.