### PR TITLE
Remove obsolete service definition

### DIFF
--- a/og.services.yml
+++ b/og.services.yml
@@ -22,11 +22,6 @@ services:
   og.access:
     class: Drupal\og\OgAccess
     arguments: ['@config.factory', '@current_user', '@module_handler', '@og.group_type_manager', '@og.permission_manager', '@og.membership_manager', '@og.group_audience_helper']
-  og.add_field:
-    class: Drupal\og\Command\OgAddFieldCommand
-    arguments: ['@entity_type.bundle.info', '@entity_type.repository', '@plugin.manager.og.fields']
-    tags:
-      - { name: drupal.command }
   og.context:
     class: Drupal\og\ContextProvider\OgContext
     arguments: ['@plugin.manager.og.group_resolver', '@config.factory']


### PR DESCRIPTION
In #640 the support for Drupal Console was removed since it was conflicting with Drupal 9 (ref commit [aa3b87c](https://github.com/Gizra/og/commit/aa3b87c87c0cf2d44507e8e0a598bf040b9c69a3)).

We removed the Drupal Console command service but forgot to clean up the service definition.