### PR TITLE
Set bundle form value in group permissions form

### DIFF
--- a/og_ui/og_ui.admin.inc
+++ b/og_ui/og_ui.admin.inc
@@ -720,6 +720,7 @@ function og_ui_admin_permissions($form, $form_state, $group_type = '', $gid = 0,
 
   if ($gid) {
     og_set_breadcrumb($group_type, $gid, array(l(t('Group'), "$group_type/$gid/group")));
+    list(, , $bundle) = entity_extract_ids($group_type, entity_load_single($group_type, $gid));
   }
 
   $form['group_type'] = array('#type' => 'value', '#value' => $group_type);


### PR DESCRIPTION
`$form['bundle']['#value']` is now also set when the group permissions form is displayed for a single group.

I use this value in a form alter hook and with this patch I only need to look at `$form['bundle']['#value']` to handle both the generic permissions form and the group specific form.