### PR TITLE
Start using the DrupalPractice set of codesniffer rules

### DIFF
--- a/phpcs-ruleset.xml.dist
+++ b/phpcs-ruleset.xml.dist
@@ -14,4 +14,22 @@
     <exclude-pattern>*.min.js</exclude-pattern>
 
     <rule ref="./vendor/drupal/coder/coder_sniffer/Drupal" />
+    <rule ref="./vendor/drupal/coder/coder_sniffer/DrupalPractice">
+        <!-- https://github.com/Gizra/og/issues/549 -->
+        <exclude name="DrupalPractice.CodeAnalysis.VariableAnalysis.UndefinedVariable" />
+        <!-- https://github.com/Gizra/og/issues/545 -->
+        <exclude name="DrupalPractice.CodeAnalysis.VariableAnalysis.UnusedVariable" />
+        <!-- https://github.com/Gizra/og/issues/548 -->
+        <exclude name="DrupalPractice.Commenting.ExpectedException.TagFound" />
+        <!-- https://github.com/Gizra/og/issues/550 -->
+        <exclude name="DrupalPractice.Constants.GlobalDefine.GlobalConstant" />
+        <!-- https://github.com/Gizra/og/issues/544 -->
+        <exclude name="DrupalPractice.InfoFiles.NamespacedDependency.NonNamespaced" />
+        <!-- https://github.com/Gizra/og/issues/546 -->
+        <exclude name="DrupalPractice.Objects.GlobalClass.GlobalClass" />
+        <!-- https://github.com/Gizra/og/issues/547 -->
+        <exclude name="DrupalPractice.Objects.GlobalDrupal.GlobalDrupal" />
+        <!-- https://github.com/Gizra/og/issues/543 -->
+        <exclude name="DrupalPractice.Objects.GlobalFunction.GlobalFunction" />
+    </rule>
 </ruleset>


### PR DESCRIPTION
This PR enables the DrupalPractice ruleset for PHP CodeSniffer. This will allow us to track whether some known best practices for Drupal development are being followed.

For the moment our code base is not yet fully compliant with the best practices. I have excluded the rules which are being violated from the ruleset and created individual issues to address these one by one, so we can work towards full compliance in the future.

These are the followup issues: #543 #544 #545 #546 #547 #548 #549 #550