### PR TITLE
Only allow users with `access user profiles` permission to access the members overview

### DIFF
--- a/config/optional/views.view.og_members_overview.yml
+++ b/config/optional/views.view.og_members_overview.yml
@@ -25,7 +25,7 @@ display:
       access:
         type: perm
         options:
-          perm: 'access content'
+          perm: 'access user profiles'
       cache:
         type: none
         options: {  }


### PR DESCRIPTION
Fixes #474.