### PR TITLE
Use custom phpcs configuration

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -39,8 +39,7 @@ plugins:
   phpcodesniffer:
     enabled: true
     config:
-      standard: "Drupal,DrupalPractice"
-      file_extensions: "php,inc,module,install,info,test,profile,theme,css,js"
+      standard: "phpcs-ruleset.xml.dist"
   phpmd:
     enabled: false
   csslint:


### PR DESCRIPTION
Use the same phpcs configuration for tests as for codeclimate

From the discussion on https://github.com/Gizra/og/pull/505#issuecomment-493636039

> The suggestions given are very good now, there are no more false positives.
> 
> Is there a way that we can source the PHP_CodeSniffer configuration from our own ruleset that we declare in phpcs-ruleset.xml.dist? There should not be any disparity between these, and if we can source this file then we can rest assured that if we make any changes to our coding standards then these will be picked up by codeclimate too.
> 
> For me personally this has not much added value since I tend to run my coding standards check before I commit and when I do have any coding standards violations I fix it by rebasing and force pushing rather than committing them one by one in the GitHub UI. But if you like it feel free to add it! For me the most important thing is that it does not cause any additional work for us as maintainers