### PR TITLE
Extend OgRoleInterface from RoleInterface

### DIFF
--- a/og.module
+++ b/og.module
@@ -383,8 +383,8 @@ function og_og_role_insert(OgRoleInterface $role) {
     return;
   }
 
-  // Do not create config while config import is in progress.
-  if (\Drupal::isConfigSyncing()) {
+  // Skip creation of action plugins while config import is in progress.
+  if ($role->isSyncing()) {
     return;
   }
 

--- a/src/Event/DefaultRoleEventInterface.php
+++ b/src/Event/DefaultRoleEventInterface.php
@@ -23,9 +23,8 @@ interface DefaultRoleEventInterface extends \ArrayAccess, \IteratorAggregate {
    * @param string $name
    *   The name of the role to return.
    *
-   * @return \Drupal\og\Entity\OgRole
-   *   The OgRole entity. Note that we cannot specify OgRoleInterface here
-   *   because of limitations in interface inheritance in PHP 5.
+   * @return \Drupal\og\OgRoleInterface
+   *   The OgRole entity.
    *
    * @throws \InvalidArgumentException
    *   Thrown when the role with the given name does not exist.

--- a/src/OgRoleInterface.php
+++ b/src/OgRoleInterface.php
@@ -3,6 +3,7 @@
 namespace Drupal\og;
 
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\user\RoleInterface;
 
 /**
  * Provides an interface defining an OG user role entity.

--- a/src/OgRoleInterface.php
+++ b/src/OgRoleInterface.php
@@ -6,10 +6,8 @@ use Drupal\Core\Entity\EntityInterface;
 
 /**
  * Provides an interface defining an OG user role entity.
- *
- * Class cannot extend RoleInterface due to PHP 5 limitations.
  */
-interface OgRoleInterface {
+interface OgRoleInterface extends RoleInterface {
 
   /**
    * The role name of the group non-member.

--- a/tests/src/Kernel/Access/OgGroupContentOperationAccessTest.php
+++ b/tests/src/Kernel/Access/OgGroupContentOperationAccessTest.php
@@ -60,9 +60,7 @@ class OgGroupContentOperationAccessTest extends KernelTestBase {
   /**
    * An array of test roles.
    *
-   * @var \Drupal\og\Entity\OgRole[]
-   *   Note that we're not using OgRoleInterface because of a class inheritance
-   *   limitation in PHP 5.
+   * @var \Drupal\og\OgRoleInterface[]
    */
   protected $roles;
 


### PR DESCRIPTION
Fixes #682.

- extend OgRoleInterface from RoleInterface
- since RoleInterface extends ConfigEntityInterface which extends SynchronizableInterface we can now use SynchronizableInterface::isSyncing()