### PR TITLE
Remove deprecated sudo property

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
-language: php
-sudo: true
 dist: xenial
+
+language: php
 
 php:
   - 7.2


### PR DESCRIPTION
Sudo should no longer be needed.

Also moved the language: php setting below 'dist'.
https://docs.travis-ci.com/user/languages/minimal-and-generic/#generic