### PR TITLE
Use currently supported versions of PHP and Drupal to test against

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ sudo: true
 dist: xenial
 
 php:
-  - 7.1
   - 7.2
   - 7.3
+  - 7.4
 
 env:
   global:
@@ -13,17 +13,20 @@ env:
   matrix:
     - TEST_SUITE=8.7.x
     - TEST_SUITE=8.8.x
+    - TEST_SUITE=8.9.x
     - TEST_SUITE=PHP_CodeSniffer
 
 # Only run the coding standards check once.
 matrix:
   exclude:
-    - php: 7.1
-      env: TEST_SUITE=PHP_CodeSniffer
     - php: 7.2
+      env: TEST_SUITE=PHP_CodeSniffer
+    - php: 7.4
       env: TEST_SUITE=PHP_CodeSniffer
   allow_failures:
     - env: TEST_SUITE=8.8.x
+    - env: TEST_SUITE=8.9.x
+    - php: 7.4
 
 mysql:
   database: og


### PR DESCRIPTION
In the meantime PHP 7.4 and Drupal 8.8 have been released, and PHP 7.1 has been deprecated. There is also a new Drupal 8.9 development branch that is interesting for forwards compatibility.

This PR updates the test matrix to the currently supported version ranges.

Drupal 8.7 is also deprecated but we should keep it for a little while longer until OG is stable against Drupal 8.8. It can be removed in a future PR.