### PR TITLE
Use full pager on member overview

### DIFF
--- a/config/optional/views.view.og_members_overview.yml
+++ b/config/optional/views.view.og_members_overview.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   module:
     - og
+    - options
     - user
 _core:
   default_config_hash: RnChWtrF4u0Q13iQMFypL0Uz6IsB4NY6ZTk_LorSbJg
@@ -47,12 +48,17 @@ display:
           sort_asc_label: Asc
           sort_desc_label: Desc
       pager:
-        type: mini
+        type: full
         options:
-          items_per_page: 10
+          items_per_page: 50
           offset: 0
           id: 0
           total_pages: null
+          tags:
+            previous: ‹‹
+            next: ››
+            first: '« First'
+            last: 'Last »'
           expose:
             items_per_page: false
             items_per_page_label: 'Items per page'
@@ -61,9 +67,7 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          tags:
-            previous: ‹‹
-            next: ››
+          quantity: 9
       style:
         type: table
         options:

--- a/tests/src/Kernel/Views/OgAdminMembersViewTest.php
+++ b/tests/src/Kernel/Views/OgAdminMembersViewTest.php
@@ -27,6 +27,7 @@ class OgAdminMembersViewTest extends ViewsKernelTestBase {
     'field',
     'node',
     'og',
+    'options',
     'views',
   ];
 


### PR DESCRIPTION
At the moment the mini pager is used for the member overview:
<img width="214" alt="mini pager" src="https://user-images.githubusercontent.com/1823998/54362321-058abe80-4669-11e9-9fe5-e99305a6f60e.png">

Most Drupal admin overviews (e.g. content, people) use 50 items per page and a full pager:
<img width="372" alt="full pager" src="https://user-images.githubusercontent.com/1823998/54362319-058abe80-4669-11e9-96ac-cb5c36de5af9.png">
