### PR TITLE
Fix minor typo in subscribe form

### DIFF
--- a/src/Form/GroupSubscribeForm.php
+++ b/src/Form/GroupSubscribeForm.php
@@ -234,7 +234,7 @@ class GroupSubscribeForm extends ContentEntityForm {
     /** @var EntityInterface $group */
     $group = $membership->getGroup();
 
-    $message = $membership->isActive() ? $this->t('Your are now subscribed to the group.') : $this->t('Your subscription request was sent.');
+    $message = $membership->isActive() ? $this->t('You are now subscribed to the group.') : $this->t('Your subscription request was sent.');
     $this->messenger()->addMessage($message);
 
     // User doesn't have access to the group entity, so redirect to front page,

--- a/src/Form/GroupSubscribeForm.php
+++ b/src/Form/GroupSubscribeForm.php
@@ -234,7 +234,7 @@ class GroupSubscribeForm extends ContentEntityForm {
     /** @var EntityInterface $group */
     $group = $membership->getGroup();
 
-    $message = $membership->isActive() ? $this->t('You are now subscribed to the group.') : $this->t('Your subscription request was sent.');
+    $message = $membership->isActive() ? $this->t('You are now subscribed to the group.') : $this->t('Your subscription request has been sent.');
     $this->messenger()->addMessage($message);
 
     // User doesn't have access to the group entity, so redirect to front page,


### PR DESCRIPTION
Also issue [3014111](https://www.drupal.org/node/3014111) on d.o.

Should say "You are now subscribed" instead of "Your are now subscribed"