### PR TITLE
Drop support for php 7.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "source": "https://git.drupalcode.org/project/og"
     },
     "require": {
-        "php": "^7.1.0",
+        "php": "^7.2",
         "drupal/core": "^8.8 || ^9.0"
     },
     "require-dev": {


### PR DESCRIPTION
Php 7.1 is no longer supported
https://www.php.net/supported-versions.php
Travis no longer runs test for php 7.2