### PR TITLE
Add support for Drupal 9.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ matrix:
       env: TEST_SUITE=PHP_CodeSniffer
   allow_failures:
     - php: 7.4
-    - env: TEST_SUITE=9.1.x
 
 mysql:
   database: og

--- a/og_ui/tests/src/Functional/BundleFormAlterTest.php
+++ b/og_ui/tests/src/Functional/BundleFormAlterTest.php
@@ -42,7 +42,7 @@ class BundleFormAlterTest extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  public function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->entityTypeManager = \Drupal::entityTypeManager();

--- a/tests/src/Functional/GroupSubscribeFormatterTest.php
+++ b/tests/src/Functional/GroupSubscribeFormatterTest.php
@@ -57,7 +57,7 @@ class GroupSubscribeFormatterTest extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Create bundle.

--- a/tests/src/Functional/GroupSubscribeTest.php
+++ b/tests/src/Functional/GroupSubscribeTest.php
@@ -98,7 +98,7 @@ class GroupSubscribeTest extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Create bundles.

--- a/tests/src/Functional/GroupTabTest.php
+++ b/tests/src/Functional/GroupTabTest.php
@@ -55,7 +55,7 @@ class GroupTabTest extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Create bundles.

--- a/tests/src/Functional/GroupTabTest.php
+++ b/tests/src/Functional/GroupTabTest.php
@@ -99,10 +99,10 @@ class GroupTabTest extends BrowserTestBase {
   public function testGroupTab() {
     $this->drupalLogin($this->user1);
     $this->drupalGet('group/node/' . $this->group->id() . '/admin');
-    $this->assertResponse(200);
+    $this->assertSession()->statusCodeEquals(200);
 
     $this->drupalGet('group/node/' . $this->nonGroup->id() . '/admin');
-    $this->assertResponse(403);
+    $this->assertSession()->statusCodeEquals(403);
   }
 
 }

--- a/tests/src/Functional/GroupUpdateTest.php
+++ b/tests/src/Functional/GroupUpdateTest.php
@@ -71,7 +71,7 @@ class GroupUpdateTest extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Create dummy users.

--- a/tests/src/Functional/OgComplexWidgetTest.php
+++ b/tests/src/Functional/OgComplexWidgetTest.php
@@ -34,7 +34,7 @@ class OgComplexWidgetTest extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  public function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Create a "group" bundle on the Custom Block entity type and turn it into

--- a/tests/src/Kernel/Access/AccessByOgMembershipTest.php
+++ b/tests/src/Kernel/Access/AccessByOgMembershipTest.php
@@ -65,7 +65,7 @@ class AccessByOgMembershipTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->installConfig(['og']);

--- a/tests/src/Kernel/Access/OgAccessHookTest.php
+++ b/tests/src/Kernel/Access/OgAccessHookTest.php
@@ -75,7 +75,7 @@ class OgAccessHookTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->installConfig(['og']);

--- a/tests/src/Kernel/Access/OgEntityAccessTest.php
+++ b/tests/src/Kernel/Access/OgEntityAccessTest.php
@@ -136,7 +136,7 @@ class OgEntityAccessTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->installConfig(['og']);

--- a/tests/src/Kernel/Access/OgGroupContentOperationAccessTest.php
+++ b/tests/src/Kernel/Access/OgGroupContentOperationAccessTest.php
@@ -83,7 +83,7 @@ class OgGroupContentOperationAccessTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->installConfig(['og']);

--- a/tests/src/Kernel/Action/ActionTestBase.php
+++ b/tests/src/Kernel/Action/ActionTestBase.php
@@ -78,7 +78,7 @@ abstract class ActionTestBase extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->installEntitySchema('og_membership');

--- a/tests/src/Kernel/Action/ChangeMultipleOgMembershipRolesActionTestBase.php
+++ b/tests/src/Kernel/Action/ChangeMultipleOgMembershipRolesActionTestBase.php
@@ -24,7 +24,7 @@ class ChangeMultipleOgMembershipRolesActionTestBase extends ChangeOgMembershipAc
   /**
    * {@inheritdoc}
    */
-  public function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->installSchema('system', ['key_value_expire']);

--- a/tests/src/Kernel/Cache/Context/OgRoleCacheContextTest.php
+++ b/tests/src/Kernel/Cache/Context/OgRoleCacheContextTest.php
@@ -79,7 +79,7 @@ class OgRoleCacheContextTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public function setUp(): void {
+  protected function setUp(): void: void {
     parent::setUp();
 
     // Add membership and config schema.

--- a/tests/src/Kernel/Cache/Context/OgRoleCacheContextTest.php
+++ b/tests/src/Kernel/Cache/Context/OgRoleCacheContextTest.php
@@ -79,7 +79,7 @@ class OgRoleCacheContextTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp(): void: void {
+  protected function setUp(): void {
     parent::setUp();
 
     // Add membership and config schema.

--- a/tests/src/Kernel/DefaultRoleEventIntegrationTest.php
+++ b/tests/src/Kernel/DefaultRoleEventIntegrationTest.php
@@ -44,7 +44,7 @@ class DefaultRoleEventIntegrationTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->eventDispatcher = $this->container->get('event_dispatcher');

--- a/tests/src/Kernel/Entity/CacheInvalidationOnGroupChangeTest.php
+++ b/tests/src/Kernel/Entity/CacheInvalidationOnGroupChangeTest.php
@@ -39,7 +39,7 @@ class CacheInvalidationOnGroupChangeTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->installEntitySchema('entity_test');

--- a/tests/src/Kernel/Entity/EntityCreateAccessTest.php
+++ b/tests/src/Kernel/Entity/EntityCreateAccessTest.php
@@ -52,7 +52,7 @@ class EntityCreateAccessTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->installConfig(['og']);

--- a/tests/src/Kernel/Entity/FieldCreateTest.php
+++ b/tests/src/Kernel/Entity/FieldCreateTest.php
@@ -40,7 +40,7 @@ class FieldCreateTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Add membership and config schema.

--- a/tests/src/Kernel/Entity/GetBundleByBundleTest.php
+++ b/tests/src/Kernel/Entity/GetBundleByBundleTest.php
@@ -60,7 +60,7 @@ class GetBundleByBundleTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->installConfig(['og']);

--- a/tests/src/Kernel/Entity/GetGroupContentTest.php
+++ b/tests/src/Kernel/Entity/GetGroupContentTest.php
@@ -47,7 +47,7 @@ class GetGroupContentTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->installConfig(['og']);

--- a/tests/src/Kernel/Entity/GetMembershipsTest.php
+++ b/tests/src/Kernel/Entity/GetMembershipsTest.php
@@ -56,7 +56,7 @@ class GetMembershipsTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->installConfig(['og']);

--- a/tests/src/Kernel/Entity/GetUserGroupsTest.php
+++ b/tests/src/Kernel/Entity/GetUserGroupsTest.php
@@ -84,7 +84,7 @@ class GetUserGroupsTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->installConfig(['og']);

--- a/tests/src/Kernel/Entity/GroupAudienceTest.php
+++ b/tests/src/Kernel/Entity/GroupAudienceTest.php
@@ -43,7 +43,7 @@ class GroupAudienceTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Add membership and config schema.

--- a/tests/src/Kernel/Entity/GroupMembershipManagerTest.php
+++ b/tests/src/Kernel/Entity/GroupMembershipManagerTest.php
@@ -77,7 +77,7 @@ class GroupMembershipManagerTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->installConfig(['og']);

--- a/tests/src/Kernel/Entity/GroupTypeTest.php
+++ b/tests/src/Kernel/Entity/GroupTypeTest.php
@@ -27,7 +27,7 @@ class GroupTypeTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->installConfig(['og']);

--- a/tests/src/Kernel/Entity/OgMembershipRoleReferenceTest.php
+++ b/tests/src/Kernel/Entity/OgMembershipRoleReferenceTest.php
@@ -51,7 +51,7 @@ class OgMembershipRoleReferenceTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Installing needed schema.

--- a/tests/src/Kernel/Entity/OgMembershipTest.php
+++ b/tests/src/Kernel/Entity/OgMembershipTest.php
@@ -74,7 +74,7 @@ class OgMembershipTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->installConfig(['og']);

--- a/tests/src/Kernel/Entity/OgRoleTest.php
+++ b/tests/src/Kernel/Entity/OgRoleTest.php
@@ -59,7 +59,7 @@ class OgRoleTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Installing needed schema.

--- a/tests/src/Kernel/Entity/OgStandardReferenceItemTest.php
+++ b/tests/src/Kernel/Entity/OgStandardReferenceItemTest.php
@@ -44,7 +44,7 @@ class OgStandardReferenceItemTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Add membership and config schema.

--- a/tests/src/Kernel/Entity/ReferenceStringIdTest.php
+++ b/tests/src/Kernel/Entity/ReferenceStringIdTest.php
@@ -43,7 +43,7 @@ class ReferenceStringIdTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Add membership and config schema.

--- a/tests/src/Kernel/Entity/SelectionHandlerTest.php
+++ b/tests/src/Kernel/Entity/SelectionHandlerTest.php
@@ -81,7 +81,7 @@ class SelectionHandlerTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Add membership and config schema.

--- a/tests/src/Kernel/EntityReference/Views/OgStandardReferenceRelationshipTest.php
+++ b/tests/src/Kernel/EntityReference/Views/OgStandardReferenceRelationshipTest.php
@@ -55,7 +55,7 @@ class OgStandardReferenceRelationshipTest extends ViewsKernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp($import_test_views = TRUE) {
+  protected function setUp($import_test_views = TRUE): void {
     parent::setUp();
 
     $this->installEntitySchema('user');

--- a/tests/src/Kernel/Form/GroupSubscribeFormTest.php
+++ b/tests/src/Kernel/Form/GroupSubscribeFormTest.php
@@ -63,7 +63,7 @@ class GroupSubscribeFormTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->installConfig(['og']);

--- a/tests/src/Kernel/GroupManagerSubscriptionTest.php
+++ b/tests/src/Kernel/GroupManagerSubscriptionTest.php
@@ -52,7 +52,7 @@ class GroupManagerSubscriptionTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->groupTypeManager = $this->container->get('og.group_type_manager');

--- a/tests/src/Kernel/GroupTypeConditionTest.php
+++ b/tests/src/Kernel/GroupTypeConditionTest.php
@@ -50,7 +50,7 @@ class GroupTypeConditionTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->conditionManager = $this->container->get('plugin.manager.condition');

--- a/tests/src/Kernel/OgDeleteOrphansTest.php
+++ b/tests/src/Kernel/OgDeleteOrphansTest.php
@@ -52,7 +52,7 @@ class OgDeleteOrphansTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Add membership and config schema.

--- a/tests/src/Kernel/OgRoleManagerTest.php
+++ b/tests/src/Kernel/OgRoleManagerTest.php
@@ -51,7 +51,7 @@ class OgRoleManagerTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Add membership and config schema.

--- a/tests/src/Kernel/PermissionEventTest.php
+++ b/tests/src/Kernel/PermissionEventTest.php
@@ -47,7 +47,7 @@ class PermissionEventTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->eventDispatcher = $this->container->get('event_dispatcher');

--- a/tests/src/Kernel/Plugin/Block/MemberCountBlockTest.php
+++ b/tests/src/Kernel/Plugin/Block/MemberCountBlockTest.php
@@ -110,7 +110,7 @@ class MemberCountBlockTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->installEntitySchema('entity_test');

--- a/tests/src/Unit/Cache/Context/OgContextCacheContextTestBase.php
+++ b/tests/src/Unit/Cache/Context/OgContextCacheContextTestBase.php
@@ -32,7 +32,7 @@ abstract class OgContextCacheContextTestBase extends OgCacheContextTestBase {
   /**
    * {@inheritdoc}
    */
-  public function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->ogContext = $this->prophesize(OgContextInterface::class);

--- a/tests/src/Unit/Cache/Context/OgMembershipStateCacheContextTest.php
+++ b/tests/src/Unit/Cache/Context/OgMembershipStateCacheContextTest.php
@@ -39,7 +39,7 @@ class OgMembershipStateCacheContextTest extends OgContextCacheContextTestBase {
   /**
    * {@inheritdoc}
    */
-  public function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->user = $this->prophesize(AccountInterface::class);

--- a/tests/src/Unit/Cache/Context/OgRoleCacheContextTest.php
+++ b/tests/src/Unit/Cache/Context/OgRoleCacheContextTest.php
@@ -56,7 +56,7 @@ class OgRoleCacheContextTest extends OgCacheContextTestBase {
   /**
    * {@inheritdoc}
    */
-  public function setUp(): void {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->entityTypeManager = $this->prophesize(EntityTypeManagerInterface::class);

--- a/tests/src/Unit/CreateMembershipTest.php
+++ b/tests/src/Unit/CreateMembershipTest.php
@@ -96,7 +96,7 @@ class CreateMembershipTest extends UnitTestCase {
   /**
    * {@inheritdoc}
    */
-  public function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->entityTypeId = $this->randomMachineName();

--- a/tests/src/Unit/DefaultRoleEventTest.php
+++ b/tests/src/Unit/DefaultRoleEventTest.php
@@ -34,7 +34,7 @@ class DefaultRoleEventTest extends UnitTestCase {
   /**
    * {@inheritdoc}
    */
-  public function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $entity_type_manager = $this->prophesize(EntityTypeManagerInterface::class);

--- a/tests/src/Unit/GroupCheckTest.php
+++ b/tests/src/Unit/GroupCheckTest.php
@@ -117,7 +117,7 @@ class GroupCheckTest extends UnitTestCase {
   /**
    * {@inheritdoc}
    */
-  public function setUp() {
+  protected function setUp(): void {
     $this->entityTypeManager = $this->prophesize(EntityTypeManagerInterface::class);
     $this->entityType = $this->prophesize(EntityTypeInterface::class);
     $this->entityStorage = $this->prophesize(EntityStorageInterface::class);

--- a/tests/src/Unit/GroupSubscribeFormatterTest.php
+++ b/tests/src/Unit/GroupSubscribeFormatterTest.php
@@ -150,7 +150,7 @@ class GroupSubscribeFormatterTest extends UnitTestCase {
   /**
    * {@inheritdoc}
    */
-  public function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->accessResult = $this->prophesize(AccessResultInterface::class);

--- a/tests/src/Unit/GroupTypeManagerTest.php
+++ b/tests/src/Unit/GroupTypeManagerTest.php
@@ -124,7 +124,7 @@ class GroupTypeManagerTest extends UnitTestCase {
   /**
    * {@inheritdoc}
    */
-  public function setUp() {
+  protected function setUp(): void {
     $this->config = $this->prophesize(Config::class);
     $this->configFactory = $this->prophesize(ConfigFactoryInterface::class);
     $this->entityTypeBundleInfo = $this->prophesize(EntityTypeBundleInfoInterface::class);

--- a/tests/src/Unit/OgAccessEntityTestBase.php
+++ b/tests/src/Unit/OgAccessEntityTestBase.php
@@ -27,7 +27,7 @@ abstract class OgAccessEntityTestBase extends OgAccessTestBase {
   /**
    * {@inheritdoc}
    */
-  public function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Mock a group content entity.

--- a/tests/src/Unit/OgAccessHookTest.php
+++ b/tests/src/Unit/OgAccessHookTest.php
@@ -15,7 +15,7 @@ class OgAccessHookTest extends OgAccessEntityTestBase {
   /**
    * {@inheritdoc}
    */
-  public function setUp() {
+  protected function setUp(): void {
     parent::setUp();
     // Since this is a unit test, we don't enable the module. However, we test
     // a hook implementation inside the module so include the module manually.

--- a/tests/src/Unit/OgAccessTestBase.php
+++ b/tests/src/Unit/OgAccessTestBase.php
@@ -129,7 +129,7 @@ class OgAccessTestBase extends UnitTestCase {
   /**
    * {@inheritdoc}
    */
-  public function setUp() {
+  protected function setUp(): void {
     $this->groupId = $this->randomMachineName();
     $this->entityTypeId = $this->randomMachineName();
     $this->bundle = $this->randomMachineName();

--- a/tests/src/Unit/OgAdminRoutesControllerTest.php
+++ b/tests/src/Unit/OgAdminRoutesControllerTest.php
@@ -103,7 +103,7 @@ class OgAdminRoutesControllerTest extends UnitTestCase {
   /**
    * {@inheritdoc}
    */
-  public function setUp() {
+  protected function setUp(): void {
 
     $this->accessManager = $this->prophesize(AccessManagerInterface::class);
     $this->routeMatch = $this->prophesize(RouteMatchInterface::class);

--- a/tests/src/Unit/OgContextTest.php
+++ b/tests/src/Unit/OgContextTest.php
@@ -69,7 +69,7 @@ class OgContextTest extends UnitTestCase {
   /**
    * {@inheritdoc}
    */
-  public function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->pluginManager = $this->prophesize(PluginManagerInterface::class);

--- a/tests/src/Unit/OgLocalTaskTest.php
+++ b/tests/src/Unit/OgLocalTaskTest.php
@@ -43,7 +43,7 @@ class OgLocalTaskTest extends UnitTestCase {
   /**
    * {@inheritdoc}
    */
-  public function setUp() {
+  protected function setUp(): void {
     $this->groupTypeManager = $this->prophesize(GroupTypeManagerInterface::class);
     $this->routeProvider = $this->prophesize(RouteProvider::class);
     $this->route = $this->prophesize(Route::class);

--- a/tests/src/Unit/OgResolvedGroupCollectionTest.php
+++ b/tests/src/Unit/OgResolvedGroupCollectionTest.php
@@ -24,7 +24,7 @@ class OgResolvedGroupCollectionTest extends UnitTestCase {
   /**
    * {@inheritdoc}
    */
-  public function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Mock some test groups.

--- a/tests/src/Unit/OgRoleManagerTest.php
+++ b/tests/src/Unit/OgRoleManagerTest.php
@@ -78,7 +78,7 @@ class OgRoleManagerTest extends UnitTestCase {
   /**
    * {@inheritdoc}
    */
-  public function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->entityTypeId = $this->randomMachineName();

--- a/tests/src/Unit/Plugin/OgGroupResolver/OgGroupResolverTestBase.php
+++ b/tests/src/Unit/Plugin/OgGroupResolver/OgGroupResolverTestBase.php
@@ -68,7 +68,7 @@ abstract class OgGroupResolverTestBase extends UnitTestCase {
   /**
    * {@inheritdoc}
    */
-  public function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Instantiate mocks of the classes that the plugins rely on.

--- a/tests/src/Unit/Plugin/OgGroupResolver/OgRouteGroupResolverTestBase.php
+++ b/tests/src/Unit/Plugin/OgGroupResolver/OgRouteGroupResolverTestBase.php
@@ -54,7 +54,7 @@ abstract class OgRouteGroupResolverTestBase extends OgGroupResolverTestBase {
   /**
    * {@inheritdoc}
    */
-  public function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Instantiate mocks of the classes that the plugins rely on.

--- a/tests/src/Unit/Plugin/OgGroupResolver/RequestQueryArgumentResolverTest.php
+++ b/tests/src/Unit/Plugin/OgGroupResolver/RequestQueryArgumentResolverTest.php
@@ -37,7 +37,7 @@ class RequestQueryArgumentResolverTest extends OgGroupResolverTestBase {
   /**
    * {@inheritdoc}
    */
-  public function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Instantiate mocks of the classes that the plugins rely on.

--- a/tests/src/Unit/SubscriptionControllerTest.php
+++ b/tests/src/Unit/SubscriptionControllerTest.php
@@ -98,7 +98,7 @@ class SubscriptionControllerTest extends UnitTestCase {
   /**
    * {@inheritdoc}
    */
-  public function setUp() {
+  protected function setUp(): void {
     $this->entityFormBuilder = $this->prophesize(EntityFormBuilderInterface::class);
     $this->group = $this->prophesize(ContentEntityInterface::class);
     $this->membershipManager = $this->prophesize(MembershipManagerInterface::class);


### PR DESCRIPTION
The tests are failing due to a deprecation warning:

```
46x: Declaring ::setUp without a void return typehint in Drupal\Tests\og\Unit\DefaultRoleEventTest is deprecated in drupal:9.0.0. Typehinting will be required before drupal:10.0.0. See https://www.drupal.org/node/3114724
```