### PR TITLE
Use strict types in the OgMembership entity

### DIFF
--- a/og.module
+++ b/og.module
@@ -72,8 +72,8 @@ function og_entity_update(EntityInterface $entity) {
  */
 function og_entity_predelete(EntityInterface $entity) {
   if (Og::isGroup($entity->getEntityTypeId(), $entity->bundle())) {
-    // Register orphaned group content for deletion, if this option has been
-    // enabled.
+    // Register orphaned group content and user memberships for deletion, if
+    // this option has been enabled.
     $config = \Drupal::config('og.settings');
     if ($config->get('delete_orphans')) {
       $plugin_id = $config->get('delete_orphans_plugin_id');

--- a/src/Entity/OgMembership.php
+++ b/src/Entity/OgMembership.php
@@ -184,14 +184,10 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
   /**
    * {@inheritdoc}
    */
-  public function getGroup(): ContentEntityInterface {
+  public function getGroup(): ?ContentEntityInterface {
     assert(!empty($this->get('entity_type')->value) || !empty($this->get('entity_id')->value), new \LogicException(__METHOD__ . '() should only be called on loaded memberships, or on newly created memberships that already have the group set.'));
     $entity_type = $this->get('entity_type')->value;
     $entity_id = $this->get('entity_id')->value;
-
-    if (empty($entity_type) || empty($entity_id)) {
-      return NULL;
-    }
 
     return \Drupal::entityTypeManager()->getStorage($entity_type)->load($entity_id);
   }

--- a/src/Entity/OgMembership.php
+++ b/src/Entity/OgMembership.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Drupal\og\Entity;
 
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Entity\ContentEntityBase;
-use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
@@ -80,14 +82,14 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
   /**
    * {@inheritdoc}
    */
-  public function getCreatedTime() {
+  public function getCreatedTime(): int {
     return $this->get('created')->value;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function setCreatedTime($timestamp) {
+  public function setCreatedTime(int $timestamp): OgMembershipInterface {
     $this->set('created', $timestamp);
     return $this;
   }
@@ -125,7 +127,7 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
   /**
    * {@inheritdoc}
    */
-  public function setGroup(EntityInterface $group) {
+  public function setGroup(ContentEntityInterface $group): OgMembershipInterface {
     $this->set('entity_type', $group->getEntityTypeId());
     $this->set('entity_bundle', $group->bundle());
     $this->set('entity_id', $group->id());
@@ -135,21 +137,21 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
   /**
    * {@inheritdoc}
    */
-  public function getGroupEntityType() {
+  public function getGroupEntityType(): string {
     return $this->get('entity_type')->value;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function getGroupBundle() {
+  public function getGroupBundle(): string {
     return $this->get('entity_bundle')->value;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function getGroupId() {
+  public function getGroupId(): string {
     return $this->get('entity_id')->value;
   }
 
@@ -170,14 +172,14 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
    * @return bool
    *   Whether or not the group is already present.
    */
-  protected function hasGroup() {
+  protected function hasGroup(): bool {
     return !empty($this->get('entity_type')->value) && !empty($this->get('entity_bundle')->value) && !empty($this->get('entity_id')->value);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function getGroup() {
+  public function getGroup(): ContentEntityInterface {
     $entity_type = $this->get('entity_type')->value;
     $entity_id = $this->get('entity_id')->value;
 
@@ -191,7 +193,7 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
   /**
    * {@inheritdoc}
    */
-  public function setState($state) {
+  public function setState(string $state): OgMembershipInterface {
     $this->set('state', $state);
     return $this;
   }
@@ -199,21 +201,21 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
   /**
    * {@inheritdoc}
    */
-  public function getState() {
+  public function getState(): string {
     return $this->get('state')->value;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function getType() {
+  public function getType(): string {
     return $this->bundle();
   }
 
   /**
    * {@inheritdoc}
    */
-  public function addRole(OgRoleInterface $role) {
+  public function addRole(OgRoleInterface $role): OgMembershipInterface {
     $roles = $this->getRoles();
     $roles[] = $role;
 
@@ -223,14 +225,14 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
   /**
    * {@inheritdoc}
    */
-  public function revokeRole(OgRoleInterface $role) {
+  public function revokeRole(OgRoleInterface $role): OgMembershipInterface {
     return $this->revokeRoleById($role->id());
   }
 
   /**
    * {@inheritdoc}
    */
-  public function revokeRoleById($role_id) {
+  public function revokeRoleById(string $role_id): OgMembershipInterface {
     $roles = $this->getRoles();
 
     foreach ($roles as $key => $existing_role) {
@@ -248,7 +250,7 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
   /**
    * {@inheritdoc}
    */
-  public function getRoles() {
+  public function getRoles(): array {
     $roles = [];
 
     // Add the member role. This is only possible if a group has been set on the
@@ -265,7 +267,7 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
   /**
    * {@inheritdoc}
    */
-  public function setRoles(array $roles = []) {
+  public function setRoles(array $roles = []): OgMembershipInterface {
     $roles = array_filter($roles, function (OgRole $role) {
       return !($role->getName() == OgRoleInterface::AUTHENTICATED);
     });
@@ -281,7 +283,7 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
   /**
    * {@inheritdoc}
    */
-  public function getRolesIds() {
+  public function getRolesIds(): array {
     return array_map(function (OgRole $role) {
       return $role->id();
     }, $this->getRoles());
@@ -290,7 +292,7 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
   /**
    * {@inheritdoc}
    */
-  public function isRoleValid(OgRoleInterface $role) {
+  public function isRoleValid(OgRoleInterface $role): bool {
     $group = $this->getGroup();
 
     // If there is no group yet then we cannot determine whether the role is
@@ -316,14 +318,14 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
   /**
    * {@inheritdoc}
    */
-  public function hasRole($role_id) {
+  public function hasRole(string $role_id): bool {
     return in_array($role_id, $this->getRolesIds());
   }
 
   /**
    * {@inheritdoc}
    */
-  public function hasPermission($permission) {
+  public function hasPermission(string $permission): bool {
     // Blocked users do not have any permissions.
     if ($this->isBlocked()) {
       return FALSE;
@@ -531,28 +533,28 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
   /**
    * {@inheritdoc}
    */
-  public function isActive() {
+  public function isActive(): bool {
     return $this->getState() === OgMembershipInterface::STATE_ACTIVE;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function isPending() {
+  public function isPending(): bool {
     return $this->getState() === OgMembershipInterface::STATE_PENDING;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function isBlocked() {
+  public function isBlocked(): bool {
     return $this->getState() === OgMembershipInterface::STATE_BLOCKED;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function isOwner() {
+  public function isOwner(): bool {
     $group = $this->getGroup();
     return $group instanceof EntityOwnerInterface && $group->getOwnerId() == $this->getOwnerId();
   }

--- a/src/Entity/OgMembership.php
+++ b/src/Entity/OgMembership.php
@@ -98,6 +98,7 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
    * {@inheritdoc}
    */
   public function getOwner() {
+    assert(!empty($this->get('uid')->entity), new \LogicException(__METHOD__ . '() should only be called on loaded memberships, or on newly created memberships that already have the owner set.'));
     return $this->get('uid')->entity;
   }
 
@@ -105,6 +106,7 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
    * {@inheritdoc}
    */
   public function getOwnerId() {
+    assert(!empty($this->get('uid')->entity), new \LogicException(__METHOD__ . '() should only be called on loaded memberships, or on newly created memberships that already have the owner set.'));
     return $this->get('uid')->target_id;
   }
 
@@ -138,6 +140,7 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
    * {@inheritdoc}
    */
   public function getGroupEntityType(): string {
+    assert(!empty($this->get('entity_type')->value), new \LogicException(__METHOD__ . '() should only be called on loaded memberships, or on newly created memberships that already have the group type set.'));
     return $this->get('entity_type')->value;
   }
 
@@ -145,6 +148,7 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
    * {@inheritdoc}
    */
   public function getGroupBundle(): string {
+    assert(!empty($this->get('entity_bundle')->value), new \LogicException(__METHOD__ . '() should only be called on loaded memberships, or on newly created memberships that already have the group bundle set.'));
     return $this->get('entity_bundle')->value;
   }
 
@@ -152,6 +156,7 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
    * {@inheritdoc}
    */
   public function getGroupId(): string {
+    assert(!empty($this->get('entity_id')->value), new \LogicException(__METHOD__ . '() should only be called on loaded memberships, or on newly created memberships that already have the group ID set.'));
     return $this->get('entity_id')->value;
   }
 
@@ -180,6 +185,7 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
    * {@inheritdoc}
    */
   public function getGroup(): ContentEntityInterface {
+    assert(!empty($this->get('entity_type')->value) || !empty($this->get('entity_id')->value), new \LogicException(__METHOD__ . '() should only be called on loaded memberships, or on newly created memberships that already have the group set.'));
     $entity_type = $this->get('entity_type')->value;
     $entity_id = $this->get('entity_id')->value;
 

--- a/src/OgMembershipInterface.php
+++ b/src/OgMembershipInterface.php
@@ -97,8 +97,8 @@ interface OgMembershipInterface extends ContentEntityInterface, EntityOwnerInter
    * Gets the group associated with the membership.
    *
    * @return \Drupal\Core\Entity\ContentEntityInterface|null
-   *   The group object which is referenced by the membership, or NULL if no
-   *   group has been set yet.
+   *   The group object which is referenced by the membership, or NULL if the
+   *   group no longer exists in the entity storage.
    */
   public function getGroup(): ?ContentEntityInterface;
 

--- a/src/OgMembershipInterface.php
+++ b/src/OgMembershipInterface.php
@@ -1,9 +1,10 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Drupal\og;
 
 use Drupal\Core\Entity\ContentEntityInterface;
-use Drupal\Core\Entity\EntityInterface;
 use Drupal\user\EntityOwnerInterface;
 
 /**
@@ -68,7 +69,7 @@ interface OgMembershipInterface extends ContentEntityInterface, EntityOwnerInter
    * @return int
    *   The membership creation timestamp.
    */
-  public function getCreatedTime();
+  public function getCreatedTime(): int;
 
   /**
    * Sets the membership creation timestamp.
@@ -79,27 +80,27 @@ interface OgMembershipInterface extends ContentEntityInterface, EntityOwnerInter
    * @return \Drupal\og\OgMembershipInterface
    *   The updated OG Membership object.
    */
-  public function setCreatedTime($timestamp);
+  public function setCreatedTime(int $timestamp): OgMembershipInterface;
 
   /**
    * Sets the group associated with the membership.
    *
-   * @param \Drupal\Core\Entity\EntityInterface $group
+   * @param \Drupal\Core\Entity\ContentEntityInterface $group
    *   The entity object.
    *
    * @return \Drupal\og\OgMembershipInterface
    *   The updated OG Membership object.
    */
-  public function setGroup(EntityInterface $group);
+  public function setGroup(ContentEntityInterface $group): OgMembershipInterface;
 
   /**
    * Gets the group associated with the membership.
    *
-   * @return \Drupal\Core\Entity\EntityInterface|null
+   * @return \Drupal\Core\Entity\ContentEntityInterface|null
    *   The group object which is referenced by the membership, or NULL if no
    *   group has been set yet.
    */
-  public function getGroup();
+  public function getGroup(): ?ContentEntityInterface;
 
   /**
    * Gets the group entity type.
@@ -107,7 +108,7 @@ interface OgMembershipInterface extends ContentEntityInterface, EntityOwnerInter
    * @return string
    *   The entity type.
    */
-  public function getGroupEntityType();
+  public function getGroupEntityType(): string;
 
   /**
    * Gets the group entity bundle.
@@ -115,7 +116,7 @@ interface OgMembershipInterface extends ContentEntityInterface, EntityOwnerInter
    * @return string
    *   The bundle.
    */
-  public function getGroupBundle();
+  public function getGroupBundle(): string;
 
   /**
    * Gets the group entity ID.
@@ -123,7 +124,7 @@ interface OgMembershipInterface extends ContentEntityInterface, EntityOwnerInter
    * @return string
    *   The entity identifier.
    */
-  public function getGroupId();
+  public function getGroupId(): string;
 
   /**
    * Sets the membership state.
@@ -137,7 +138,7 @@ interface OgMembershipInterface extends ContentEntityInterface, EntityOwnerInter
    * @return \Drupal\og\OgMembershipInterface
    *   The updated OG Membership object.
    */
-  public function setState($state);
+  public function setState(string $state): OgMembershipInterface;
 
   /**
    * Gets the membership state.
@@ -148,7 +149,7 @@ interface OgMembershipInterface extends ContentEntityInterface, EntityOwnerInter
    *   - OgMembershipInterface::STATE_PENDING
    *   - OgMembershipInterface::STATE_BLOCKED
    */
-  public function getState();
+  public function getState(): string;
 
   /**
    * Gets the membership type.
@@ -156,7 +157,7 @@ interface OgMembershipInterface extends ContentEntityInterface, EntityOwnerInter
    * @return string
    *   The bundle of the membership type.
    */
-  public function getType();
+  public function getType(): string;
 
   /**
    * Sets the group's roles for the current user group membership.
@@ -167,7 +168,7 @@ interface OgMembershipInterface extends ContentEntityInterface, EntityOwnerInter
    * @return \Drupal\og\OgMembershipInterface
    *   The updated OG Membership object.
    */
-  public function setRoles(array $roles = []);
+  public function setRoles(array $roles = []): OgMembershipInterface;
 
   /**
    * Adds a role to the user membership.
@@ -178,7 +179,7 @@ interface OgMembershipInterface extends ContentEntityInterface, EntityOwnerInter
    * @return \Drupal\og\OgMembershipInterface
    *   The updated OG Membership object.
    */
-  public function addRole(OgRoleInterface $role);
+  public function addRole(OgRoleInterface $role): OgMembershipInterface;
 
   /**
    * Revokes a role from the OG membership.
@@ -189,7 +190,7 @@ interface OgMembershipInterface extends ContentEntityInterface, EntityOwnerInter
    * @return \Drupal\og\OgMembershipInterface
    *   The updated OG Membership object.
    */
-  public function revokeRole(OgRoleInterface $role);
+  public function revokeRole(OgRoleInterface $role): OgMembershipInterface;
 
   /**
    * Revokes a role from the OG membership.
@@ -200,7 +201,7 @@ interface OgMembershipInterface extends ContentEntityInterface, EntityOwnerInter
    * @return \Drupal\og\OgMembershipInterface
    *   The updated OG Membership object.
    */
-  public function revokeRoleById($role_id);
+  public function revokeRoleById(string $role_id): OgMembershipInterface;
 
   /**
    * Gets all the referenced OG roles.
@@ -208,7 +209,7 @@ interface OgMembershipInterface extends ContentEntityInterface, EntityOwnerInter
    * @return \Drupal\og\Entity\OgRole[]
    *   List of OG roles the user own for the current membership instance.
    */
-  public function getRoles();
+  public function getRoles(): array;
 
   /**
    * Gets all the referenced OG role IDs.
@@ -216,7 +217,7 @@ interface OgMembershipInterface extends ContentEntityInterface, EntityOwnerInter
    * @return string[]
    *   List of OG role IDs that are granted in the membership.
    */
-  public function getRolesIds();
+  public function getRolesIds(): array;
 
   /**
    * Returns whether the given role is valid for this membership.
@@ -231,7 +232,7 @@ interface OgMembershipInterface extends ContentEntityInterface, EntityOwnerInter
    *   Thrown when the validity of the role cannot be established, for example
    *   because the group hasn't yet been set on the membership.
    */
-  public function isRoleValid(OgRoleInterface $role);
+  public function isRoleValid(OgRoleInterface $role): bool;
 
   /**
    * Checks if the membership has the role with the given ID.
@@ -242,7 +243,7 @@ interface OgMembershipInterface extends ContentEntityInterface, EntityOwnerInter
    * @return bool
    *   True if the membership has the role.
    */
-  public function hasRole($role_id);
+  public function hasRole(string $role_id): bool;
 
   /**
    * Checks if the user has a permission inside the group.
@@ -253,7 +254,7 @@ interface OgMembershipInterface extends ContentEntityInterface, EntityOwnerInter
    * @return bool
    *   TRUE if the user has permission.
    */
-  public function hasPermission($permission);
+  public function hasPermission(string $permission): bool;
 
   /**
    * Returns TRUE if the OG membership is active.
@@ -261,7 +262,7 @@ interface OgMembershipInterface extends ContentEntityInterface, EntityOwnerInter
    * @return bool
    *   TRUE if the OG membership is active, FALSE otherwise.
    */
-  public function isActive();
+  public function isActive(): bool;
 
   /**
    * Returns TRUE if the OG membership is pending.
@@ -269,7 +270,7 @@ interface OgMembershipInterface extends ContentEntityInterface, EntityOwnerInter
    * @return bool
    *   TRUE if the OG membership is pending, FALSE otherwise.
    */
-  public function isPending();
+  public function isPending(): bool;
 
   /**
    * Returns TRUE if the OG membership is blocked.
@@ -277,7 +278,7 @@ interface OgMembershipInterface extends ContentEntityInterface, EntityOwnerInter
    * @return bool
    *   TRUE if the OG membership is blocked, FALSE otherwise.
    */
-  public function isBlocked();
+  public function isBlocked(): bool;
 
   /**
    * Returns TRUE if the OG membership belongs to the group owner.
@@ -285,6 +286,6 @@ interface OgMembershipInterface extends ContentEntityInterface, EntityOwnerInter
    * @return bool
    *   TRUE if the OG membership belongs to the group owner, FALSE otherwise.
    */
-  public function isOwner();
+  public function isOwner(): bool;
 
 }

--- a/src/OgMembershipInterface.php
+++ b/src/OgMembershipInterface.php
@@ -98,7 +98,9 @@ interface OgMembershipInterface extends ContentEntityInterface, EntityOwnerInter
    *
    * @return \Drupal\Core\Entity\ContentEntityInterface|null
    *   The group object which is referenced by the membership, or NULL if the
-   *   group no longer exists in the entity storage.
+   *   group no longer exists in the entity storage. This can happen when the
+   *   cleanup of orphaned memberships is configured to be handled in a cron job
+   *   or batch process.
    */
   public function getGroup(): ?ContentEntityInterface;
 

--- a/tests/src/Kernel/Entity/OgMembershipTest.php
+++ b/tests/src/Kernel/Entity/OgMembershipTest.php
@@ -124,6 +124,32 @@ class OgMembershipTest extends KernelTestBase {
   }
 
   /**
+   * Tests getting the owner of a newly created membership.
+   *
+   * @covers ::getOwner
+   * @expectedException \LogicException
+   */
+  public function testGetOwnerOnNewMembership() {
+    // A brand new entity does not have an owner set yet. It should throw a
+    // logic exception.
+    $membership = OgMembership::create();
+    $membership->getOwner();
+  }
+
+  /**
+   * Tests getting the owner ID of a newly created membership.
+   *
+   * @covers ::getOwnerId
+   * @expectedException \LogicException
+   */
+  public function testGetOwnerIdOnNewMembership() {
+    // A brand new entity does not have an owner set yet. It should throw a
+    // logic exception.
+    $membership = OgMembership::create();
+    $membership->getOwnerId();
+  }
+
+  /**
    * Tests getting and setting owners by ID on OgMemberships.
    *
    * @covers ::getOwner
@@ -459,15 +485,25 @@ class OgMembershipTest extends KernelTestBase {
   public function testGetGroup() {
     $membership = OgMembership::create();
 
-    // When no group has been set yet, the method should return NULL.
-    $this->assertNull($membership->getGroup());
-
     // Set a group.
     $membership->setGroup($this->group);
 
     // Now the group should be returned. Check both the entity type and ID.
     $this->assertEquals($this->group->getEntityTypeId(), $membership->getGroup()->getEntityTypeId());
     $this->assertEquals($this->group->id(), $membership->getGroup()->id());
+  }
+
+  /**
+   * Tests getting the group from a new membership.
+   *
+   * @covers ::getGroup
+   * @expectedException \LogicException
+   */
+  public function testGetGroupOnNewMembership() {
+    $membership = OgMembership::create();
+
+    // When no group has been set yet, the method should throw an assertion.
+    $membership->getGroup();
   }
 
   /**
@@ -478,14 +514,87 @@ class OgMembershipTest extends KernelTestBase {
   public function testGetGroupBundle() {
     $membership = OgMembership::create();
 
-    // When no group has been set yet, the method should return NULL.
-    $this->assertNull($membership->getGroupBundle());
-
     // Set a group.
     $membership->setGroup($this->group);
 
     // Now the group bundle should be returned.
     $this->assertEquals($this->group->bundle(), $membership->getGroupBundle());
+  }
+
+  /**
+   * Tests getting the group bundle of a newly created membership.
+   *
+   * @covers ::getGroupBundle
+   * @expectedException \LogicException
+   */
+  public function testGetGroupBundleOnNewMembership() {
+    $membership = OgMembership::create();
+    $membership->getGroupBundle();
+  }
+
+  /**
+   * Tests getting the entity type ID of the group associated with a membership.
+   *
+   * @covers ::getGroupEntityType
+   */
+  public function testGetGroupEntityType() {
+    $membership = OgMembership::create();
+    $membership->setGroup($this->group);
+    $this->assertEquals($this->group->getEntityTypeId(), $membership->getGroupEntityType());
+  }
+
+  /**
+   * Tests getting the group entity type ID of a newly created membership.
+   *
+   * @covers ::getGroupEntityType
+   * @expectedException \LogicException
+   */
+  public function testGetGroupEntityTypeOnNewMembership() {
+    $membership = OgMembership::create();
+    $membership->getGroupEntityType();
+  }
+
+  /**
+   * Tests getting the ID of the group associated with a membership.
+   *
+   * @covers ::getGroupId
+   */
+  public function testGetGroupId() {
+    $membership = OgMembership::create();
+    $membership->setGroup($this->group);
+    $this->assertEquals($this->group->id(), $membership->getGroupId());
+  }
+
+  /**
+   * Tests getting the group ID of a newly created membership.
+   *
+   * @covers ::getGroupId
+   * @expectedException \LogicException
+   */
+  public function testGetGroupIdOnNewMembership() {
+    $membership = OgMembership::create();
+    $membership->getGroupId();
+  }
+
+  /**
+   * Tests getting and setting the creation time.
+   *
+   * @covers ::getCreatedTime
+   * @covers ::setCreatedTime
+   */
+  public function testGetSetCreatedTime() {
+    // When creating a brand new membership the request time should be set as
+    // the creation time.
+    $expected_time = $this->container->get('datetime.time')->getRequestTime();
+    $membership = OgMembership::create();
+    $this->assertEquals($expected_time, $membership->getCreatedTime());
+
+    // Try setting a custom creation time and retrieving it.
+    $custom_time = strtotime('January 1, 2019');
+    $created_time = $membership
+      ->setCreatedTime($custom_time)
+      ->getCreatedTime();
+    $this->assertEquals($custom_time, $created_time);
   }
 
   /**

--- a/tests/src/Unit/CreateMembershipTest.php
+++ b/tests/src/Unit/CreateMembershipTest.php
@@ -4,7 +4,7 @@ namespace Drupal\Tests\og\Unit;
 
 use Drupal\Core\Cache\MemoryCache\MemoryCacheInterface;
 use Drupal\Core\DependencyInjection\ContainerBuilder;
-use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\EntityTypeRepositoryInterface;
@@ -123,7 +123,7 @@ class CreateMembershipTest extends UnitTestCase {
       ->willReturn($membership_entity->reveal());
 
     // Create a mocked test group.
-    $this->group = $this->prophesize(EntityInterface::class);
+    $this->group = $this->prophesize(ContentEntityInterface::class);
 
     // Create a mocked test user.
     $this->user = $this->prophesize(UserInterface::class);


### PR DESCRIPTION
Since we are requiring PHP 7.1 and higher we can start leveraging the new security features of PHP 7.

This PR proposes to use strict typing in OgMembership entities. This will ensure that our code will not be subject to typing bugs. Unfortunately this effort is limited to our internal protected methods and public methods that we define ourselves; the Drupal interfaces are still supporting PHP 5 and do not define return types and scalar type hints.

Still, this will still enhance security and it will be interesting to see if we get any test failures which point to bugs in our code or test coverage.