### PR TITLE
Add slack to support channels

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "support": {
         "issues": "https://drupal.org/project/issues/og",
         "irc": "irc://irc.freenode.org/drupal-og",
-        "slack": "slack://channel?team=T06GX3JTS&id=CELR48EA0",
+        "slack": "https://drupal.slack.com/messages/CELR48EA0",
         "source": "https://git.drupalcode.org/project/og"
     },
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     "support": {
         "issues": "https://drupal.org/project/issues/og",
         "irc": "irc://irc.freenode.org/drupal-og",
+        "slack": "slack://channel?team=T06GX3JTS&id=CELR48EA0",
         "source": "https://cgit.drupalcode.org/og"
     },
     "require": {


### PR DESCRIPTION
There's now an #og channel on drupal.slack.com
See slack://channel?team=T06GX3JTS&id=CELR48EA0