### PR TITLE
Fix deprecated license

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "drupal/og",
     "description": "API to allow associating content with groups.",
     "type": "drupal-module",
-    "license": "GPL-2.0+",
+    "license": "GPL-2.0-or-later",
     "homepage": "https://drupal.org/project/og",
     "support": {
         "issues": "https://drupal.org/project/issues/og",


### PR DESCRIPTION
Originally reported on https://www.drupal.org/project/og/issues/3161323

See https://getcomposer.org/doc/04-schema.md for details on the schema
License "GPL-2.0+" is a deprecated SPDX license identifier, use "GPL-2.0-or-later" instead