### PR TITLE
Drop support for Drupal 8.7.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
   global:
     - COMPOSER_MEMORY_LIMIT=2G
   matrix:
-    - TEST_SUITE=8.7.x
     - TEST_SUITE=8.8.x
     - TEST_SUITE=8.9.x
     - TEST_SUITE=9.0.x
@@ -72,10 +71,6 @@ before_script:
 
   # Install Composer dependencies for core. Skip this for the coding standards test.
   - test ${TEST_SUITE} == "PHP_CodeSniffer" || composer install --working-dir=$DRUPAL_DIR
-
-  # Drupal 8.7.x still uses the legacy PHPUnit 4.x which is not compatible with
-  # PHP 7. Update it to 6.x.
-  - test ${TEST_SUITE} == "8.7.x" && composer require --dev phpunit/phpunit:~6 --update-with-dependencies --working-dir=$DRUPAL_DIR || true
 
   # Start a web server on port 8888 in the background.
   - test ${TEST_SUITE} == "PHP_CodeSniffer" || nohup php -S localhost:8888 --docroot $DRUPAL_DIR > /dev/null 2>&1 &

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
         "source": "https://git.drupalcode.org/project/og"
     },
     "require": {
-        "php": ">=7.1.0",
-        "drupal/core": "~8.7 || ^9.0"
+        "php": "^7.1.0",
+        "drupal/core": "^8.8 || ^9.0"
     },
     "require-dev": {
         "drupal/coder": "^8.2"

--- a/og.info.yml
+++ b/og.info.yml
@@ -2,8 +2,7 @@ name: Organic Groups
 description: API to allow associating content with groups.
 package: Organic Groups
 
-core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^8.8 || ^9
 type: module
 php: 7.1
 


### PR DESCRIPTION
Drupal 8.7.x is EOL, let's drop support and update the test matrix to the currently supported versions.