### PR TITLE
Provide a method to retrieve the membership IDs of a given group

### DIFF
--- a/src/MembershipManager.php
+++ b/src/MembershipManager.php
@@ -178,7 +178,8 @@ class MembershipManager implements MembershipManagerInterface {
    * {@inheritdoc}
    */
   public function getGroupMembershipsByRoleNames(EntityInterface $group, array $role_names, array $states = [OgMembershipInterface::STATE_ACTIVE]) {
-    return $this->loadMemberships($this->getGroupMembershipIdsByRoleNames($group, $role_names, $states));
+    $ids = $this->getGroupMembershipIdsByRoleNames($group, $role_names, $states);
+    return $this->loadMemberships($ids);
   }
 
   /**

--- a/src/MembershipManager.php
+++ b/src/MembershipManager.php
@@ -124,7 +124,7 @@ class MembershipManager implements MembershipManagerInterface {
   /**
    * {@inheritdoc}
    */
-  public function getGroupMembershipsByRoleNames(EntityInterface $group, array $role_names, array $states = [OgMembershipInterface::STATE_ACTIVE]) {
+  public function getGroupMembershipIdsByRoleNames(EntityInterface $group, array $role_names, array $states = [OgMembershipInterface::STATE_ACTIVE]) {
     if (empty($role_names)) {
       throw new \InvalidArgumentException('The array of role names should not be empty.');
     }
@@ -171,7 +171,14 @@ class MembershipManager implements MembershipManagerInterface {
       $this->cache[$identifier] = $query->execute();
     }
 
-    return $this->loadMemberships($this->cache[$identifier]);
+    return $this->cache[$identifier];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getGroupMembershipsByRoleNames(EntityInterface $group, array $role_names, array $states = [OgMembershipInterface::STATE_ACTIVE]) {
+    return $this->loadMemberships($this->getGroupMembershipIdsByRoleNames($group, $role_names, $states));
   }
 
   /**

--- a/src/MembershipManagerInterface.php
+++ b/src/MembershipManagerInterface.php
@@ -89,12 +89,31 @@ interface MembershipManagerInterface {
   public function getMembership(EntityInterface $group, AccountInterface $user, array $states = [OgMembershipInterface::STATE_ACTIVE]);
 
   /**
+   * Returns the membership IDs of the given group filtered by role name.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $group
+   *   The group entity for which to return the memberships.
+   * @param array $role_names
+   *   An array of role names to filter by. In order to retrieve a list of all
+   *   membership IDs, pass `[OgRoleInterface::AUTHENTICATED]`.
+   * @param array $states
+   *   (optional) Array with the states to return. Defaults to only returning
+   *   active membership IDs. In order to retrieve all membership IDs regardless
+   *   of state, pass `OgMembershipInterface::ALL_STATES`.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface[]
+   *   The membership entities.
+   */
+  public function getGroupMembershipIdsByRoleNames(EntityInterface $group, array $role_names, array $states = [OgMembershipInterface::STATE_ACTIVE]);
+
+  /**
    * Returns the memberships of the given group filtered by role name.
    *
    * @param \Drupal\Core\Entity\EntityInterface $group
    *   The group entity for which to return the memberships.
    * @param array $role_names
-   *   An array of role names to filter by.
+   *   An array of role names to filter by. In order to retrieve a list of all
+   *   memberships, pass `[OgRoleInterface::AUTHENTICATED]`.
    * @param array $states
    *   (optional) Array with the states to return. Defaults to only returning
    *   active memberships. In order to retrieve all memberships regardless of

--- a/src/MembershipManagerInterface.php
+++ b/src/MembershipManagerInterface.php
@@ -89,7 +89,7 @@ interface MembershipManagerInterface {
   public function getMembership(EntityInterface $group, AccountInterface $user, array $states = [OgMembershipInterface::STATE_ACTIVE]);
 
   /**
-   * Returns the membership IDs of the given group filtered by role name.
+   * Returns the membership IDs of the given group filtered by role names.
    *
    * @param \Drupal\Core\Entity\EntityInterface $group
    *   The group entity for which to return the memberships.


### PR DESCRIPTION
For many of the methods in `MembershipManager` that return entity data we offer two versions for convenience: one that returns IDs, and one that returns fully loaded entities. See for example:

* `::getUserGroups()` vs `::getUserGroupIds()`
* `::getGroups()` vs `::getGroupIds()`

This PR adds a new method `::getGroupMembershipIdsByRoleNames()` which is equivalent to `::getGroupMembershipsByRoleNames()` but avoids to load the full entity objects.

I am needing this since I am implementing a block that shows the membership count of a group for #472 but it would be wasteful to load the full `OgMembership` entities just to get a count.