### PR TITLE
Do not require to pass the full user object when only the ID is required

### DIFF
--- a/og.module
+++ b/og.module
@@ -90,7 +90,7 @@ function og_entity_predelete(EntityInterface $entity) {
   if ($entity instanceof UserInterface) {
     /** @var \Drupal\og\MembershipManagerInterface $membership_manager */
     $membership_manager = \Drupal::service('og.membership_manager');
-    foreach ($membership_manager->getMemberships($entity, []) as $membership) {
+    foreach ($membership_manager->getMemberships($entity->id(), []) as $membership) {
       $membership->delete();
     }
   }

--- a/phpcs-ruleset.xml.dist
+++ b/phpcs-ruleset.xml.dist
@@ -13,5 +13,10 @@
     <exclude-pattern>*.min.css</exclude-pattern>
     <exclude-pattern>*.min.js</exclude-pattern>
 
-    <rule ref="./vendor/drupal/coder/coder_sniffer/Drupal" />
+    <rule ref="./vendor/drupal/coder/coder_sniffer/Drupal">
+        <!-- URLs in deprecation messages point to Github rather than drupal.org. -->
+        <exclude name="Drupal.Semantics.FunctionTriggerError.TriggerErrorSeeUrlFormat" />
+        <!-- Deprecation versions are allowed to include beta versions. -->
+        <exclude name="Drupal.Semantics.FunctionTriggerError.TriggerErrorVersion" />
+    </rule>
 </ruleset>

--- a/src/Cache/Context/OgMembershipStateCacheContext.php
+++ b/src/Cache/Context/OgMembershipStateCacheContext.php
@@ -77,7 +77,7 @@ class OgMembershipStateCacheContext implements CacheContextInterface {
     }
 
     /** @var \Drupal\og\OgMembershipInterface $membership */
-    $membership = $this->membershipManager->getMembership($group, $this->user, OgMembershipInterface::ALL_STATES);
+    $membership = $this->membershipManager->getMembership($group, $this->user->id(), OgMembershipInterface::ALL_STATES);
     return $membership ? $membership->getState() : self::NO_CONTEXT;
   }
 

--- a/src/Cache/Context/OgRoleCacheContext.php
+++ b/src/Cache/Context/OgRoleCacheContext.php
@@ -87,7 +87,7 @@ class OgRoleCacheContext extends UserCacheContextBase implements CacheContextInt
     // compute the hash once.
     if (empty($this->hashes[$this->user->id()])) {
       $memberships = [];
-      foreach ($this->membershipManager->getMemberships($this->user) as $membership) {
+      foreach ($this->membershipManager->getMemberships($this->user->id()) as $membership) {
         $role_names = array_map(function (OgRoleInterface $role) {
           return $role->getName();
         }, $membership->getRoles());

--- a/src/MembershipManager.php
+++ b/src/MembershipManager.php
@@ -63,7 +63,7 @@ class MembershipManager implements MembershipManagerInterface {
    * {@inheritdoc}
    */
   public function getUserGroupIds($user_id, array $states = [OgMembershipInterface::STATE_ACTIVE]) {
-    if (!is_int($user_id)) {
+    if ($user_id instanceof AccountInterface) {
       trigger_error('Passing an account object is deprecated in og:8.1.0-alpha4 and is removed from og:8.1.0-beta1. Instead pass the user ID as an integer value. See https://github.com/Gizra/og/issues/542', E_USER_DEPRECATED);
       $user_id = $user_id->id();
     }
@@ -82,7 +82,7 @@ class MembershipManager implements MembershipManagerInterface {
    * {@inheritdoc}
    */
   public function getUserGroups($user_id, array $states = [OgMembershipInterface::STATE_ACTIVE]) {
-    if (!is_int($user_id)) {
+    if ($user_id instanceof AccountInterface) {
       trigger_error('Passing an account object is deprecated in og:8.1.0-alpha4 and is removed from og:8.1.0-beta1. Instead pass the user ID as an integer value. See https://github.com/Gizra/og/issues/542', E_USER_DEPRECATED);
       $user_id = $user_id->id();
     }
@@ -95,7 +95,7 @@ class MembershipManager implements MembershipManagerInterface {
    * {@inheritdoc}
    */
   public function getMemberships($user_id, array $states = [OgMembershipInterface::STATE_ACTIVE]) {
-    if (!is_int($user_id)) {
+    if ($user_id instanceof AccountInterface) {
       trigger_error('Passing an account object is deprecated in og:8.1.0-alpha4 and is removed from og:8.1.0-beta1. Instead pass the user ID as an integer value. See https://github.com/Gizra/og/issues/542', E_USER_DEPRECATED);
       $user_id = $user_id->id();
     }
@@ -130,7 +130,7 @@ class MembershipManager implements MembershipManagerInterface {
    * {@inheritdoc}
    */
   public function getMembership(EntityInterface $group, $user_id, array $states = [OgMembershipInterface::STATE_ACTIVE]) {
-    if (!is_int($user_id)) {
+    if ($user_id instanceof AccountInterface) {
       trigger_error('Passing an account object is deprecated in og:8.1.0-alpha4 and is removed from og:8.1.0-beta1. Instead pass the user ID as an integer value. See https://github.com/Gizra/og/issues/542', E_USER_DEPRECATED);
       $user_id = $user_id->id();
     }
@@ -149,7 +149,7 @@ class MembershipManager implements MembershipManagerInterface {
    * {@inheritdoc}
    */
   public function getUserGroupIdsByRoleIds($user_id, array $role_ids, array $states = [OgMembershipInterface::STATE_ACTIVE], bool $require_all_roles = TRUE): array {
-    if (!is_int($user_id)) {
+    if ($user_id instanceof AccountInterface) {
       trigger_error('Passing an account object is deprecated in og:8.1.0-alpha4 and is removed from og:8.1.0-beta1. Instead pass the user ID as an integer value. See https://github.com/Gizra/og/issues/542', E_USER_DEPRECATED);
       $user_id = $user_id->id();
     }
@@ -172,7 +172,7 @@ class MembershipManager implements MembershipManagerInterface {
    * {@inheritdoc}
    */
   public function getUserGroupsByRoleIds($user_id, array $role_ids, array $states = [OgMembershipInterface::STATE_ACTIVE], bool $require_all_roles = TRUE): array {
-    if (!is_int($user_id)) {
+    if ($user_id instanceof AccountInterface) {
       trigger_error('Passing an account object is deprecated in og:8.1.0-alpha4 and is removed from og:8.1.0-beta1. Instead pass the user ID as an integer value. See https://github.com/Gizra/og/issues/542', E_USER_DEPRECATED);
       $user_id = $user_id->id();
     }
@@ -415,7 +415,7 @@ class MembershipManager implements MembershipManagerInterface {
    * {@inheritdoc}
    */
   public function isMember(EntityInterface $group, $user_id, array $states = [OgMembershipInterface::STATE_ACTIVE]) {
-    if (!is_int($user_id)) {
+    if ($user_id instanceof AccountInterface) {
       trigger_error('Passing an account object is deprecated in og:8.1.0-alpha4 and is removed from og:8.1.0-beta1. Instead pass the user ID as an integer value. See https://github.com/Gizra/og/issues/542', E_USER_DEPRECATED);
       $user_id = $user_id->id();
     }
@@ -429,7 +429,7 @@ class MembershipManager implements MembershipManagerInterface {
    * {@inheritdoc}
    */
   public function isMemberPending(EntityInterface $group, $user_id) {
-    if (!is_int($user_id)) {
+    if ($user_id instanceof AccountInterface) {
       trigger_error('Passing an account object is deprecated in og:8.1.0-alpha4 and is removed from og:8.1.0-beta1. Instead pass the user ID as an integer value. See https://github.com/Gizra/og/issues/542', E_USER_DEPRECATED);
       $user_id = $user_id->id();
     }
@@ -441,7 +441,7 @@ class MembershipManager implements MembershipManagerInterface {
    * {@inheritdoc}
    */
   public function isMemberBlocked(EntityInterface $group, $user_id) {
-    if (!is_int($user_id)) {
+    if ($user_id instanceof AccountInterface) {
       trigger_error('Passing an account object is deprecated in og:8.1.0-alpha4 and is removed from og:8.1.0-beta1. Instead pass the user ID as an integer value. See https://github.com/Gizra/og/issues/542', E_USER_DEPRECATED);
       $user_id = $user_id->id();
     }

--- a/src/MembershipManager.php
+++ b/src/MembershipManager.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Drupal\og;
 
 use Drupal\Component\Utility\NestedArray;
@@ -60,11 +62,15 @@ class MembershipManager implements MembershipManagerInterface {
   /**
    * {@inheritdoc}
    */
-  public function getUserGroupIds(AccountInterface $user, array $states = [OgMembershipInterface::STATE_ACTIVE]) {
+  public function getUserGroupIds($user_id, array $states = [OgMembershipInterface::STATE_ACTIVE]) {
+    if ($user_id instanceof AccountInterface) {
+      trigger_error('Passing an account object is deprecated in og:8.1.0-alpha4 and is removed from og:8.1.0-beta1. Pass the user ID instead.', E_USER_DEPRECATED);
+      $user_id = $user_id->id();
+    }
     $group_ids = [];
 
     /** @var \Drupal\og\Entity\OgMembership[] $memberships */
-    $memberships = $this->getMemberships($user, $states);
+    $memberships = $this->getMemberships($user_id, $states);
     foreach ($memberships as $membership) {
       $group_ids[$membership->getGroupEntityType()][] = $membership->getGroupId();
     }
@@ -75,22 +81,32 @@ class MembershipManager implements MembershipManagerInterface {
   /**
    * {@inheritdoc}
    */
-  public function getUserGroups(AccountInterface $user, array $states = [OgMembershipInterface::STATE_ACTIVE]) {
-    $group_ids = $this->getUserGroupIds($user, $states);
+  public function getUserGroups($user_id, array $states = [OgMembershipInterface::STATE_ACTIVE]) {
+    if ($user_id instanceof AccountInterface) {
+      trigger_error('Passing an account object is deprecated in og:8.1.0-alpha4 and is removed from og:8.1.0-beta1. Pass the user ID instead.', E_USER_DEPRECATED);
+      $user_id = $user_id->id();
+    }
+
+    $group_ids = $this->getUserGroupIds($user_id, $states);
     return $this->loadGroups($group_ids);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function getMemberships(AccountInterface $user, array $states = [OgMembershipInterface::STATE_ACTIVE]) {
+  public function getMemberships($user_id, array $states = [OgMembershipInterface::STATE_ACTIVE]) {
+    if ($user_id instanceof AccountInterface) {
+      trigger_error('Passing an account object is deprecated in og:8.1.0-alpha4 and is removed from og:8.1.0-beta1. Pass the user ID instead.', E_USER_DEPRECATED);
+      $user_id = $user_id->id();
+    }
+
     // When an empty array is passed, retrieve memberships with all possible
     // states.
     $states = $this->prepareConditionArray($states, OgMembership::ALL_STATES);
 
     $cid = [
       __METHOD__,
-      $user->id(),
+      $user_id,
       implode('|', $states),
     ];
     $cid = implode(':', $cid);
@@ -100,7 +116,7 @@ class MembershipManager implements MembershipManagerInterface {
       $query = $this->entityTypeManager
         ->getStorage('og_membership')
         ->getQuery()
-        ->condition('uid', $user->id())
+        ->condition('uid', $user_id)
         ->condition('state', $states, 'IN');
 
       $membership_ids = $query->execute();
@@ -113,8 +129,13 @@ class MembershipManager implements MembershipManagerInterface {
   /**
    * {@inheritdoc}
    */
-  public function getMembership(EntityInterface $group, AccountInterface $user, array $states = [OgMembershipInterface::STATE_ACTIVE]) {
-    foreach ($this->getMemberships($user, $states) as $membership) {
+  public function getMembership(EntityInterface $group, $user_id, array $states = [OgMembershipInterface::STATE_ACTIVE]) {
+    if ($user_id instanceof AccountInterface) {
+      trigger_error('Passing an account object is deprecated in og:8.1.0-alpha4 and is removed from og:8.1.0-beta1. Pass the user ID instead.', E_USER_DEPRECATED);
+      $user_id = $user_id->id();
+    }
+
+    foreach ($this->getMemberships($user_id, $states) as $membership) {
       if ($membership->getGroupEntityType() === $group->getEntityTypeId() && $membership->getGroupId() === $group->id()) {
         return $membership;
       }
@@ -127,9 +148,14 @@ class MembershipManager implements MembershipManagerInterface {
   /**
    * {@inheritdoc}
    */
-  public function getUserGroupIdsByRoleIds(AccountInterface $user, array $role_ids, array $states = [OgMembershipInterface::STATE_ACTIVE], bool $require_all_roles = TRUE): array {
+  public function getUserGroupIdsByRoleIds($user_id, array $role_ids, array $states = [OgMembershipInterface::STATE_ACTIVE], bool $require_all_roles = TRUE): array {
+    if ($user_id instanceof AccountInterface) {
+      trigger_error('Passing an account object is deprecated in og:8.1.0-alpha4 and is removed from og:8.1.0-beta1. Pass the user ID instead.', E_USER_DEPRECATED);
+      $user_id = $user_id->id();
+    }
+
     /** @var \Drupal\og\OgMembershipInterface[] $memberships */
-    $memberships = $this->getMemberships($user, $states);
+    $memberships = $this->getMemberships($user_id, $states);
     $memberships = array_filter($memberships, function (OgMembershipInterface $membership) use ($role_ids, $require_all_roles): bool {
       $membership_roles_ids = $membership->getRolesIds();
       return $require_all_roles ? empty(array_diff($role_ids, $membership_roles_ids)) : !empty(array_intersect($membership_roles_ids, $role_ids));
@@ -145,8 +171,13 @@ class MembershipManager implements MembershipManagerInterface {
   /**
    * {@inheritdoc}
    */
-  public function getUserGroupsByRoleIds(AccountInterface $user, array $role_ids, array $states = [OgMembershipInterface::STATE_ACTIVE], bool $require_all_roles = TRUE): array {
-    $group_ids = $this->getUserGroupIdsByRoleIds($user, $role_ids, $states, $require_all_roles);
+  public function getUserGroupsByRoleIds($user_id, array $role_ids, array $states = [OgMembershipInterface::STATE_ACTIVE], bool $require_all_roles = TRUE): array {
+    if ($user_id instanceof AccountInterface) {
+      trigger_error('Passing an account object is deprecated in og:8.1.0-alpha4 and is removed from og:8.1.0-beta1. Pass the user ID instead.', E_USER_DEPRECATED);
+      $user_id = $user_id->id();
+    }
+
+    $group_ids = $this->getUserGroupIdsByRoleIds($user_id, $role_ids, $states, $require_all_roles);
     return $this->loadGroups($group_ids);
   }
 
@@ -383,8 +414,13 @@ class MembershipManager implements MembershipManagerInterface {
   /**
    * {@inheritdoc}
    */
-  public function isMember(EntityInterface $group, AccountInterface $user, array $states = [OgMembershipInterface::STATE_ACTIVE]) {
-    $group_ids = $this->getUserGroupIds($user, $states);
+  public function isMember(EntityInterface $group, $user_id, array $states = [OgMembershipInterface::STATE_ACTIVE]) {
+    if ($user_id instanceof AccountInterface) {
+      trigger_error('Passing an account object is deprecated in og:8.1.0-alpha4 and is removed from og:8.1.0-beta1. Pass the user ID instead.', E_USER_DEPRECATED);
+      $user_id = $user_id->id();
+    }
+
+    $group_ids = $this->getUserGroupIds($user_id, $states);
     $entity_type_id = $group->getEntityTypeId();
     return !empty($group_ids[$entity_type_id]) && in_array($group->id(), $group_ids[$entity_type_id]);
   }
@@ -392,15 +428,25 @@ class MembershipManager implements MembershipManagerInterface {
   /**
    * {@inheritdoc}
    */
-  public function isMemberPending(EntityInterface $group, AccountInterface $user) {
-    return $this->isMember($group, $user, [OgMembershipInterface::STATE_PENDING]);
+  public function isMemberPending(EntityInterface $group, $user_id) {
+    if ($user_id instanceof AccountInterface) {
+      trigger_error('Passing an account object is deprecated in og:8.1.0-alpha4 and is removed from og:8.1.0-beta1. Pass the user ID instead.', E_USER_DEPRECATED);
+      $user_id = $user_id->id();
+    }
+
+    return $this->isMember($group, $user_id, [OgMembershipInterface::STATE_PENDING]);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function isMemberBlocked(EntityInterface $group, AccountInterface $user) {
-    return $this->isMember($group, $user, [OgMembershipInterface::STATE_BLOCKED]);
+  public function isMemberBlocked(EntityInterface $group, $user_id) {
+    if ($user_id instanceof AccountInterface) {
+      trigger_error('Passing an account object is deprecated in og:8.1.0-alpha4 and is removed from og:8.1.0-beta1. Pass the user ID instead.', E_USER_DEPRECATED);
+      $user_id = $user_id->id();
+    }
+
+    return $this->isMember($group, $user_id, [OgMembershipInterface::STATE_BLOCKED]);
   }
 
   /**

--- a/src/MembershipManager.php
+++ b/src/MembershipManager.php
@@ -63,8 +63,8 @@ class MembershipManager implements MembershipManagerInterface {
    * {@inheritdoc}
    */
   public function getUserGroupIds($user_id, array $states = [OgMembershipInterface::STATE_ACTIVE]) {
-    if ($user_id instanceof AccountInterface) {
-      trigger_error('Passing an account object is deprecated in og:8.1.0-alpha4 and is removed from og:8.1.0-beta1. Pass the user ID instead.', E_USER_DEPRECATED);
+    if (!is_int($user_id)) {
+      trigger_error('Passing an account object is deprecated in og:8.1.0-alpha4 and is removed from og:8.1.0-beta1. Instead pass the user ID as an integer value. See https://github.com/Gizra/og/issues/542', E_USER_DEPRECATED);
       $user_id = $user_id->id();
     }
     $group_ids = [];
@@ -82,8 +82,8 @@ class MembershipManager implements MembershipManagerInterface {
    * {@inheritdoc}
    */
   public function getUserGroups($user_id, array $states = [OgMembershipInterface::STATE_ACTIVE]) {
-    if ($user_id instanceof AccountInterface) {
-      trigger_error('Passing an account object is deprecated in og:8.1.0-alpha4 and is removed from og:8.1.0-beta1. Pass the user ID instead.', E_USER_DEPRECATED);
+    if (!is_int($user_id)) {
+      trigger_error('Passing an account object is deprecated in og:8.1.0-alpha4 and is removed from og:8.1.0-beta1. Instead pass the user ID as an integer value. See https://github.com/Gizra/og/issues/542', E_USER_DEPRECATED);
       $user_id = $user_id->id();
     }
 
@@ -95,8 +95,8 @@ class MembershipManager implements MembershipManagerInterface {
    * {@inheritdoc}
    */
   public function getMemberships($user_id, array $states = [OgMembershipInterface::STATE_ACTIVE]) {
-    if ($user_id instanceof AccountInterface) {
-      trigger_error('Passing an account object is deprecated in og:8.1.0-alpha4 and is removed from og:8.1.0-beta1. Pass the user ID instead.', E_USER_DEPRECATED);
+    if (!is_int($user_id)) {
+      trigger_error('Passing an account object is deprecated in og:8.1.0-alpha4 and is removed from og:8.1.0-beta1. Instead pass the user ID as an integer value. See https://github.com/Gizra/og/issues/542', E_USER_DEPRECATED);
       $user_id = $user_id->id();
     }
 
@@ -130,8 +130,8 @@ class MembershipManager implements MembershipManagerInterface {
    * {@inheritdoc}
    */
   public function getMembership(EntityInterface $group, $user_id, array $states = [OgMembershipInterface::STATE_ACTIVE]) {
-    if ($user_id instanceof AccountInterface) {
-      trigger_error('Passing an account object is deprecated in og:8.1.0-alpha4 and is removed from og:8.1.0-beta1. Pass the user ID instead.', E_USER_DEPRECATED);
+    if (!is_int($user_id)) {
+      trigger_error('Passing an account object is deprecated in og:8.1.0-alpha4 and is removed from og:8.1.0-beta1. Instead pass the user ID as an integer value. See https://github.com/Gizra/og/issues/542', E_USER_DEPRECATED);
       $user_id = $user_id->id();
     }
 
@@ -149,8 +149,8 @@ class MembershipManager implements MembershipManagerInterface {
    * {@inheritdoc}
    */
   public function getUserGroupIdsByRoleIds($user_id, array $role_ids, array $states = [OgMembershipInterface::STATE_ACTIVE], bool $require_all_roles = TRUE): array {
-    if ($user_id instanceof AccountInterface) {
-      trigger_error('Passing an account object is deprecated in og:8.1.0-alpha4 and is removed from og:8.1.0-beta1. Pass the user ID instead.', E_USER_DEPRECATED);
+    if (!is_int($user_id)) {
+      trigger_error('Passing an account object is deprecated in og:8.1.0-alpha4 and is removed from og:8.1.0-beta1. Instead pass the user ID as an integer value. See https://github.com/Gizra/og/issues/542', E_USER_DEPRECATED);
       $user_id = $user_id->id();
     }
 
@@ -172,8 +172,8 @@ class MembershipManager implements MembershipManagerInterface {
    * {@inheritdoc}
    */
   public function getUserGroupsByRoleIds($user_id, array $role_ids, array $states = [OgMembershipInterface::STATE_ACTIVE], bool $require_all_roles = TRUE): array {
-    if ($user_id instanceof AccountInterface) {
-      trigger_error('Passing an account object is deprecated in og:8.1.0-alpha4 and is removed from og:8.1.0-beta1. Pass the user ID instead.', E_USER_DEPRECATED);
+    if (!is_int($user_id)) {
+      trigger_error('Passing an account object is deprecated in og:8.1.0-alpha4 and is removed from og:8.1.0-beta1. Instead pass the user ID as an integer value. See https://github.com/Gizra/og/issues/542', E_USER_DEPRECATED);
       $user_id = $user_id->id();
     }
 
@@ -415,8 +415,8 @@ class MembershipManager implements MembershipManagerInterface {
    * {@inheritdoc}
    */
   public function isMember(EntityInterface $group, $user_id, array $states = [OgMembershipInterface::STATE_ACTIVE]) {
-    if ($user_id instanceof AccountInterface) {
-      trigger_error('Passing an account object is deprecated in og:8.1.0-alpha4 and is removed from og:8.1.0-beta1. Pass the user ID instead.', E_USER_DEPRECATED);
+    if (!is_int($user_id)) {
+      trigger_error('Passing an account object is deprecated in og:8.1.0-alpha4 and is removed from og:8.1.0-beta1. Instead pass the user ID as an integer value. See https://github.com/Gizra/og/issues/542', E_USER_DEPRECATED);
       $user_id = $user_id->id();
     }
 
@@ -429,8 +429,8 @@ class MembershipManager implements MembershipManagerInterface {
    * {@inheritdoc}
    */
   public function isMemberPending(EntityInterface $group, $user_id) {
-    if ($user_id instanceof AccountInterface) {
-      trigger_error('Passing an account object is deprecated in og:8.1.0-alpha4 and is removed from og:8.1.0-beta1. Pass the user ID instead.', E_USER_DEPRECATED);
+    if (!is_int($user_id)) {
+      trigger_error('Passing an account object is deprecated in og:8.1.0-alpha4 and is removed from og:8.1.0-beta1. Instead pass the user ID as an integer value. See https://github.com/Gizra/og/issues/542', E_USER_DEPRECATED);
       $user_id = $user_id->id();
     }
 
@@ -441,8 +441,8 @@ class MembershipManager implements MembershipManagerInterface {
    * {@inheritdoc}
    */
   public function isMemberBlocked(EntityInterface $group, $user_id) {
-    if ($user_id instanceof AccountInterface) {
-      trigger_error('Passing an account object is deprecated in og:8.1.0-alpha4 and is removed from og:8.1.0-beta1. Pass the user ID instead.', E_USER_DEPRECATED);
+    if (!is_int($user_id)) {
+      trigger_error('Passing an account object is deprecated in og:8.1.0-alpha4 and is removed from og:8.1.0-beta1. Instead pass the user ID as an integer value. See https://github.com/Gizra/og/issues/542', E_USER_DEPRECATED);
       $user_id = $user_id->id();
     }
 

--- a/src/MembershipManagerInterface.php
+++ b/src/MembershipManagerInterface.php
@@ -19,8 +19,8 @@ interface MembershipManagerInterface {
    * to the group is stored on a field attached to the content entity, while
    * user memberships are tracked in OgMembership entities.
    *
-   * @param \Drupal\Core\Session\AccountInterface $user
-   *   The user to get groups for.
+   * @param int $user_id
+   *   The ID of the user to get groups for.
    * @param array $states
    *   (optional) Array with the state to return. Defaults to active.
    *
@@ -30,7 +30,7 @@ interface MembershipManagerInterface {
    *
    * @see \Drupal\og\MembershipManager::getGroupIds()
    */
-  public function getUserGroupIds(AccountInterface $user, array $states = [OgMembershipInterface::STATE_ACTIVE]);
+  public function getUserGroupIds($user_id, array $states = [OgMembershipInterface::STATE_ACTIVE]);
 
   /**
    * Returns all groups associated with the given user.
@@ -41,8 +41,8 @@ interface MembershipManagerInterface {
    * on a field attached to the content entity, while user memberships are
    * tracked in OgMembership entities.
    *
-   * @param \Drupal\Core\Session\AccountInterface $user
-   *   The user to get groups for.
+   * @param int $user_id
+   *   The ID of the user to get groups for.
    * @param string[] $states
    *   (optional) Array with the states to return. Defaults to active.
    *
@@ -53,13 +53,13 @@ interface MembershipManagerInterface {
    * @see \Drupal\og\MembershipManager::getGroups()
    * @see \Drupal\og\MembershipManager::getMemberships()
    */
-  public function getUserGroups(AccountInterface $user, array $states = [OgMembershipInterface::STATE_ACTIVE]);
+  public function getUserGroups($user_id, array $states = [OgMembershipInterface::STATE_ACTIVE]);
 
   /**
    * Returns an array of groups filtered by the OG roles of the user.
    *
-   * @param \Drupal\Core\Session\AccountInterface $user
-   *   The user to get the groups for.
+   * @param int $user_id
+   *   The ID of the user to get the groups for.
    * @param string[] $role_ids
    *   A list of OG role IDs to filter by.
    * @param string[] $states
@@ -73,13 +73,13 @@ interface MembershipManagerInterface {
    *   An associative array, keyed by group entity type, each item an array of
    *   group entities.
    */
-  public function getUserGroupsByRoleIds(AccountInterface $user, array $role_ids, array $states = [OgMembershipInterface::STATE_ACTIVE], bool $require_all_roles = TRUE): array;
+  public function getUserGroupsByRoleIds($user_id, array $role_ids, array $states = [OgMembershipInterface::STATE_ACTIVE], bool $require_all_roles = TRUE): array;
 
   /**
    * Returns an array of groups ids filtered by the og roles of the user.
    *
-   * @param \Drupal\Core\Session\AccountInterface $user
-   *   The user to get the groups for.
+   * @param int $user_id
+   *   The ID of the user to get the groups for.
    * @param string[] $role_ids
    *   A list of OG role IDs to filter by.
    * @param string[] $states
@@ -93,13 +93,13 @@ interface MembershipManagerInterface {
    *   An associative array, keyed by group entity type, each item an array of
    *   group IDs.
    */
-  public function getUserGroupIdsByRoleIds(AccountInterface $user, array $role_ids, array $states = [OgMembershipInterface::STATE_ACTIVE], bool $require_all_roles = TRUE): array;
+  public function getUserGroupIdsByRoleIds($user_id, array $role_ids, array $states = [OgMembershipInterface::STATE_ACTIVE], bool $require_all_roles = TRUE): array;
 
   /**
    * Returns the group memberships a user is associated with.
    *
-   * @param \Drupal\Core\Session\AccountInterface $user
-   *   The user to get groups for.
+   * @param int $user_id
+   *   The ID of the user to get group memberships for.
    * @param array $states
    *   (optional) Array with the states to return. Defaults to only returning
    *   active memberships. In order to retrieve all memberships regardless of
@@ -108,15 +108,15 @@ interface MembershipManagerInterface {
    * @return \Drupal\og\OgMembershipInterface[]
    *   An array of OgMembership entities, keyed by ID.
    */
-  public function getMemberships(AccountInterface $user, array $states = [OgMembershipInterface::STATE_ACTIVE]);
+  public function getMemberships($user_id, array $states = [OgMembershipInterface::STATE_ACTIVE]);
 
   /**
    * Returns the group membership for a given user and group.
    *
    * @param \Drupal\Core\Entity\EntityInterface $group
    *   The group to get the membership for.
-   * @param \Drupal\Core\Session\AccountInterface $user
-   *   The user to get the membership for.
+   * @param int $user_id
+   *   The ID of the user to get the membership for.
    * @param array $states
    *   (optional) Array with the states to return. Defaults to only returning
    *   active memberships. In order to retrieve all memberships regardless of
@@ -126,7 +126,7 @@ interface MembershipManagerInterface {
    *   The OgMembership entity. NULL will be returned if no membership is
    *   available that matches the passed in $states.
    */
-  public function getMembership(EntityInterface $group, AccountInterface $user, array $states = [OgMembershipInterface::STATE_ACTIVE]);
+  public function getMembership(EntityInterface $group, $user_id, array $states = [OgMembershipInterface::STATE_ACTIVE]);
 
   /**
    * Returns the membership IDs of the given group filtered by role names.
@@ -272,8 +272,8 @@ interface MembershipManagerInterface {
    *
    * @param \Drupal\Core\Entity\EntityInterface $group
    *   The group entity.
-   * @param \Drupal\Core\Session\AccountInterface $user
-   *   The user to test the membership for.
+   * @param int $user_id
+   *   The ID of the user to test the membership for.
    * @param array $states
    *   (optional) Array with the membership states to check the membership.
    *   Defaults to active memberships.
@@ -282,36 +282,36 @@ interface MembershipManagerInterface {
    *   TRUE if the entity (e.g. the user or node) belongs to a group with
    *   a certain state.
    */
-  public function isMember(EntityInterface $group, AccountInterface $user, array $states = [OgMembershipInterface::STATE_ACTIVE]);
+  public function isMember(EntityInterface $group, $user_id, array $states = [OgMembershipInterface::STATE_ACTIVE]);
 
   /**
    * Returns whether a user belongs to a group with a pending status.
    *
    * @param \Drupal\Core\Entity\EntityInterface $group
    *   The group entity.
-   * @param \Drupal\Core\Session\AccountInterface $user
-   *   The user entity.
+   * @param int $user_id
+   *   The ID of the user.
    *
    * @return bool
    *   True if the membership is pending.
    *
    * @see \Drupal\og\Og::isMember
    */
-  public function isMemberPending(EntityInterface $group, AccountInterface $user);
+  public function isMemberPending(EntityInterface $group, $user_id);
 
   /**
    * Returns whether an entity belongs to a group with a blocked status.
    *
    * @param \Drupal\Core\Entity\EntityInterface $group
    *   The group entity.
-   * @param \Drupal\Core\Session\AccountInterface $user
-   *   The entity to test the membership for.
+   * @param int $user_id
+   *   The ID of the user to test the membership for.
    *
    * @return bool
    *   True if the membership is blocked.
    *
    * @see \Drupal\og\Og::isMember
    */
-  public function isMemberBlocked(EntityInterface $group, AccountInterface $user);
+  public function isMemberBlocked(EntityInterface $group, $user_id);
 
 }

--- a/src/Og.php
+++ b/src/Og.php
@@ -143,7 +143,7 @@ class Og {
   public static function getMemberships(AccountInterface $user, array $states = [OgMembershipInterface::STATE_ACTIVE]) {
     /** @var \Drupal\og\MembershipManagerInterface $membership_manager */
     $membership_manager = \Drupal::service('og.membership_manager');
-    return $membership_manager->getMemberships($user, $states);
+    return $membership_manager->getMemberships($user->id(), $states);
   }
 
   /**
@@ -165,7 +165,7 @@ class Og {
   public static function getMembership(EntityInterface $group, AccountInterface $user, array $states = [OgMembershipInterface::STATE_ACTIVE]) {
     /** @var \Drupal\og\MembershipManagerInterface $membership_manager */
     $membership_manager = \Drupal::service('og.membership_manager');
-    return $membership_manager->getMembership($group, $user, $states);
+    return $membership_manager->getMembership($group, $user->id(), $states);
   }
 
   /**
@@ -205,7 +205,7 @@ class Og {
   public static function isMember(EntityInterface $group, AccountInterface $user, array $states = [OgMembershipInterface::STATE_ACTIVE]) {
     /** @var \Drupal\og\MembershipManagerInterface $membership_manager */
     $membership_manager = \Drupal::service('og.membership_manager');
-    return $membership_manager->isMember($group, $user, $states);
+    return $membership_manager->isMember($group, $user->id(), $states);
   }
 
   /**

--- a/src/OgAccess.php
+++ b/src/OgAccess.php
@@ -185,7 +185,7 @@ class OgAccess implements OgAccessInterface {
     if (!$pre_alter_cache) {
       $permissions = [];
       $user_is_group_admin = FALSE;
-      if ($membership = $this->membershipManager->getMembership($group, $user)) {
+      if ($membership = $this->membershipManager->getMembership($group, $user->id())) {
         foreach ($membership->getRoles() as $role) {
           // Check for the is_admin flag.
           /** @var \Drupal\og\Entity\OgRole $role */
@@ -197,7 +197,7 @@ class OgAccess implements OgAccessInterface {
           $permissions = array_merge($permissions, $role->getPermissions());
         }
       }
-      elseif (!$this->membershipManager->isMember($group, $user, [OgMembershipInterface::STATE_BLOCKED])) {
+      elseif (!$this->membershipManager->isMember($group, $user->id(), [OgMembershipInterface::STATE_BLOCKED])) {
         // User is a non-member or has a pending membership.
         /** @var \Drupal\og\Entity\OgRole $role */
         $role = OgRole::loadByGroupAndName($group, OgRoleInterface::ANONYMOUS);
@@ -267,7 +267,7 @@ class OgAccess implements OgAccessInterface {
       $cache_tags = $entity_type->getListCacheTags();
 
       // The entity might be a user or a non-user entity.
-      $groups = $entity instanceof UserInterface ? $this->membershipManager->getUserGroups($entity) : $this->membershipManager->getGroups($entity);
+      $groups = $entity instanceof UserInterface ? $this->membershipManager->getUserGroups($entity->id()) : $this->membershipManager->getGroups($entity);
 
       if ($groups) {
         $forbidden = AccessResult::forbidden()->addCacheTags($cache_tags);

--- a/src/Plugin/EntityReferenceSelection/OgSelection.php
+++ b/src/Plugin/EntityReferenceSelection/OgSelection.php
@@ -120,10 +120,9 @@ class OgSelection extends DefaultSelection {
    *   Array with the user's group, or an empty array if none found.
    */
   protected function getUserGroups() {
-    $user = User::load($this->currentUser->id());
     /** @var \Drupal\og\MembershipManagerInterface $membership_manager */
     $membership_manager = \Drupal::service('og.membership_manager');
-    $other_groups = $membership_manager->getUserGroups($user);
+    $other_groups = $membership_manager->getUserGroups($this->currentUser->id());
     return isset($other_groups[$this->configuration['target_type']]) ? $other_groups[$this->configuration['target_type']] : [];
   }
 

--- a/src/Plugin/EntityReferenceSelection/OgSelection.php
+++ b/src/Plugin/EntityReferenceSelection/OgSelection.php
@@ -3,7 +3,6 @@
 namespace Drupal\og\Plugin\EntityReferenceSelection;
 
 use Drupal\Core\Entity\Plugin\EntityReferenceSelection\DefaultSelection;
-use Drupal\user\Entity\User;
 use Drupal\og\Og;
 
 /**

--- a/src/Plugin/Field/FieldWidget/OgComplex.php
+++ b/src/Plugin/Field/FieldWidget/OgComplex.php
@@ -10,7 +10,6 @@ use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\Field\Plugin\Field\FieldWidget\EntityReferenceAutocompleteWidget;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\og\OgAccess;
-use Drupal\user\Entity\User;
 
 /**
  * Plugin implementation of the 'entity_reference autocomplete' widget.

--- a/src/Plugin/Field/FieldWidget/OgComplex.php
+++ b/src/Plugin/Field/FieldWidget/OgComplex.php
@@ -72,7 +72,7 @@ class OgComplex extends EntityReferenceAutocompleteWidget {
 
     /** @var \Drupal\og\MembershipManagerInterface $membership_manager */
     $membership_manager = \Drupal::service('og.membership_manager');
-    $user_groups = $membership_manager->getUserGroups(User::load(\Drupal::currentUser()->id()));
+    $user_groups = $membership_manager->getUserGroups(\Drupal::currentUser()->id());
     $user_groups_target_type = isset($user_groups[$target_type]) ? $user_groups[$target_type] : [];
     $user_group_ids = array_map(function ($group) {
       return $group->id();
@@ -235,7 +235,7 @@ class OgComplex extends EntityReferenceAutocompleteWidget {
 
     /** @var \Drupal\og\MembershipManagerInterface $membership_manager */
     $membership_manager = \Drupal::service('og.membership_manager');
-    $user_groups = $membership_manager->getUserGroups(User::load(\Drupal::currentUser()->id()));
+    $user_groups = $membership_manager->getUserGroups(\Drupal::currentUser()->id());
     $user_groups_target_type = isset($user_groups[$target_type]) ? $user_groups[$target_type] : [];
     $user_group_ids = array_map(function ($group) {
       return $group->id();

--- a/tests/src/Kernel/Action/ActionTestBase.php
+++ b/tests/src/Kernel/Action/ActionTestBase.php
@@ -114,7 +114,7 @@ abstract class ActionTestBase extends KernelTestBase {
 
     // Store a reference to the group owner membership that is automatically
     // created along with the group.
-    $this->memberships['group_owner'] = $this->membershipManager->getMembership($this->group, $this->users['group_owner']);
+    $this->memberships['group_owner'] = $this->membershipManager->getMembership($this->group, $this->users['group_owner']->id());
 
     // Store a reference to the administrator role for our group type.
     $this->roles['administrator'] = OgRole::getRole('node', $group_bundle, OgRoleInterface::ADMINISTRATOR);

--- a/tests/src/Kernel/Action/DeleteOgMembershipActionTest.php
+++ b/tests/src/Kernel/Action/DeleteOgMembershipActionTest.php
@@ -34,7 +34,7 @@ class DeleteOgMembershipActionTest extends ChangeOgMembershipActionTestBase {
     $plugin = $this->getPlugin($configuration);
     $plugin->execute($membership);
 
-    $this->assertFalse($this->membershipManager->isMember($this->group, $member, [
+    $this->assertFalse($this->membershipManager->isMember($this->group, $member->id(), [
       OgMembershipInterface::STATE_ACTIVE,
       OgMembershipInterface::STATE_BLOCKED,
       OgMembershipInterface::STATE_PENDING,

--- a/tests/src/Kernel/Entity/GetUserGroupsTest.php
+++ b/tests/src/Kernel/Entity/GetUserGroupsTest.php
@@ -133,7 +133,7 @@ class GetUserGroupsTest extends KernelTestBase {
    * @todo Convert Og::isMember() calls to $this->membershipManager->isMember().
    */
   public function testOwnerGroupsOnly() {
-    $actual = $this->membershipManager->getUserGroups($this->user1);
+    $actual = $this->membershipManager->getUserGroups($this->user1->id());
 
     $this->assertCount(1, $actual['entity_test']);
     $this->assertGroupExistsInResults($this->group1, $actual);
@@ -142,7 +142,7 @@ class GetUserGroupsTest extends KernelTestBase {
     $this->assertTrue(Og::isMember($this->group1, $this->user1));
     $this->assertFalse(Og::isMember($this->group1, $this->user2));
 
-    $actual = $this->membershipManager->getUserGroups($this->user2);
+    $actual = $this->membershipManager->getUserGroups($this->user2->id());
 
     $this->assertCount(1, $actual['entity_test']);
     $this->assertGroupExistsInResults($this->group2, $actual);
@@ -159,7 +159,7 @@ class GetUserGroupsTest extends KernelTestBase {
    */
   public function testOtherGroups() {
     // Should not be a part of any groups.
-    $this->assertEquals([], $this->membershipManager->getUserGroups($this->user3));
+    $this->assertEquals([], $this->membershipManager->getUserGroups($this->user3->id()));
     $this->assertFalse(Og::isMember($this->group1, $this->user3));
     $this->assertFalse(Og::isMember($this->group2, $this->user3));
 
@@ -170,7 +170,7 @@ class GetUserGroupsTest extends KernelTestBase {
     // Add user to group 1 should now return that group only.
     $this->createOgMembership($this->group1, $this->user3);
 
-    $actual = $this->membershipManager->getUserGroups($this->user3);
+    $actual = $this->membershipManager->getUserGroups($this->user3->id());
 
     $this->assertCount(1, $actual['entity_test']);
     $this->assertGroupExistsInResults($this->group1, $actual);
@@ -183,7 +183,7 @@ class GetUserGroupsTest extends KernelTestBase {
     // Add to group 2 should also return that.
     $this->createOgMembership($this->group2, $this->user3);
 
-    $actual = $this->membershipManager->getUserGroups($this->user3);
+    $actual = $this->membershipManager->getUserGroups($this->user3->id());
 
     $this->assertCount(2, $actual['entity_test']);
     $this->assertGroupExistsInResults($this->group1, $actual);
@@ -266,26 +266,26 @@ class GetUserGroupsTest extends KernelTestBase {
     // By default only active memberships are retrieved, so if we ask the
     // groups where the user is a normal member of the result should not include
     // group 2 where our test user is blocked.
-    $groups = $this->membershipManager->getUserGroupIdsByRoleIds($this->user3, [$member_role->id()]);
+    $groups = $this->membershipManager->getUserGroupIdsByRoleIds($this->user3->id(), [$member_role->id()]);
     $this->assertCount(1, $groups['entity_test']);
     $actual = reset($groups['entity_test']);
     $this->assertEquals($this->group1->id(), $actual);
 
     // When asking for the groups where our user has the test role, the result
     // should not include the blocked membership, so it should be empty.
-    $groups = $this->membershipManager->getUserGroupsByRoleIds($this->user3, [$extra_role_1->id()]);
+    $groups = $this->membershipManager->getUserGroupsByRoleIds($this->user3->id(), [$extra_role_1->id()]);
     $this->assertCount(0, $groups);
 
     // Include all states.
-    $groups = $this->membershipManager->getUserGroupIdsByRoleIds($this->user3, [$member_role->id()], OgMembershipInterface::ALL_STATES, FALSE);
+    $groups = $this->membershipManager->getUserGroupIdsByRoleIds($this->user3->id(), [$member_role->id()], OgMembershipInterface::ALL_STATES, FALSE);
     $this->assertCount(2, $groups['entity_test']);
 
     // Request any of multiple roles.
-    $groups = $this->membershipManager->getUserGroupsByRoleIds($this->user3, [$member_role->id(), $extra_role_1->id()], OgMembershipInterface::ALL_STATES, FALSE);
+    $groups = $this->membershipManager->getUserGroupsByRoleIds($this->user3->id(), [$member_role->id(), $extra_role_1->id()], OgMembershipInterface::ALL_STATES, FALSE);
     $this->assertCount(2, $groups['entity_test']);
 
     // Request all of multiple roles.
-    $groups = $this->membershipManager->getUserGroupsByRoleIds($this->user3, [$member_role->id(), $extra_role_1->id()], OgMembershipInterface::ALL_STATES, TRUE);
+    $groups = $this->membershipManager->getUserGroupsByRoleIds($this->user3->id(), [$member_role->id(), $extra_role_1->id()], OgMembershipInterface::ALL_STATES, TRUE);
     $this->assertCount(1, $groups['entity_test']);
     $actual = reset($groups['entity_test']);
     $this->assertEquals($this->group2->id(), $actual->id());

--- a/tests/src/Kernel/GroupManagerSubscriptionTest.php
+++ b/tests/src/Kernel/GroupManagerSubscriptionTest.php
@@ -108,7 +108,7 @@ class GroupManagerSubscriptionTest extends KernelTestBase {
 
     // Check that a membership has only been created if the group had an owner
     // set.
-    $membership = $this->membershipManager->getMembership($group, $this->owner);
+    $membership = $this->membershipManager->getMembership($group, $this->owner->id());
     $this->assertEquals($group_has_owner, !empty($membership));
 
     // Check if the membership has been overridden.

--- a/tests/src/Unit/Cache/Context/OgMembershipStateCacheContextTest.php
+++ b/tests/src/Unit/Cache/Context/OgMembershipStateCacheContextTest.php
@@ -96,7 +96,7 @@ class OgMembershipStateCacheContextTest extends OgContextCacheContextTestBase {
     ];
 
     $this->membershipManager
-      ->getMembership($this->group->reveal(), $this->user->reveal(), $states)
+      ->getMembership($this->group->reveal(), $this->user->reveal()->id(), $states)
       ->willReturn($state);
   }
 

--- a/tests/src/Unit/Cache/Context/OgRoleCacheContextTest.php
+++ b/tests/src/Unit/Cache/Context/OgRoleCacheContextTest.php
@@ -54,7 +54,7 @@ class OgRoleCacheContextTest extends OgCacheContextTestBase {
     // manager.
     /** @var \Drupal\Core\Session\AccountInterface|\Prophecy\Prophecy\ObjectProphecy $user */
     $user = $this->prophesize(AccountInterface::class)->reveal();
-    $this->membershipManager->getMemberships($user)->willReturn([]);
+    $this->membershipManager->getMemberships($user->id())->willReturn([]);
 
     // The result should be the predefined 'NO_CONTEXT' value.
     $result = $this->getContextResult($user);
@@ -84,7 +84,7 @@ class OgRoleCacheContextTest extends OgCacheContextTestBase {
     // manager.
     /** @var \Drupal\Core\Session\AccountInterface|\Prophecy\Prophecy\ObjectProphecy $user */
     $user = $this->prophesize(AccountInterface::class)->reveal();
-    $this->membershipManager->getMemberships($user)->willReturn([$membership]);
+    $this->membershipManager->getMemberships($user->id())->willReturn([$membership]);
 
     // The result should be the predefined 'NO_CONTEXT' value.
     $result = $this->getContextResult($user);
@@ -161,7 +161,7 @@ class OgRoleCacheContextTest extends OgCacheContextTestBase {
       // When the memberships for every user in the test case are requested from
       // the membership manager, the respective array of memberships will be
       // returned.
-      $this->membershipManager->getMemberships($user)->willReturn($memberships[$user_id]);
+      $this->membershipManager->getMemberships($user_id)->willReturn($memberships[$user_id]);
       $cache_context_ids[$user_id] = $this->getContextResult($user);
     }
 

--- a/tests/src/Unit/GroupSubscribeFormatterTest.php
+++ b/tests/src/Unit/GroupSubscribeFormatterTest.php
@@ -319,7 +319,7 @@ class GroupSubscribeFormatterTest extends UnitTestCase {
 
     $this
       ->membershipManager
-      ->isMember($this->group->reveal(), $this->user->reveal(), [OgMembershipInterface::STATE_BLOCKED])
+      ->isMember($this->group->reveal(), $this->user->reveal()->id(), [OgMembershipInterface::STATE_BLOCKED])
       ->willReturn(TRUE);
 
     $elements = $this->getElements();
@@ -334,12 +334,12 @@ class GroupSubscribeFormatterTest extends UnitTestCase {
 
     $this
       ->membershipManager
-      ->isMember($this->group->reveal(), $this->user->reveal(), [OgMembershipInterface::STATE_BLOCKED])
+      ->isMember($this->group->reveal(), $this->user->reveal()->id(), [OgMembershipInterface::STATE_BLOCKED])
       ->willReturn(FALSE);
 
     $this
       ->membershipManager
-      ->isMember($this->group->reveal(), $this->user->reveal(), [OgMembershipInterface::STATE_ACTIVE, OgMembershipInterface::STATE_PENDING])
+      ->isMember($this->group->reveal(), $this->user->reveal()->id(), [OgMembershipInterface::STATE_ACTIVE, OgMembershipInterface::STATE_PENDING])
       ->willReturn(TRUE);
 
     $elements = $this->getElements();

--- a/tests/src/Unit/OgAccessTestBase.php
+++ b/tests/src/Unit/OgAccessTestBase.php
@@ -164,16 +164,17 @@ class OgAccessTestBase extends UnitTestCase {
     $this->config->getCacheMaxAge()->willReturn(0);
 
     // Create a mocked test user.
+    $user_id = 2;
     $this->user = $this->prophesize(AccountInterface::class);
     $this->user->isAuthenticated()->willReturn(TRUE);
-    $this->user->id()->willReturn(2);
+    $this->user->id()->willReturn($user_id);
     $this->user->hasPermission(OgAccess::ADMINISTER_GROUP_PERMISSION)->willReturn(FALSE);
 
     $this->group = $this->groupEntity()->reveal();
 
     $this->membershipManager = $this->prophesize(MembershipManagerInterface::class);
-    $this->membershipManager->getMembership($this->group, $this->user->reveal())->willReturn($this->membership->reveal());
-    $this->membershipManager->getMembership($this->group, $this->user->reveal(), [OgMembershipInterface::STATE_ACTIVE])->willReturn($this->membership->reveal());
+    $this->membershipManager->getMembership($this->group, $user_id)->willReturn($this->membership->reveal());
+    $this->membershipManager->getMembership($this->group, $user_id, [OgMembershipInterface::STATE_ACTIVE])->willReturn($this->membership->reveal());
     $this->membershipManager->getGroupCount(Argument::any())->willReturn(1);
     $this->membership->getRoles()->willReturn([$this->ogRole->reveal()]);
 

--- a/tests/src/Unit/SubscriptionControllerTest.php
+++ b/tests/src/Unit/SubscriptionControllerTest.php
@@ -80,6 +80,13 @@ class SubscriptionControllerTest extends UnitTestCase {
   protected $user;
 
   /**
+   * A user ID to use in the test.
+   *
+   * @var int
+   */
+  protected $userId;
+
+  /**
    * {@inheritdoc}
    */
   public function setUp() {
@@ -91,6 +98,9 @@ class SubscriptionControllerTest extends UnitTestCase {
     $this->ogMembership = $this->prophesize(OgMembershipInterface::class);
     $this->url = $this->prophesize(Url::class);
     $this->user = $this->prophesize(AccountInterface::class);
+
+    $this->userId = rand(20, 50);
+    $this->user->id()->willReturn($this->userId);
 
     // Set the container for the string translation service.
     $container = new ContainerBuilder();
@@ -117,7 +127,7 @@ class SubscriptionControllerTest extends UnitTestCase {
 
     $this
       ->membershipManager
-      ->getMembership($this->group->reveal(), $this->user->reveal(), $states)
+      ->getMembership($this->group->reveal(), $this->userId, $states)
       ->willReturn(NULL);
 
     $this->unsubscribe();
@@ -138,7 +148,7 @@ class SubscriptionControllerTest extends UnitTestCase {
 
     $this
       ->membershipManager
-      ->getMembership($this->group->reveal(), $this->user->reveal(), $states)
+      ->getMembership($this->group->reveal(), $this->userId, $states)
       ->willReturn($this->ogMembership->reveal());
 
     $this
@@ -164,7 +174,7 @@ class SubscriptionControllerTest extends UnitTestCase {
 
     $this
       ->membershipManager
-      ->getMembership($this->group->reveal(), $this->user->reveal(), $states)
+      ->getMembership($this->group->reveal(), $this->userId, $states)
       ->willReturn($this->ogMembership->reveal());
 
     $this
@@ -212,7 +222,7 @@ class SubscriptionControllerTest extends UnitTestCase {
 
     $this
       ->membershipManager
-      ->getMembership($this->group->reveal(), $this->user->reveal(), $states)
+      ->getMembership($this->group->reveal(), $this->userId, $states)
       ->willReturn($this->ogMembership->reveal());
 
     $this
@@ -220,17 +230,10 @@ class SubscriptionControllerTest extends UnitTestCase {
       ->getState()
       ->willReturn($state);
 
-    $entity_id = rand(20, 50);
-
-    $this
-      ->user
-      ->id()
-      ->willReturn($entity_id);
-
     $this
       ->group
       ->getOwnerId()
-      ->willReturn($entity_id);
+      ->willReturn($this->userId);
 
     $this
       ->group


### PR DESCRIPTION
This is part of #487 

Most of the methods in the `MembershipManager` service that deal with users require the full user object to be passed in, but only require the user ID to operate. This requires the calling code to needlessly load the full user entity from the database while they could simply pass in the entity ID.

This PR provides a B/C layer so that existing code keeps working for now.