### PR TITLE
Remove dead code in OgAccessHookTest

### DIFF
--- a/tests/src/Unit/OgAccessHookTest.php
+++ b/tests/src/Unit/OgAccessHookTest.php
@@ -44,17 +44,7 @@ class OgAccessHookTest extends OgAccessEntityTestBase {
   public function testGetEntityGroups($operation) {
     $this->user->hasPermission(OgAccess::ADMINISTER_GROUP_PERMISSION)->willReturn(TRUE);
     $user_entity_access = og_entity_access($this->groupContentEntity->reveal(), $operation, $this->user->reveal());
-
-    // @todo This is strange, 'view' is not part of the operations supplied by
-    //   ::permissionsProvider(). And why would a group administrator be allowed
-    //   access to all operations, except 'view'? Shouldn't this also return
-    //   'allowed'?
-    if ($operation == 'view') {
-      $this->assertTrue($user_entity_access->isNeutral());
-    }
-    else {
-      $this->assertTrue($user_entity_access->isAllowed());
-    }
+    $this->assertTrue($user_entity_access->isAllowed());
   }
 
 }


### PR DESCRIPTION
There is some dead code in OgAccessHookTest which has been identified before and has been marked with a `@todo`. It appears that this is just some relic from an earlier test case that no longer exists, and can simply be removed.