### PR TITLE
Revert "Removed redundant getGroupBundlesByEntityType() method."

### DIFF
--- a/src/GroupTypeManager.php
+++ b/src/GroupTypeManager.php
@@ -191,8 +191,22 @@ class GroupTypeManager implements GroupTypeManagerInterface {
    * {@inheritdoc}
    */
   public function getAllGroupBundles($entity_type = NULL) {
-    // @todo Should be removed since this method don't do any thing.
+    // Todo - should be remove since this method don't do any thing.
     return $this->getGroupMap();
+  }
+
+  /**
+   * Get group bundles of an entity type.
+   *
+   * @param string $entity_type_id
+   *   The entity type ID.
+   *
+   * @return array
+   *   An associative array of bundle IDs, or an empty array if none found.
+   */
+  public function getGroupBundlesByEntityType($entity_type_id) {
+    $group_map = $this->getGroupMap();
+    return isset($group_map[$entity_type_id]) ? $group_map[$entity_type_id] : [];
   }
 
   /**

--- a/src/Plugin/EntityReferenceSelection/OgSelection.php
+++ b/src/Plugin/EntityReferenceSelection/OgSelection.php
@@ -144,7 +144,7 @@ class OgSelection extends DefaultSelection {
     $definition = \Drupal::entityTypeManager()->getDefinition($target_type);
 
     if ($bundle_key = $definition->getKey('bundle')) {
-      $bundles = Og::groupTypeManager()->getAllGroupBundles($target_type);
+      $bundles = Og::groupTypeManager()->getGroupBundlesByEntityType($target_type);
 
       if (!$bundles) {
         // If there are no bundles defined, we can return early.
@@ -224,7 +224,7 @@ class OgSelection extends DefaultSelection {
 
     if ($entity_type->hasKey('bundle')) {
 
-      $bundles = Og::groupTypeManager()->getAllGroupBundles($entity_type_id);
+      $bundles = Og::groupTypeManager()->getGroupBundlesByEntityType($entity_type_id);
       foreach ($bundles as $bundle) {
         $bundle_options[$bundle] = $bundles_info[$bundle]['label'];
       }


### PR DESCRIPTION
Reverts Gizra/og#596

It seems like #596 introduced several failures in #570 so I'm reverting for now.

Also have a look at this remark: https://github.com/Gizra/og/pull/181/files#r199885163