### PR TITLE
Drupal 9.1.x deprecation notice: AssertLegacyTrait::assertOptionSelected() is deprecated

### DIFF
--- a/og_ui/tests/src/Functional/BundleFormAlterTest.php
+++ b/og_ui/tests/src/Functional/BundleFormAlterTest.php
@@ -82,7 +82,7 @@ class BundleFormAlterTest extends BrowserTestBase {
     $this->drupalGet('admin/structure/types/add');
     $this->submitForm($edit, new TranslatableMarkup('Save content type'));
     $this->content = $this->drupalGet('admin/structure/types/manage/class');
-    $this->assertOptionSelected('edit-og-target-bundles', 'school');
+    $this->assertTrue($this->assertSession()->optionExists('edit-og-target-bundles', 'school')->isSelected());
     $this->assertTargetType('block_content', 'The target type is set to the "Custom Block" entity type.');
     $this->assertTargetBundles(['school' => 'school'], 'The target bundles are set to the "school" bundle.');
 


### PR DESCRIPTION
We were alerted in #661 that there is a new deprecation in Drupal 9.1.x:

```
  1x: AssertLegacyTrait::assertOptionSelected() is deprecated in drupal:8.2.0 and is removed from drupal:10.0.0. Use $this->assertSession()->optionExists() instead and check the "selected" attribute. See https://www.drupal.org/node/3129738

    1x in BundleFormAlterTest::testCreate from Drupal\Tests\og_ui\Functional
```

ref. https://travis-ci.com/github/Gizra/og/jobs/360667959