### PR TITLE
Use selectionPluginManager::getInstance() to get default selection handler

### DIFF
--- a/og.module
+++ b/og.module
@@ -213,7 +213,7 @@ function og_entity_create_access(AccountInterface $account, array $context, $bun
     /** @var \Drupal\Core\Entity\EntityReferenceSelection\SelectionPluginManager $handler */
     $handler = \Drupal::service('plugin.manager.entity_reference_selection');
 
-    if ($handler->createInstance('og:default', $options)) {
+    if ($handler->getInstance($options)) {
       return AccessResult::neutral();
     }
     // Allow users to create content outside of groups, if none of the

--- a/tests/src/Kernel/Entity/SelectionHandlerTest.php
+++ b/tests/src/Kernel/Entity/SelectionHandlerTest.php
@@ -120,7 +120,7 @@ class SelectionHandlerTest extends KernelTestBase {
       'handler' => $this->fieldDefinition->getSetting('handler'),
       'field_mode' => 'admin',
     ];
-    $this->selectionPluginManager->createInstance('og:default', $options);
+    $this->selectionPluginManager->getInstance($options);
     $this->selectionHandler = $this->selectionPluginManager->getSelectionHandler($this->fieldDefinition);
 
     // Create two users.
@@ -170,7 +170,7 @@ class SelectionHandlerTest extends KernelTestBase {
       'handler' => $this->fieldDefinition->getSetting('handler'),
       'field_mode' => 'admin',
     ];
-    $this->selectionHandler = $this->selectionPluginManager->createInstance('og:default', $options);
+    $this->selectionHandler = $this->selectionPluginManager->getInstance($options);
 
     $this->setCurrentAccount($this->user1);
     $groups = $this->selectionHandler->getReferenceableEntities();


### PR DESCRIPTION
In #580 Og::getSelectionHandler was deprecated to selectionPluginManager::getInstance but instead of using selectionPluginManager::getInstance, selectionPluginManager::createInstance was used.