### PR TITLE
Upgrade to xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
 sudo: true
+dist: xenial
 
 php:
   - 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,9 @@ mysql:
   username: root
   encoding: utf8
 
+services:
+  - mysql
+
 before_script:
   # Remove Xdebug as we don't need it and it causes "PHP Fatal error: Maximum
   # function nesting level of '256' reached."


### PR DESCRIPTION
We noticed some issues with mysql on Travis:
`The command "mysql -e 'create database og'" failed and exited with 1 during .`

It seems Travis is upgrading their default setup from trusty to xenial.

See https://docs.travis-ci.com/user/reference/xenial/
Todo:
- fix dist to xenial
- add services: mysql ([it's no longer started by default](https://github.com/travis-ci/travis-ci/issues/6842#issuecomment-502259411
))