### PR TITLE
[PP] 630 Begin support for Drupal 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
     - TEST_SUITE=8.7.x
     - TEST_SUITE=8.8.x
     - TEST_SUITE=8.9.x
+    - TEST_SUITE=9.0.x
     - TEST_SUITE=PHP_CodeSniffer
 
 # Only run the coding standards check once.
@@ -25,6 +26,7 @@ matrix:
       env: TEST_SUITE=PHP_CodeSniffer
   allow_failures:
     - php: 7.4
+    - env: TEST_SUITE=9.0.x
 
 mysql:
   database: og

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ env:
 matrix:
   exclude:
     - php: 7.2
+      env: TEST_SUITE=9.0.x
+    - php: 7.2
       env: TEST_SUITE=PHP_CodeSniffer
     - php: 7.4
       env: TEST_SUITE=PHP_CodeSniffer


### PR DESCRIPTION
Fix #630.

[First alpha of Drupal 9](https://www.drupal.org/project/drupal/releases/9.0.0-alpha1) is out, adding it to the test matrix.

Allowing failures, for now.
Exclude unsupported php versions for Drupal 9

A lot of Symfony 4 dependencies still need to be fixed.