### PR TITLE
MembershipManager returns memberships of the wrong group

### DIFF
--- a/src/MembershipManager.php
+++ b/src/MembershipManager.php
@@ -142,6 +142,7 @@ class MembershipManager implements MembershipManagerInterface {
 
     $identifier = [
       __METHOD__,
+      $group->getEntityTypeId(),
       $group->id(),
       implode('|', $role_names),
       implode('|', $states),

--- a/tests/src/Kernel/Entity/GroupMembershipManagerTest.php
+++ b/tests/src/Kernel/Entity/GroupMembershipManagerTest.php
@@ -526,6 +526,15 @@ class GroupMembershipManagerTest extends KernelTestBase {
             ],
             'expected_memberships' => [4, 7],
           ],
+          // There is one pending administrator, just as in the node group with
+          // the same entity ID. This ensures that the correct result will be
+          // returned for groups that have different entity types but the same
+          // entity ID.
+          [
+            'roles' => [OgRoleInterface::ADMINISTRATOR],
+            'states' => [OgMembershipInterface::STATE_PENDING],
+            'expected_memberships' => [8],
+          ],
           // There is one blocked moderator.
           [
             'roles' => [
@@ -673,6 +682,17 @@ class GroupMembershipManagerTest extends KernelTestBase {
           1 => [
             'state' => OgMembershipInterface::STATE_BLOCKED,
             'roles' => [OgRoleInterface::AUTHENTICATED],
+          ],
+        ],
+      ],
+
+      // A user which is a pending administrator of the second test entity
+      // group.
+      8 => [
+        'entity_test' => [
+          1 => [
+            'state' => OgMembershipInterface::STATE_PENDING,
+            'roles' => [OgRoleInterface::ADMINISTRATOR],
           ],
         ],
       ],


### PR DESCRIPTION
There is a bug in `MembershipManager::getGroupMembershipIdsByRoleNames()` and `::getGroupMembershipsByRoleNames()`: when there are multiple groups with different entity types but the same entity ID then the results of the first group will be cached and will be returned for the other groups.

We should include the entity type in the cache ID.