### PR TITLE
Fixed codesniffer errors

### DIFF
--- a/src/Access/GroupCheck.php
+++ b/src/Access/GroupCheck.php
@@ -8,7 +8,6 @@ use Drupal\Core\Routing\Access\AccessInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\og\Og;
-use Drupal\og\OgAccess;
 use Drupal\og\OgAccessInterface;
 use Symfony\Component\Routing\Route;
 

--- a/tests/src/Kernel/PermissionEventTest.php
+++ b/tests/src/Kernel/PermissionEventTest.php
@@ -170,7 +170,7 @@ class PermissionEventTest extends KernelTestBase {
       // Test retrieving permissions for a group that has no group content types
       // associated with it.
       [
-    [],
+        [],
         // It should only return the default permissions.
         $default_permissions,
         // The list of permissions should only contain the group level
@@ -183,9 +183,9 @@ class PermissionEventTest extends KernelTestBase {
       // Test retrieving permissions for a group that has a group content type
       // associated with it.
       [
-    [
-      'node' => ['test_group_content'],
-    ],
+        [
+          'node' => ['test_group_content'],
+        ],
         // It should return the default permissions as well as the permissions
         // to create, delete and update group content.
         array_merge($default_permissions, $group_content_permissions),


### PR DESCRIPTION
Not sure how this came about but it seems like we missed these codesniffer remarks:

```
FILE: /home/travis/build/zerolab/og/tests/src/Kernel/PermissionEventTest.php
--------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
--------------------------------------------------------------------------------
 186 | ERROR | [x] Line indented incorrectly; expected at least 6 spaces, found
     |       |     4
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------
FILE: /home/travis/build/zerolab/og/src/Access/GroupCheck.php
----------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
----------------------------------------------------------------------
 11 | WARNING | [x] Unused use statement
----------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------
```

I only noticed them on zerolab's repo.