### PR TITLE
Uncaught Error: Cannot use object of type stdClass as array

### DIFF
--- a/src/GroupTypeManager.php
+++ b/src/GroupTypeManager.php
@@ -370,8 +370,8 @@ class GroupTypeManager implements GroupTypeManagerInterface {
    */
   protected function refreshGroupRelationMap() {
     // Retrieve a cached version of the map if it exists.
-    if ($data_cached = $this->cache->get(self::GROUP_RELATION_MAP_CACHE_KEY)) {
-      $this->groupRelationMap = $data_cached->data;
+    if ($cached_map = $this->getCachedGroupRelationMap()) {
+      $this->groupRelationMap = $cached_map;
       return;
     }
 
@@ -396,6 +396,17 @@ class GroupTypeManager implements GroupTypeManagerInterface {
     }
     // Cache the map.
     $this->cache->set(self::GROUP_RELATION_MAP_CACHE_KEY, $this->groupRelationMap);
+  }
+
+  /**
+   * Returns the group relation map from the cache.
+   *
+   * @return array|null
+   *   An associative array representing group and group content relations, or
+   *   NULL if the group relation map was not found in the cache.
+   */
+  protected function getCachedGroupRelationMap(): ?array {
+    return $this->cache->get(self::GROUP_RELATION_MAP_CACHE_KEY)->data ?? NULL;
   }
 
 }

--- a/src/GroupTypeManager.php
+++ b/src/GroupTypeManager.php
@@ -371,7 +371,7 @@ class GroupTypeManager implements GroupTypeManagerInterface {
   protected function refreshGroupRelationMap() {
     // Retrieve a cached version of the map if it exists.
     if ($group_relation_map = $this->cache->get(self::GROUP_RELATION_MAP_CACHE_KEY)) {
-      $this->groupRelationMap = $group_relation_map;
+      $this->groupRelationMap = $group_relation_map->data;
       return;
     }
 

--- a/src/GroupTypeManager.php
+++ b/src/GroupTypeManager.php
@@ -370,8 +370,8 @@ class GroupTypeManager implements GroupTypeManagerInterface {
    */
   protected function refreshGroupRelationMap() {
     // Retrieve a cached version of the map if it exists.
-    if ($group_relation_map = $this->cache->get(self::GROUP_RELATION_MAP_CACHE_KEY)) {
-      $this->groupRelationMap = $group_relation_map->data;
+    if ($data_cached = $this->cache->get(self::GROUP_RELATION_MAP_CACHE_KEY)) {
+      $this->groupRelationMap = $data_cached->data;
       return;
     }
 

--- a/src/GroupTypeManager.php
+++ b/src/GroupTypeManager.php
@@ -352,7 +352,7 @@ class GroupTypeManager implements GroupTypeManagerInterface {
    */
   protected function getGroupRelationMap() {
     if (empty($this->groupRelationMap)) {
-      $this->refreshGroupRelationMap();
+      $this->populateGroupRelationMap();
     }
     return $this->groupRelationMap;
   }
@@ -368,7 +368,7 @@ class GroupTypeManager implements GroupTypeManagerInterface {
   /**
    * Populates the map of relations between group types and group content types.
    */
-  protected function refreshGroupRelationMap() {
+  protected function populateGroupRelationMap(): void {
     // Retrieve a cached version of the map if it exists.
     if ($cached_map = $this->getCachedGroupRelationMap()) {
       $this->groupRelationMap = $cached_map;


### PR DESCRIPTION
This PR replaces #504 with a test first approach.

Original report:

Fatal error: Uncaught Error: Cannot use object of type stdClass as array in web/modules/contrib/og/src/GroupTypeManager.php on line 268

In #450 we refactored the use `Drupal\Core\State\StateInterface` to `Drupal\Core\Cache\CacheBackendInterface` but CacheBackendInterface::get() returns an object with a data property (not an array).

```
object(stdClass)[6055]
  public 'cid' => string 'og.group_manager.group_relation_map' (length=35)
  public 'data' => 
    array (size=1)
      'node' => 
        array (size=1)
          'subsite' => 
            array (size=2)
              ...
  public 'created' => string '1557745337.212' (length=14)
  public 'expire' => string '-1' (length=2)
  public 'serialized' => string '1' (length=1)
  public 'tags' => 
    array (size=0)
      empty
  public 'checksum' => string '0' (length=1)
  public 'valid' => boolean true
```
