### PR TITLE
Providing settings under 'handler_settings' is deprecated

### DIFF
--- a/config/schema/og.schema.yml
+++ b/config/schema/og.schema.yml
@@ -13,9 +13,9 @@ field.field_settings.og_membership_reference:
     handler:
       type: string
       label: 'Reference method'
-    handler_settings:
-      type: entity_reference_selection.[%parent.handler]
-      label: 'Organic Groups reference selection plugin settings'
+    field_mode:
+      type: string
+      label: 'The field mode'
     access_override:
       type: boolean
       label: 'Access Override'
@@ -35,9 +35,9 @@ field.field_settings.og_standard_reference:
     handler:
       type: string
       label: 'Reference method'
-    handler_settings:
-      type: entity_reference_selection.[%parent.handler]
-      label: 'Organic Groups reference selection plugin settings'
+    field_mode:
+      type: string
+      label: 'The field mode'
     access_override:
       type: boolean
       label: 'Access Override'

--- a/src/Og.php
+++ b/src/Og.php
@@ -394,9 +394,7 @@ class Og {
     $options = NestedArray::mergeDeep([
       'target_type' => $field_definition->getFieldStorageDefinition()->getSetting('target_type'),
       'handler' => $field_definition->getSetting('handler'),
-      'handler_settings' => [
-        'field_mode' => 'default',
-      ],
+      'field_mode' => 'default',
     ], $options);
 
     // Deep merge the handler settings.

--- a/src/Plugin/EntityReferenceSelection/OgSelection.php
+++ b/src/Plugin/EntityReferenceSelection/OgSelection.php
@@ -36,7 +36,7 @@ class OgSelection extends DefaultSelection {
       // 'handler' key intentionally absent as we want the selection manager to
       // choose the best option.
       // @see \Drupal\Core\Entity\EntityReferenceSelection\SelectionPluginManager::getInstance()
-      'handler_settings' => $this->configuration['handler_settings'],
+      'field_mode' => $this->configuration['field_mode'],
     ];
     return \Drupal::service('plugin.manager.entity_reference_selection')->getInstance($options);
   }
@@ -84,7 +84,7 @@ class OgSelection extends DefaultSelection {
     $identifier_key = $definition->getKey('id');
 
     $ids = [];
-    if (!empty($this->configuration['handler_settings']['field_mode']) && $this->configuration['handler_settings']['field_mode'] == 'admin') {
+    if (!empty($this->configuration['field_mode']) && $this->configuration['field_mode'] == 'admin') {
       // Don't include the groups, the user doesn't have create permission.
       foreach ($user_groups as $delta => $group) {
         $ids[] = $group->id();

--- a/tests/src/Kernel/Entity/SelectionHandlerTest.php
+++ b/tests/src/Kernel/Entity/SelectionHandlerTest.php
@@ -107,7 +107,7 @@ class SelectionHandlerTest extends KernelTestBase {
     $this->fieldDefinition = Og::createField(OgGroupAudienceHelperInterface::DEFAULT_FIELD, 'node', $this->groupContentBundle);
 
     // Get the storage of the field.
-    $this->selectionHandler = Og::getSelectionHandler($this->fieldDefinition, ['handler_settings' => ['field_mode' => 'default']]);
+    $this->selectionHandler = Og::getSelectionHandler($this->fieldDefinition, ['field_mode' => 'default']);
 
     // Create two users.
     $this->user1 = User::create(['name' => $this->randomString()]);
@@ -151,7 +151,7 @@ class SelectionHandlerTest extends KernelTestBase {
     $this->assertEquals($user2_groups, array_keys($groups[$this->groupBundle]));
 
     // Check the other groups.
-    $this->selectionHandler = Og::getSelectionHandler($this->fieldDefinition, ['handler_settings' => ['field_mode' => 'admin']]);
+    $this->selectionHandler = Og::getSelectionHandler($this->fieldDefinition, ['field_mode' => 'admin']);
 
     $this->setCurrentAccount($this->user1);
     $groups = $this->selectionHandler->getReferenceableEntities();


### PR DESCRIPTION
This PR is intended to address one of the deprecations warnings we are receiving and are preventing us from moving to Drupal 8.8 in the future:

```
  15x: Providing settings under 'handler_settings' is deprecated and will be removed before 9.0.0. Move the settings in the root of the configuration array. See https://www.drupal.org/node/2870971.

    6x in SelectionHandlerTest::testSelectionHandlerResults from Drupal\Tests\og\Kernel\Entity

    4x in EntityCreateAccessTest::testViewPermissionDoesNotGrantCreateAccess from Drupal\Tests\og\Kernel\Entity

    3x in OgComplexWidgetTest::testFields from Drupal\Tests\og\Functional

    2x in SelectionHandlerTest::testSelectionHandler from Drupal\Tests\og\Kernel\Entity
```

The change record for this deprecation is [Entity reference selection handlers should extend a base class](https://www.drupal.org/node/2870971).