### PR TITLE
Don't add self referencing dependency when exporting og permissions

### DIFF
--- a/includes/og_features_permission.features.inc
+++ b/includes/og_features_permission.features.inc
@@ -33,7 +33,7 @@ function og_features_permission_features_export($data, &$export, $module_name = 
       if (isset($permissions[$group_type][$bundle][$perm]['module'])) {
         // Add the module which defines the permission as a dependency.
         $module = $permissions[$group_type][$bundle][$perm]['module'];
-        if ($module != $module_name) {
+        if ($module !== $module_name) {
           $export['dependencies'][$module] = $module;
         }
 

--- a/includes/og_features_permission.features.inc
+++ b/includes/og_features_permission.features.inc
@@ -33,7 +33,9 @@ function og_features_permission_features_export($data, &$export, $module_name = 
       if (isset($permissions[$group_type][$bundle][$perm]['module'])) {
         // Add the module which defines the permission as a dependency.
         $module = $permissions[$group_type][$bundle][$perm]['module'];
-        $export['dependencies'][$module] = $module;
+        if ($module != $module_name) {
+          $export['dependencies'][$module] = $module;
+        }
 
         $export['dependencies']['features'] = 'features';
         $export['dependencies']['og'] = 'og';


### PR DESCRIPTION
The function `og_features_permission_features_export()` prevents adding the module that provides a permission at the start of the function, but doesn't do so later on.