### PR TITLE
Fix random failure in OgMembershipTest::testGetSetCreatedTime().

### DIFF
--- a/tests/src/Kernel/Entity/OgMembershipTest.php
+++ b/tests/src/Kernel/Entity/OgMembershipTest.php
@@ -585,7 +585,8 @@ class OgMembershipTest extends KernelTestBase {
   public function testGetSetCreatedTime() {
     // When creating a brand new membership the request time should be set as
     // the creation time.
-    $expected_time = $this->container->get('datetime.time')->getRequestTime();
+    // @todo Replace this with \Drupal::time()->getRequestTime() in Drupal 9.
+    $expected_time = (int) $_SERVER['REQUEST_TIME'];
     $membership = OgMembership::create();
     $this->assertEquals($expected_time, $membership->getCreatedTime());
 


### PR DESCRIPTION
`CreatedItem::applyDefaultValue()` is responsible for setting the created time on a newly created entity but still depends on the deprecated `REQUEST_TIME` constant. Switch back to this to avoid random failures when the time service is instantiated one second after the request time is set.

Fixes #502 