### PR TITLE
Fixed grammar

### DIFF
--- a/src/OgAccess.php
+++ b/src/OgAccess.php
@@ -329,7 +329,7 @@ class OgAccess implements OgAccessInterface {
    * {@inheritdoc}
    */
   public function reset(): void {
-    trigger_error('OgAccessInterface::reset() is deprecated in og:8.1.0-alpha6 and is removed from og:8.1.0-beta1. The static cache has been removed and this no longer server any purpose. See https://github.com/Gizra/og/issues/654', E_USER_DEPRECATED);
+    trigger_error('OgAccessInterface::reset() is deprecated in og:8.1.0-alpha6 and is removed from og:8.1.0-beta1. The static cache has been removed and this method no longer serves any purpose. Any calls to this method can safely be removed. See https://github.com/Gizra/og/issues/654', E_USER_DEPRECATED);
   }
 
 }


### PR DESCRIPTION
The static cache has been removed and this no longer **server** any purpose. 

Using the same message as the deprecation dochead:

The static cache has been removed and this method no longer serves any purpose. Any calls to this method can safely be removed.

