### PR TITLE
Add code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,11 +35,6 @@ services:
   - mysql
 
 before_script:
-  # Remove Xdebug as we don't need it and it causes "PHP Fatal error: Maximum
-  # function nesting level of '256' reached."
-  # We also don't care if that file exists or not on PHP 7.
-  - phpenv config-rm xdebug.ini || true
-
   # Make sure Composer is up to date.
   - composer self-update
 
@@ -48,7 +43,7 @@ before_script:
 
   # Navigate out of module directory to prevent blown stack by recursive module
   # lookup.
-  - cd ..
+  - cd ../../
 
   # Create database.
   - mysql -e 'create database og'

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,4 +84,4 @@ before_script:
 script: DRUPAL_DIR=$DRUPAL_DIR MODULE_DIR=$MODULE_DIR $MODULE_DIR/scripts/travis-ci/run-test.sh $TEST_SUITE
 
 after_script:
-  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter after-build --coverage-input-type clover --exit-code $TRAVIS_TEST_RESULT; fi
+  - if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "${TEST_SUITE}" != "PHP_CodeSniffer" ]; then ./cc-test-reporter after-build --coverage-input-type clover --exit-code $TRAVIS_TEST_RESULT; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,16 +81,16 @@ before_script:
   - export SIMPLETEST_DB=mysql://root:@127.0.0.1/og
 
   # Get the CodeClimate test reporter.
-  - test ${TEST_SUITE} == "8.8.x" || curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-  - test ${TEST_SUITE} == "8.8.x" || chmod +x ./cc-test-reporter
-  - test ${TEST_SUITE} == "8.8.x" || ./cc-test-reporter before-build
+  - test ${TEST_SUITE} != "8.8.x" || curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - test ${TEST_SUITE} != "8.8.x" || chmod +x ./cc-test-reporter
+  - test ${TEST_SUITE} != "8.8.x" || ./cc-test-reporter before-build
 
 script:
   # Restore xdebug to support PHPUnit code coverage.
-  - test ${TEST_SUITE} == "8.8.x" || phpenv config-add /tmp/xdebug.ini
+  - test ${TEST_SUITE} != "8.8.x" || phpenv config-add /tmp/xdebug.ini
 
   # Run testsuite.
   - DRUPAL_DIR=$DRUPAL_DIR MODULE_DIR=$MODULE_DIR $MODULE_DIR/scripts/travis-ci/run-test.sh $TEST_SUITE
 
 after_script:
-  - test ${TEST_SUITE} == "8.8.x" || ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+  - test ${TEST_SUITE} != "8.8.x" || ./cc-test-reporter after-build --coverage-input-type clover --exit-code $TRAVIS_TEST_RESULT

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,10 @@ services:
   - mysql
 
 before_script:
+  # Disable xdebug to increase performance.
+  - cp $HOME/.phpenv/versions/$(phpenv global)/etc/conf.d/xdebug.ini /tmp
+  - phpenv config-rm xdebug.ini
+
   # Make sure Composer is up to date.
   - composer self-update
 
@@ -77,11 +81,16 @@ before_script:
   - export SIMPLETEST_DB=mysql://root:@127.0.0.1/og
 
   # Get the CodeClimate test reporter.
-  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-  - chmod +x ./cc-test-reporter
-  - ./cc-test-reporter before-build
+  - test ${TEST_SUITE} == "8.8.x" || curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - test ${TEST_SUITE} == "8.8.x" || chmod +x ./cc-test-reporter
+  - test ${TEST_SUITE} == "8.8.x" || ./cc-test-reporter before-build
 
-script: DRUPAL_DIR=$DRUPAL_DIR MODULE_DIR=$MODULE_DIR $MODULE_DIR/scripts/travis-ci/run-test.sh $TEST_SUITE
+script:
+  # Restore xdebug to support PHPUnit code coverage.
+  - test ${TEST_SUITE} == "8.8.x" || phpenv config-add /tmp/xdebug.ini
+
+  # Run testsuite.
+  - DRUPAL_DIR=$DRUPAL_DIR MODULE_DIR=$MODULE_DIR $MODULE_DIR/scripts/travis-ci/run-test.sh $TEST_SUITE
 
 after_script:
-  - if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "${TEST_SUITE}" != "PHP_CodeSniffer" ]; then ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT; fi
+  - test ${TEST_SUITE} == "8.8.x" || ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,4 +76,12 @@ before_script:
   # Export database variable for kernel tests.
   - export SIMPLETEST_DB=mysql://root:@127.0.0.1/og
 
+  # Get the CodeClimate test reporter.
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
+
 script: DRUPAL_DIR=$DRUPAL_DIR MODULE_DIR=$MODULE_DIR $MODULE_DIR/scripts/travis-ci/run-test.sh $TEST_SUITE
+
+after_script:
+  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter after-build --coverage-input-type clover --exit-code $TRAVIS_TEST_RESULT; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,4 +84,4 @@ before_script:
 script: DRUPAL_DIR=$DRUPAL_DIR MODULE_DIR=$MODULE_DIR $MODULE_DIR/scripts/travis-ci/run-test.sh $TEST_SUITE
 
 after_script:
-  - if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "${TEST_SUITE}" != "PHP_CodeSniffer" ]; then ./cc-test-reporter after-build --coverage-input-type clover --exit-code $TRAVIS_TEST_RESULT; fi
+  - if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "${TEST_SUITE}" != "PHP_CodeSniffer" ]; then ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT; fi

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -64,8 +64,8 @@
   <!-- Filter for coverage reports. -->
   <filter>
     <whitelist processUncoveredFilesFromWhitelist="true">
-      <directory suffix=".php">./modules/og</directory>
-      <directory suffix=".php">./modules/og/og_ui</directory>
+      <directory suffix=".php">modules/og</directory>
+      <directory suffix=".php">modules/og/og_ui</directory>
       <exclude>
           <!-- API documentation files have no tests. -->
           <directory suffix=".api.php">./</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- TODO set checkForUnintentionallyCoveredCode="true" once https://www.drupal.org/node/2626832 is resolved. -->
+<!-- PHPUnit expects functional tests to be run with either a privileged user
+ or your current system user. See core/tests/README.md and
+ https://www.drupal.org/node/2116263 for details.
+-->
+<phpunit bootstrap="tests/bootstrap.php" colors="true"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutChangesToGlobalState="true"
+         printerClass="\Drupal\Tests\Listeners\HtmlOutputPrinter">
+  <php>
+    <!-- Set error reporting to E_ALL. -->
+    <ini name="error_reporting" value="32767"/>
+    <!-- Do not limit the amount of memory tests take to run. -->
+    <ini name="memory_limit" value="-1"/>
+    <!-- Example SIMPLETEST_BASE_URL value: http://localhost -->
+    <env name="SIMPLETEST_BASE_URL" value=""/>
+    <!-- Example SIMPLETEST_DB value: mysql://username:password@localhost/databasename#table_prefix -->
+    <env name="SIMPLETEST_DB" value=""/>
+    <!-- Example BROWSERTEST_OUTPUT_DIRECTORY value: /path/to/webroot/sites/simpletest/browser_output -->
+    <env name="BROWSERTEST_OUTPUT_DIRECTORY" value=""/>
+    <!-- To have browsertest output use an alternative base URL. For example if
+     SIMPLETEST_BASE_URL is an internal DDEV URL, you can set this to the
+     external DDev URL so you can follow the links directly.
+    -->
+    <env name="BROWSERTEST_OUTPUT_BASE_URL" value=""/>
+    <!-- To disable deprecation testing completely uncomment the next line. -->
+    <!-- <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/> -->
+    <!-- Example for changing the driver class for mink tests MINK_DRIVER_CLASS value: 'Drupal\FunctionalJavascriptTests\DrupalSelenium2Driver' -->
+    <env name="MINK_DRIVER_CLASS" value=''/>
+    <!-- Example for changing the driver args to mink tests MINK_DRIVER_ARGS value: '["http://127.0.0.1:8510"]' -->
+    <env name="MINK_DRIVER_ARGS" value=''/>
+    <!-- Example for changing the driver args to phantomjs tests MINK_DRIVER_ARGS_PHANTOMJS value: '["http://127.0.0.1:8510"]' -->
+    <env name="MINK_DRIVER_ARGS_PHANTOMJS" value=''/>
+    <!-- Example for changing the driver args to webdriver tests MINK_DRIVER_ARGS_WEBDRIVER value: '["chrome", { "chromeOptions": { "w3c": false } }, "http://localhost:4444/wd/hub"]' For using the Firefox browser, replace "chrome" with "firefox" -->
+    <env name="MINK_DRIVER_ARGS_WEBDRIVER" value=''/>
+  </php>
+  <testsuites>
+    <testsuite name="unit">
+      <file>./tests/TestSuites/UnitTestSuite.php</file>
+    </testsuite>
+    <testsuite name="kernel">
+      <file>./tests/TestSuites/KernelTestSuite.php</file>
+    </testsuite>
+    <testsuite name="functional">
+      <file>./tests/TestSuites/FunctionalTestSuite.php</file>
+    </testsuite>
+    <testsuite name="functional-javascript">
+      <file>./tests/TestSuites/FunctionalJavascriptTestSuite.php</file>
+    </testsuite>
+    <testsuite name="build">
+      <file>./tests/TestSuites/BuildTestSuite.php</file>
+    </testsuite>
+  </testsuites>
+  <listeners>
+    <listener class="\Drupal\Tests\Listeners\DrupalListener">
+    </listener>
+    <!-- The Symfony deprecation listener has to come after the Drupal listener -->
+    <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener">
+    </listener>
+  </listeners>
+  <!-- Filter for coverage reports. -->
+  <filter>
+    <whitelist processUncoveredFilesFromWhitelist="true">
+      <directory suffix=".php">/home/travis/build/drupal/modules/og</directory>
+      <directory suffix=".php">/home/travis/build/drupal/modules/og/og_ui</directory>
+      <exclude>
+          <!-- API documentation files have no tests. -->
+          <directory suffix=".api.php">./</directory>
+          <!-- By definition test classes have no tests. -->
+          <directory suffix="Test.php">./</directory>
+          <directory suffix="TestBase.php">./</directory>
+      </exclude>
+    </whitelist>
+  </filter>
+</phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -64,8 +64,7 @@
   <!-- Filter for coverage reports. -->
   <filter>
     <whitelist processUncoveredFilesFromWhitelist="true">
-      <directory suffix=".php">./drupal/modules/og</directory>
-      <directory suffix=".php">./drupal/modules/og/og_ui</directory>
+      <directory suffix=".php">/home/travis/build/drupal/modules/og</directory>
       <exclude>
           <!-- API documentation files have no tests. -->
           <directory suffix=".api.php">./</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -64,8 +64,8 @@
   <!-- Filter for coverage reports. -->
   <filter>
     <whitelist processUncoveredFilesFromWhitelist="true">
-      <directory suffix=".php">/home/travis/build/drupal/modules/og</directory>
-      <directory suffix=".php">/home/travis/build/drupal/modules/og/og_ui</directory>
+      <directory suffix=".php">./modules/og</directory>
+      <directory suffix=".php">./modules/og/og_ui</directory>
       <exclude>
           <!-- API documentation files have no tests. -->
           <directory suffix=".api.php">./</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -64,8 +64,8 @@
   <!-- Filter for coverage reports. -->
   <filter>
     <whitelist processUncoveredFilesFromWhitelist="true">
-      <directory suffix=".php">modules/og</directory>
-      <directory suffix=".php">modules/og/og_ui</directory>
+      <directory suffix=".php">./drupal/modules/og</directory>
+      <directory suffix=".php">./drupal/modules/og/og_ui</directory>
       <exclude>
           <!-- API documentation files have no tests. -->
           <directory suffix=".api.php">./</directory>

--- a/scripts/travis-ci/run-test.sh
+++ b/scripts/travis-ci/run-test.sh
@@ -23,6 +23,7 @@ case "$1" in
         ln -s $MODULE_DIR $DRUPAL_DIR/modules/og
         cd $DRUPAL_DIR
         cp $DRUPAL_DIR/modules/og/phpunit.xml.dist ./core/phpunit.xml.dist
-        ./vendor/bin/phpunit --coverage-clover "$TRAVIS_BUILD_DIR/build/logs/clover.xml" -c ./core/phpunit.xml.dist || EXIT=1
+        cat ./core/phpunit.xml.dist
+        ./vendor/bin/phpunit --coverage-clover "$TRAVIS_BUILD_DIR/build/logs/clover.xml" -c ./core/phpunit.xml.dist
         exit $?
 esac

--- a/scripts/travis-ci/run-test.sh
+++ b/scripts/travis-ci/run-test.sh
@@ -11,8 +11,6 @@ mysql_to_ramdisk() {
   sudo service mysql start
 }
 
-TEST_DIRS=($DRUPAL_DIR/modules/og/tests $DRUPAL_DIR/modules/og/og_ui/tests)
-
 case "$1" in
     PHP_CodeSniffer)
         cd $MODULE_DIR
@@ -27,7 +25,7 @@ case "$1" in
         EXIT=0
         for i in ${TEST_DIRS[@]}; do
           echo " > Executing tests from $i"
-          ./vendor/bin/phpunit --coverage-clover "$TRAVIS_BUILD_DIR/build/logs/clover.xml" -c ./core/phpunit.xml.dist $i || EXIT=1
+          ./vendor/bin/phpunit --coverage-clover "$TRAVIS_BUILD_DIR/build/logs/clover.xml" -c $DRUPAL_DIR/modules/og/phpunit.xml.dist || EXIT=1
         done
         exit $EXIT
 esac

--- a/scripts/travis-ci/run-test.sh
+++ b/scripts/travis-ci/run-test.sh
@@ -27,7 +27,7 @@ case "$1" in
         EXIT=0
         for i in ${TEST_DIRS[@]}; do
           echo " > Executing tests from $i"
-          ./vendor/bin/phpunit -c ./core/phpunit.xml.dist $i || EXIT=1
+          ./vendor/bin/phpunit --coverage-clover "$TRAVIS_BUILD_DIR/build/logs/clover.xml" -c ./core/phpunit.xml.dist $i || EXIT=1
         done
         exit $EXIT
 esac

--- a/scripts/travis-ci/run-test.sh
+++ b/scripts/travis-ci/run-test.sh
@@ -22,6 +22,7 @@ case "$1" in
         mysql_to_ramdisk
         ln -s $MODULE_DIR $DRUPAL_DIR/modules/og
         cd $DRUPAL_DIR
-        ./vendor/bin/phpunit --coverage-clover "$TRAVIS_BUILD_DIR/build/logs/clover.xml" -c $DRUPAL_DIR/modules/og/phpunit.xml.dist || EXIT=1
+        cp $DRUPAL_DIR/modules/og/phpunit.xml.dist ./core/phpunit.xml.dist
+        ./vendor/bin/phpunit --coverage-clover "$TRAVIS_BUILD_DIR/build/logs/clover.xml" -c ./core/phpunit.xml.dist || EXIT=1
         exit $?
 esac

--- a/scripts/travis-ci/run-test.sh
+++ b/scripts/travis-ci/run-test.sh
@@ -23,9 +23,6 @@ case "$1" in
         ln -s $MODULE_DIR $DRUPAL_DIR/modules/og
         cd $DRUPAL_DIR
         EXIT=0
-        for i in ${TEST_DIRS[@]}; do
-          echo " > Executing tests from $i"
-          ./vendor/bin/phpunit --coverage-clover "$TRAVIS_BUILD_DIR/build/logs/clover.xml" -c $DRUPAL_DIR/modules/og/phpunit.xml.dist || EXIT=1
-        done
+        ./vendor/bin/phpunit --coverage-clover "$TRAVIS_BUILD_DIR/build/logs/clover.xml" -c $DRUPAL_DIR/modules/og/phpunit.xml.dist || EXIT=1
         exit $EXIT
 esac

--- a/scripts/travis-ci/run-test.sh
+++ b/scripts/travis-ci/run-test.sh
@@ -22,7 +22,6 @@ case "$1" in
         mysql_to_ramdisk
         ln -s $MODULE_DIR $DRUPAL_DIR/modules/og
         cd $DRUPAL_DIR
-        EXIT=0
         ./vendor/bin/phpunit --coverage-clover "$TRAVIS_BUILD_DIR/build/logs/clover.xml" -c $DRUPAL_DIR/modules/og/phpunit.xml.dist || EXIT=1
-        exit $EXIT
+        exit $?
 esac


### PR DESCRIPTION
- Re-enabled xdebug by installing Drupal one directory up. (due to a bug during module lookup that causes the stack to grow too much)
- Added phpunit test reporter

Code coverage allows us to visualize progress and to enforce unit tests in new features.
See demo on https://youtu.be/r1joerjQL_c?t=33

This PR only reports code coverage to code climate. Code coverage can be enforced with GitHub's branch protection and configured in:
<img width="825" alt="Schermafbeelding 2020-02-08 om 19 06 34" src="https://user-images.githubusercontent.com/1823998/74089902-3ad0a400-4aa6-11ea-91e6-5a843b5101d6.png">
