### PR TITLE
Add support for Drupal 8.7.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ env:
   global:
     - COMPOSER_MEMORY_LIMIT=2G
   matrix:
-    - TEST_SUITE=8.6.x
     - TEST_SUITE=8.7.x
     - TEST_SUITE=8.8.x
     - TEST_SUITE=PHP_CodeSniffer

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
   matrix:
     - TEST_SUITE=8.6.x
     - TEST_SUITE=8.7.x
+    - TEST_SUITE=8.8.x
     - TEST_SUITE=PHP_CodeSniffer
 
 # Only run the coding standards check once.
@@ -22,7 +23,7 @@ matrix:
     - php: 7.2
       env: TEST_SUITE=PHP_CodeSniffer
   allow_failures:
-    - env: TEST_SUITE=8.7.x
+    - env: TEST_SUITE=8.8.x
 
 mysql:
   database: og

--- a/composer.json
+++ b/composer.json
@@ -14,5 +14,6 @@
     },
     "require-dev": {
         "drupal/coder": "~8.2"
-    }
+    },
+    "minimum-stability": "RC"
 }

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "source": "https://cgit.drupalcode.org/og"
     },
     "require": {
-        "drupal/core": "~8.6"
+        "drupal/core": "~8.7"
     },
     "require-dev": {
         "drupal/coder": "~8.2"

--- a/src/Entity/OgMembershipType.php
+++ b/src/Entity/OgMembershipType.php
@@ -25,6 +25,11 @@ use Drupal\og\OgMembershipTypeInterface;
  *   entity_keys = {
  *     "id" = "type",
  *     "label" = "name"
+ *   },
+ *   config_export = {
+ *     "type",
+ *     "name",
+ *     "description"
  *   }
  * )
  */

--- a/src/Plugin/Condition/GroupType.php
+++ b/src/Plugin/Condition/GroupType.php
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @Condition(
  *   id = "og_group_type",
  *   label = @Translation("Group type"),
- *   context = {
+ *   context_definitions = {
  *     "og" = @ContextDefinition("entity", label = @Translation("Group"))
  *   }
  * )

--- a/tests/src/Functional/OgComplexWidgetTest.php
+++ b/tests/src/Functional/OgComplexWidgetTest.php
@@ -7,9 +7,9 @@ use Drupal\block_content\Entity\BlockContentType;
 use Drupal\node\Entity\Node;
 use Drupal\og\Og;
 use Drupal\og\OgGroupAudienceHelperInterface;
-use Drupal\simpletest\BrowserTestBase;
-use Drupal\simpletest\ContentTypeCreationTrait;
-use Drupal\simpletest\NodeCreationTrait;
+use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\node\Traits\ContentTypeCreationTrait;
+use Drupal\Tests\node\Traits\NodeCreationTrait;
 
 /**
  * Tests the complex widget.
@@ -88,7 +88,6 @@ class OgComplexWidgetTest extends BrowserTestBase {
     $this->assertSession()->statusCodeEquals(200);
 
     // Retrieve the post that was created from the database.
-    /** @var QueryInterface $query */
     $query = $this->container->get('entity_type.manager')->getStorage('node')->getQuery();
     $result = $query
       ->condition('type', 'post')
@@ -97,7 +96,7 @@ class OgComplexWidgetTest extends BrowserTestBase {
       ->execute();
     $post_nid = reset($result);
 
-    /** @var \Drupal\node\Entity\NodeInterface $post */
+    /** @var \Drupal\node\NodeInterface $post */
     $post = Node::load($post_nid);
 
     // Check that the post references the group correctly.

--- a/tests/src/Kernel/Access/OgGroupContentOperationAccessTest.php
+++ b/tests/src/Kernel/Access/OgGroupContentOperationAccessTest.php
@@ -235,6 +235,7 @@ class OgGroupContentOperationAccessTest extends KernelTestBase {
               'comment_type' => $bundle_id,
               'entity_id' => $this->group->id(),
               'entity_type' => 'entity_test',
+              'field_name' => 'an_imaginary_field',
               OgGroupAudienceHelperInterface::DEFAULT_FIELD => [['target_id' => $this->group->id()]],
             ];
             break;

--- a/tests/src/Kernel/Action/ActionTestBase.php
+++ b/tests/src/Kernel/Action/ActionTestBase.php
@@ -84,7 +84,7 @@ abstract class ActionTestBase extends KernelTestBase {
     $this->installEntitySchema('og_membership');
     $this->installEntitySchema('user');
     $this->installEntitySchema('node');
-    $this->installSchema('system', ['queue', 'sequences']);
+    $this->installSchema('system', ['sequences']);
 
     $this->membershipManager = $this->container->get('og.membership_manager');
     $this->groupTypeManager = $this->container->get('og.group_type_manager');

--- a/tests/src/Kernel/Entity/EntityCreateAccessTest.php
+++ b/tests/src/Kernel/Entity/EntityCreateAccessTest.php
@@ -7,8 +7,8 @@ use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
 use Drupal\og\Og;
 use Drupal\og\OgGroupAudienceHelperInterface;
-use Drupal\simpletest\ContentTypeCreationTrait;
-use Drupal\simpletest\NodeCreationTrait;
+use Drupal\Tests\node\Traits\ContentTypeCreationTrait;
+use Drupal\Tests\node\Traits\NodeCreationTrait;
 use Drupal\user\Entity\Role;
 use Drupal\user\Entity\User;
 

--- a/tests/src/Kernel/GroupManagerSubscriptionTest.php
+++ b/tests/src/Kernel/GroupManagerSubscriptionTest.php
@@ -63,7 +63,7 @@ class GroupManagerSubscriptionTest extends KernelTestBase {
     $this->installEntitySchema('node');
     $this->installEntitySchema('og_membership');
     $this->installEntitySchema('user');
-    $this->installSchema('system', ['queue', 'sequences']);
+    $this->installSchema('system', ['sequences']);
 
     // Create a group type.
     NodeType::create([

--- a/tests/src/Kernel/GroupTypeConditionTest.php
+++ b/tests/src/Kernel/GroupTypeConditionTest.php
@@ -61,7 +61,7 @@ class GroupTypeConditionTest extends KernelTestBase {
     $this->installEntitySchema('entity_test');
     $this->installEntitySchema('node');
     $this->installEntitySchema('user');
-    $this->installSchema('system', ['queue', 'sequences']);
+    $this->installSchema('system', ['sequences']);
 
     // Create three test groups of different types.
     for ($i = 0; $i < 2; $i++) {

--- a/tests/src/Kernel/OgDeleteOrphansTest.php
+++ b/tests/src/Kernel/OgDeleteOrphansTest.php
@@ -61,7 +61,7 @@ class OgDeleteOrphansTest extends KernelTestBase {
     $this->installEntitySchema('user');
     $this->installEntitySchema('node');
     $this->installSchema('node', 'node_access');
-    $this->installSchema('system', ['queue', 'sequences']);
+    $this->installSchema('system', ['sequences']);
 
     /** @var \Drupal\og\OgDeleteOrphansPluginManager $plugin_manager */
     $plugin_manager = \Drupal::service('plugin.manager.og.delete_orphans');

--- a/tests/src/Kernel/Views/OgAdminMembersViewTest.php
+++ b/tests/src/Kernel/Views/OgAdminMembersViewTest.php
@@ -5,7 +5,7 @@ namespace Drupal\Tests\og\Kernel\Views;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
 use Drupal\og\Og;
-use Drupal\simpletest\UserCreationTrait;
+use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\Tests\views\Kernel\ViewsKernelTestBase;
 use Drupal\views\Views;
 


### PR DESCRIPTION
The first release candidate of Drupal 8.7 has been released. This is a good moment to start supporting Drupal 8.7, and start experimental support of Drupal 8.8.