### PR TITLE
Small optimization for adding/removing roles to/from memberships

### DIFF
--- a/src/Plugin/Action/AddSingleOgMembershipRole.php
+++ b/src/Plugin/Action/AddSingleOgMembershipRole.php
@@ -26,7 +26,7 @@ class AddSingleOgMembershipRole extends ChangeSingleOgMembershipRoleBase {
     $role_name = $this->configuration['role_name'];
     $role_id = implode('-', [
       $membership->getGroupEntityType(),
-      $membership->getGroup()->bundle(),
+      $membership->getGroupBundle(),
       $role_name,
     ]);
     // Only add the role if it is valid and doesn't exist yet.

--- a/src/Plugin/Action/RemoveSingleOgMembershipRole.php
+++ b/src/Plugin/Action/RemoveSingleOgMembershipRole.php
@@ -25,7 +25,7 @@ class RemoveSingleOgMembershipRole extends ChangeSingleOgMembershipRoleBase {
     $role_name = $this->configuration['role_name'];
     $role_id = implode('-', [
       $membership->getGroupEntityType(),
-      $membership->getGroup()->bundle(),
+      $membership->getGroupBundle(),
       $role_name,
     ]);
     // Skip removing the role from the membership if it doesn't have it.


### PR DESCRIPTION
The plugins that handle the addition and removal of roles do the following to retrieve the group bundle:

```
$membership->getGroup()->bundle();
```

However since the bundle is directly available on the membership it is not needed to load the full group entity for this. It can be changed to:

```
$membership->getGroupBundle();
```
