### PR TITLE
Fixed Uncaught Error: Cannot use object of type stdClass as array

### DIFF
--- a/src/GroupTypeManager.php
+++ b/src/GroupTypeManager.php
@@ -371,7 +371,7 @@ class GroupTypeManager implements GroupTypeManagerInterface {
   protected function refreshGroupRelationMap() {
     // Retrieve a cached version of the map if it exists.
     if ($group_relation_map = $this->cache->get(self::GROUP_RELATION_MAP_CACHE_KEY)) {
-      $this->groupRelationMap = $group_relation_map;
+      $this->groupRelationMap = $group_relation_map->data;
       return;
     }
 

--- a/src/GroupTypeManager.php
+++ b/src/GroupTypeManager.php
@@ -370,8 +370,8 @@ class GroupTypeManager implements GroupTypeManagerInterface {
    */
   protected function refreshGroupRelationMap() {
     // Retrieve a cached version of the map if it exists.
-    if ($group_relation_map = $this->cache->get(self::GROUP_RELATION_MAP_CACHE_KEY)) {
-      $this->groupRelationMap = $group_relation_map->data;
+    if ($data_cached = $this->cache->get(self::GROUP_RELATION_MAP_CACHE_KEY)) {
+      $this->groupRelationMap = $data_cached->data;
       return;
     }
 


### PR DESCRIPTION
( ! ) Fatal error: Uncaught Error: Cannot use object of type stdClass as array in web/modules/contrib/og/src/GroupTypeManager.php on line 268
--

In #450 we refactored the use `Drupal\Core\State\StateInterface` to `Drupal\Core\Cache\CacheBackendInterface` but CacheBackendInterface::get() returns an object with a data property (not an array).

```
object(stdClass)[6055]
  public 'cid' => string 'og.group_manager.group_relation_map' (length=35)
  public 'data' => 
    array (size=1)
      'node' => 
        array (size=1)
          'subsite' => 
            array (size=2)
              ...
  public 'created' => string '1557745337.212' (length=14)
  public 'expire' => string '-1' (length=2)
  public 'serialized' => string '1' (length=1)
  public 'tags' => 
    array (size=0)
      empty
  public 'checksum' => string '0' (length=1)
  public 'valid' => boolean true
```
