### PR TITLE
Permission based access checks should return neutral if a permission is not granted

### DIFF
--- a/src/Event/AccessEventBase.php
+++ b/src/Event/AccessEventBase.php
@@ -57,15 +57,17 @@ class AccessEventBase extends Event implements AccessEventInterface {
   /**
    * {@inheritdoc}
    */
-  public function grantAccess(): void {
+  public function grantAccess(): AccessResultInterface {
     $this->access = $this->access->orIf(AccessResult::allowed());
+    return $this->access;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function denyAccess(): void {
+  public function denyAccess(): AccessResultInterface {
     $this->access = $this->access->orIf(AccessResult::forbidden());
+    return $this->access;
   }
 
   /**

--- a/src/Event/AccessEventBase.php
+++ b/src/Event/AccessEventBase.php
@@ -73,6 +73,14 @@ class AccessEventBase extends Event implements AccessEventInterface {
   /**
    * {@inheritdoc}
    */
+  public function mergeAccessResult(AccessResultInterface $access_result): AccessResultInterface {
+    $this->access = $this->access->orIf($access_result);
+    return $this->access;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getGroup(): ContentEntityInterface {
     return $this->group;
   }

--- a/src/Event/AccessEventInterface.php
+++ b/src/Event/AccessEventInterface.php
@@ -19,8 +19,11 @@ interface AccessEventInterface extends RefinableCacheableDependencyInterface {
    *
    * Calling this method will cause access to be granted for the action that is
    * being checked, unless another event listener denies access.
+   *
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   The updated access result.
    */
-  public function grantAccess(): void;
+  public function grantAccess(): AccessResultInterface;
 
   /**
    * Declare that access is being denied.
@@ -28,8 +31,11 @@ interface AccessEventInterface extends RefinableCacheableDependencyInterface {
    * Calling this method will cause access to be denied for the action that is
    * being checked. This takes precedence over any other event listeners that
    * might grant access.
+   *
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   The updated access result.
    */
-  public function denyAccess(): void;
+  public function denyAccess(): AccessResultInterface;
 
   /**
    * Returns the group that provides the context for the access check.

--- a/src/Event/AccessEventInterface.php
+++ b/src/Event/AccessEventInterface.php
@@ -38,6 +38,14 @@ interface AccessEventInterface extends RefinableCacheableDependencyInterface {
   public function denyAccess(): AccessResultInterface;
 
   /**
+   * Merges the given access result with the existing access result.
+   *
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   The updated access result.
+   */
+  public function mergeAccessResult(AccessResultInterface $access_result): AccessResultInterface;
+
+  /**
    * Returns the group that provides the context for the access check.
    *
    * @return \Drupal\Core\Entity\ContentEntityInterface

--- a/src/EventSubscriber/OgEventSubscriber.php
+++ b/src/EventSubscriber/OgEventSubscriber.php
@@ -416,16 +416,7 @@ class OgEventSubscriber implements EventSubscriberInterface {
 
     if ($permissions) {
       foreach ($permissions as $permission) {
-        // This currently does not handle access in the same way as Drupal core
-        // does - if any of the permissions grant access we will grant access.
-        // Once OgAccess::userAccess() is refactored to return a neutral result
-        // in case no access is determined we can just apply the result
-        // directly.
-        $access_result = $this->ogAccess->userAccess($group_entity, $permission->getName(), $user);
-        if ($access_result->isAllowed()) {
-          $event->grantAccess();
-          break;
-        }
+        $event->mergeAccessResult($this->ogAccess->userAccess($group_entity, $permission->getName(), $user));
       }
     }
   }

--- a/src/OgAccess.php
+++ b/src/OgAccess.php
@@ -217,7 +217,7 @@ class OgAccess implements OgAccessInterface {
       return AccessResult::allowed()->addCacheableDependency($cacheable_metadata);
     }
 
-    return AccessResult::forbidden()->addCacheableDependency($cacheable_metadata);
+    return AccessResult::neutral()->addCacheableDependency($cacheable_metadata);
   }
 
   /**
@@ -231,46 +231,31 @@ class OgAccess implements OgAccessInterface {
     $bundle = $entity->bundle();
 
     if ($this->groupTypeManager->isGroup($entity_type_id, $bundle)) {
-      $user_access = $this->userAccess($entity, $permission, $user);
-      if ($user_access->isAllowed()) {
-        return $user_access;
-      }
-      else {
-        // An entity can be a group and group content in the same time. The
-        // group didn't allow access, but the user still might have access to
-        // the permission in group content context. So instead of returning a
-        // deny here, we set the result, that might change if an access is
-        // found.
-        $result = AccessResult::forbidden()->inheritCacheability($user_access);
+      // An entity can be a group and group content in the same time. If the
+      // group returns a neutral result the user still might have access to
+      // the permission in group content context. So if we get a neutral result
+      // we will continue with the group content access check below.
+      $result = $this->userAccess($entity, $permission, $user);
+      if (!$result->isNeutral()) {
+        return $result;
       }
     }
 
     if ($this->groupTypeManager->isGroupContent($entity_type_id, $bundle)) {
-      $cache_tags = $entity_type->getListCacheTags();
+      $result->addCacheTags($entity_type->getListCacheTags());
 
       // The entity might be a user or a non-user entity.
       $groups = $entity instanceof UserInterface ? $this->membershipManager->getUserGroups($entity->id()) : $this->membershipManager->getGroups($entity);
 
       if ($groups) {
-        $forbidden = AccessResult::forbidden()->addCacheTags($cache_tags);
         foreach ($groups as $entity_groups) {
           foreach ($entity_groups as $group) {
-            $user_access = $this->userAccess($group, $permission, $user);
-            if ($user_access->isAllowed()) {
-              return $user_access->addCacheTags($cache_tags);
-            }
-
-            $forbidden->inheritCacheability($user_access);
+            $result = $result->orIf($this->userAccess($group, $permission, $user));
           }
         }
-        return $forbidden;
       }
-
-      $result->addCacheTags($cache_tags);
     }
 
-    // Either the user didn't have permission, or the entity might be orphaned
-    // group content.
     return $result;
   }
 
@@ -290,45 +275,32 @@ class OgAccess implements OgAccessInterface {
       if (array_key_exists($operation, self::OPERATION_GROUP_PERMISSION_MAPPING)) {
         $permission = self::OPERATION_GROUP_PERMISSION_MAPPING[$operation];
 
-        $user_access = $this->userAccess($entity, $permission, $user);
-        if ($user_access->isAllowed()) {
-          return $user_access;
-        }
-        else {
-          // An entity can be a group and group content in the same time. The
-          // group permission check didn't allow access, but the user still
-          // might have access to perform the operation in group content
-          // context. So instead of returning a deny here, we set the result,
-          // that might change if an access is found.
-          $result = AccessResult::forbidden()->inheritCacheability($user_access);
+        // An entity can be a group and group content in the same time. If the
+        // group returns a neutral result the user still might have access to
+        // the permission in group content context. So if we get a neutral result
+        // we will continue with the group content access check below.
+        $result = $this->userAccess($entity, $permission, $user);
+        if (!$result->isNeutral()) {
+          return $result;
         }
       }
     }
 
     if ($this->groupTypeManager->isGroupContent($entity_type_id, $bundle)) {
-      $cache_tags = $entity_type->getListCacheTags();
+      $result->addCacheTags($entity_type->getListCacheTags());
 
       // The entity might be a user or a non-user entity.
       $groups = $entity instanceof UserInterface ? $this->membershipManager->getUserGroups($entity->id()) : $this->membershipManager->getGroups($entity);
 
       if ($groups) {
-        $forbidden = AccessResult::forbidden()->addCacheTags($cache_tags);
         foreach ($groups as $entity_groups) {
           foreach ($entity_groups as $group) {
-            $operation_access = $this->userAccessGroupContentEntityOperation($operation, $group, $entity, $user);
-            if ($operation_access->isAllowed()) {
-              return $operation_access->addCacheTags($cache_tags);
-            }
+            $result = $result->orIf($this->userAccessGroupContentEntityOperation($operation, $group, $entity, $user));
           }
         }
-        return $forbidden;
       }
-
-      $result->addCacheTags($cache_tags);
     }
 
-    // Either the user didn't have permission, or the entity might be orphaned
-    // group content.
     return $result;
   }
 

--- a/src/OgAccess.php
+++ b/src/OgAccess.php
@@ -277,8 +277,8 @@ class OgAccess implements OgAccessInterface {
 
         // An entity can be a group and group content in the same time. If the
         // group returns a neutral result the user still might have access to
-        // the permission in group content context. So if we get a neutral result
-        // we will continue with the group content access check below.
+        // the permission in group content context. So if we get a neutral
+        // result we will continue with the group content access check below.
         $result = $this->userAccess($entity, $permission, $user);
         if (!$result->isNeutral()) {
           return $result;

--- a/tests/src/Kernel/Access/GroupLevelAccessTest.php
+++ b/tests/src/Kernel/Access/GroupLevelAccessTest.php
@@ -146,15 +146,15 @@ class GroupLevelAccessTest extends KernelTestBase {
     $this->assertTrue($this->ogAccess->userAccess($this->group, 'some_perm', $users['has_permission_in_both_groups'])->isAllowed());
     // This user should not have access to 'some_perm_2' as that was only
     // assigned to group 2.
-    $this->assertTrue($this->ogAccess->userAccess($this->group, 'some_perm_2', $users['has_permission_in_both_groups'])->isForbidden());
+    $this->assertTrue($this->ogAccess->userAccess($this->group, 'some_perm_2', $users['has_permission_in_both_groups'])->isNeutral());
     // Check the permission of group 1 again.
     $this->assertTrue($this->ogAccess->userAccess($this->group, 'some_perm', $users['has_permission_in_both_groups'])->isAllowed());
 
     // A member user without the correct role.
-    $this->assertTrue($this->ogAccess->userAccess($this->group, 'some_perm', $users['has_no_permission'])->isForbidden());
+    $this->assertTrue($this->ogAccess->userAccess($this->group, 'some_perm', $users['has_no_permission'])->isNeutral());
 
     // A non-member user.
-    $this->assertTrue($this->ogAccess->userAccess($this->group, 'some_perm', $this->nonMemberUser)->isForbidden());
+    $this->assertTrue($this->ogAccess->userAccess($this->group, 'some_perm', $this->nonMemberUser)->isNeutral());
 
     // Grant the arbitrary permission to non-members and check that our
     // non-member now has the permission.

--- a/tests/src/Unit/OgAccessEntityTest.php
+++ b/tests/src/Unit/OgAccessEntityTest.php
@@ -25,7 +25,7 @@ class OgAccessEntityTest extends OgAccessEntityTestBase {
 
     // We populate the allowed permissions cache in
     // OgAccessEntityTestBase::setup().
-    $condition = $permission == 'update group' ? $user_access->isAllowed() : $user_access->isForbidden();
+    $condition = $permission == 'update group' ? $user_access->isAllowed() : $user_access->isNeutral();
     $this->assertTrue($condition);
   }
 

--- a/tests/src/Unit/OgAccessTest.php
+++ b/tests/src/Unit/OgAccessTest.php
@@ -35,7 +35,7 @@ class OgAccessTest extends OgAccessTestBase {
 
     // We populate the allowed permissions cache in
     // OgAccessTestBase::setup().
-    $condition = $operation == 'update group' ? $user_access->isAllowed() : $user_access->isForbidden();
+    $condition = $operation == 'update group' ? $user_access->isAllowed() : $user_access->isNeutral();
 
     $this->assertTrue($condition);
   }


### PR DESCRIPTION
Fixes #691 

Very happy with how this turned out.

It is remarkable how this small change cleans up our access code. By leveraging the core functionality we no longer need to handle the access checks and merging of cacheability metadata ourselves and the end result is very lean and readable code.

This is building on top of #684 so marking this as a draft until that PR is in.