### PR TITLE
544 Namespace all dependencies

### DIFF
--- a/phpcs-ruleset.xml.dist
+++ b/phpcs-ruleset.xml.dist
@@ -22,8 +22,6 @@
     <rule ref="./vendor/drupal/coder/coder_sniffer/DrupalPractice">
         <!-- https://github.com/Gizra/og/issues/549 -->
         <exclude name="DrupalPractice.CodeAnalysis.VariableAnalysis.UndefinedVariable" />
-        <!-- https://github.com/Gizra/og/issues/544 -->
-        <exclude name="DrupalPractice.InfoFiles.NamespacedDependency.NonNamespaced" />
         <!-- https://github.com/Gizra/og/issues/546 -->
         <exclude name="DrupalPractice.Objects.GlobalClass.GlobalClass" />
         <!-- https://github.com/Gizra/og/issues/543 -->


### PR DESCRIPTION
Fix #544. Namespace all dependencies with the project name.

- [x] Remove the following line from `phpcs-ruleset.xml.dist`:
`<exclude name="DrupalPractice.InfoFiles.NamespacedDependency.NonNamespaced" />`
- [x] Run `./vendor/bin/phpcs`
- [x] Fix all reported warnings.