### PR TITLE
694 Fix access condition check in SubscriptionController

### DIFF
--- a/src/Controller/SubscriptionController.php
+++ b/src/Controller/SubscriptionController.php
@@ -136,7 +136,8 @@ class SubscriptionController extends ControllerBase {
       return new RedirectResponse($group->toUrl()->setAbsolute(TRUE)->toString());
     }
 
-    if (!$this->ogAccess->userAccess($group, 'subscribe', $user) && !$this->ogAccess->userAccess($group, 'subscribe without approval', $user)) {
+    if ((($access = $this->ogAccess->userAccess($group, 'subscribe', $user)) && $access->isForbidden()) &&
+      (($access = $this->ogAccess->userAccess($group, 'subscribe without approval', $user)) && $access->isForbidden())) {
       throw new AccessDeniedHttpException();
     }
 

--- a/src/Controller/SubscriptionController.php
+++ b/src/Controller/SubscriptionController.php
@@ -86,7 +86,7 @@ class SubscriptionController extends ControllerBase {
       throw new AccessDeniedHttpException();
     }
 
-    $user = $this->currentUser();
+    $user = $this->entityTypeManager()->getStorage('user')->load($this->currentUser()->id());
 
     if ($user->isAnonymous()) {
       // Anonymous user can't request membership.

--- a/src/Controller/SubscriptionController.php
+++ b/src/Controller/SubscriptionController.php
@@ -137,7 +137,7 @@ class SubscriptionController extends ControllerBase {
     }
 
     $subscribe = $this->ogAccess->userAccess($group, 'subscribe');
-    $subscribeWithoutApproval = $this->ogAccess->userAccess($group, 'subscribe without approval');
+    $subscribe_without_approval = $this->ogAccess->userAccess($group, 'subscribe without approval');
     if ($subscribe->isForbidden() && $subscribeWithoutApproval->isForbidden()) {
       throw new AccessDeniedHttpException();
     }

--- a/src/Controller/SubscriptionController.php
+++ b/src/Controller/SubscriptionController.php
@@ -138,7 +138,7 @@ class SubscriptionController extends ControllerBase {
 
     $subscribe = $this->ogAccess->userAccess($group, 'subscribe');
     $subscribe_without_approval = $this->ogAccess->userAccess($group, 'subscribe without approval');
-    if ($subscribe->isForbidden() && $subscribe_without_approval->isForbidden()) {
+    if (!$subscribe->isAllowed() && !$subscribe_without_approval->isAllowed()) {
       throw new AccessDeniedHttpException();
     }
 

--- a/src/Controller/SubscriptionController.php
+++ b/src/Controller/SubscriptionController.php
@@ -136,8 +136,8 @@ class SubscriptionController extends ControllerBase {
       return new RedirectResponse($group->toUrl()->setAbsolute(TRUE)->toString());
     }
 
-    $subscribe = $this->ogAccess->userAccess($group, 'subscribe', $user);
-    $subscribeWithoutApproval = $this->ogAccess->userAccess($group, 'subscribe without approval', $user);
+    $subscribe = $this->ogAccess->userAccess($group, 'subscribe');
+    $subscribeWithoutApproval = $this->ogAccess->userAccess($group, 'subscribe without approval');
     if ($subscribe->isForbidden() && $subscribeWithoutApproval->isForbidden()) {
       throw new AccessDeniedHttpException();
     }

--- a/src/Controller/SubscriptionController.php
+++ b/src/Controller/SubscriptionController.php
@@ -136,8 +136,9 @@ class SubscriptionController extends ControllerBase {
       return new RedirectResponse($group->toUrl()->setAbsolute(TRUE)->toString());
     }
 
-    if ((($access = $this->ogAccess->userAccess($group, 'subscribe', $user)) && $access->isForbidden()) &&
-      (($access = $this->ogAccess->userAccess($group, 'subscribe without approval', $user)) && $access->isForbidden())) {
+    $subscribe = $this->ogAccess->userAccess($group, 'subscribe', $user);
+    $subscribeWithoutApproval = $this->ogAccess->userAccess($group, 'subscribe without approval', $user);
+    if ($subscribe->isForbidden() && $subscribeWithoutApproval->isForbidden()) {
       throw new AccessDeniedHttpException();
     }
 

--- a/src/Controller/SubscriptionController.php
+++ b/src/Controller/SubscriptionController.php
@@ -86,7 +86,7 @@ class SubscriptionController extends ControllerBase {
       throw new AccessDeniedHttpException();
     }
 
-    $user = $this->entityTypeManager()->getStorage('user')->load($this->currentUser()->id());
+    $user = $this->currentUser();
 
     if ($user->isAnonymous()) {
       // Anonymous user can't request membership.

--- a/src/Controller/SubscriptionController.php
+++ b/src/Controller/SubscriptionController.php
@@ -138,7 +138,7 @@ class SubscriptionController extends ControllerBase {
 
     $subscribe = $this->ogAccess->userAccess($group, 'subscribe');
     $subscribe_without_approval = $this->ogAccess->userAccess($group, 'subscribe without approval');
-    if ($subscribe->isForbidden() && $subscribeWithoutApproval->isForbidden()) {
+    if ($subscribe->isForbidden() && $subscribe_without_approval->isForbidden()) {
       throw new AccessDeniedHttpException();
     }
 

--- a/tests/src/Functional/GroupSubscribeTest.php
+++ b/tests/src/Functional/GroupSubscribeTest.php
@@ -63,6 +63,13 @@ class GroupSubscribeTest extends BrowserTestBase {
   protected $group4;
 
   /**
+   * Test entity group.
+   *
+   * @var \Drupal\node\NodeInterface
+   */
+  protected $group5;
+
+  /**
    * A group bundle name.
    *
    * @var string
@@ -75,6 +82,13 @@ class GroupSubscribeTest extends BrowserTestBase {
    * @var string
    */
   protected $groupBundle2;
+
+  /**
+   * A group bundle name.
+   *
+   * @var string
+   */
+  protected $groupBundle3;
 
   /**
    * A membership type bundle name.
@@ -108,6 +122,8 @@ class GroupSubscribeTest extends BrowserTestBase {
     NodeType::create(['type' => $this->groupBundle1])->save();
     $this->groupBundle2 = mb_strtolower($this->randomMachineName());
     NodeType::create(['type' => $this->groupBundle2])->save();
+    $this->groupBundle3 = mb_strtolower($this->randomMachineName());
+    NodeType::create(['type' => $this->groupBundle3])->save();
     $this->nonGroupBundle = mb_strtolower($this->randomMachineName());
     NodeType::create(['type' => $this->nonGroupBundle])->save();
     $this->membershipTypeBundle = mb_strtolower($this->randomMachineName());
@@ -116,11 +132,13 @@ class GroupSubscribeTest extends BrowserTestBase {
     // Define the entities as groups.
     Og::groupTypeManager()->addGroup('node', $this->groupBundle1);
     Og::groupTypeManager()->addGroup('node', $this->groupBundle2);
+    Og::groupTypeManager()->addGroup('node', $this->groupBundle3);
 
     // Create node author user.
     $user = $this->createUser();
 
-    // Create groups.
+    // Create test groups. The first group has the 'subscribe without approval'
+    // permission.
     $this->group1 = Node::create([
       'type' => $this->groupBundle1,
       'title' => $this->randomString(),
@@ -128,6 +146,8 @@ class GroupSubscribeTest extends BrowserTestBase {
     ]);
     $this->group1->save();
 
+    // A group which is using default permissions; it grants the 'subscribe'
+    // permission to non-members.
     $this->group2 = Node::create([
       'type' => $this->groupBundle2,
       'title' => $this->randomString(),
@@ -135,7 +155,7 @@ class GroupSubscribeTest extends BrowserTestBase {
     ]);
     $this->group2->save();
 
-    // Create an unpublished node.
+    // An unpublished group.
     $this->group3 = Node::create([
       'type' => $this->groupBundle1,
       'title' => $this->randomString(),
@@ -152,10 +172,24 @@ class GroupSubscribeTest extends BrowserTestBase {
     ]);
     $this->group4->save();
 
-    $role = OgRole::getRole('node', $this->groupBundle1, OgRoleInterface::ANONYMOUS);
+    // A group which is closed for subscription. It grants neither 'subscribe'
+    // nor 'subscribe without approval'.
+    $this->group5 = Node::create([
+      'type' => $this->groupBundle3,
+      'title' => $this->randomString(),
+      'uid' => $user->id(),
+    ]);
+    $this->group5->save();
 
-    $role
+    // Grant the permission to 'subscribe without approval' to the first group
+    // type.
+    OgRole::getRole('node', $this->groupBundle1, OgRoleInterface::ANONYMOUS)
       ->grantPermission('subscribe without approval')
+      ->save();
+
+    // Revoke the permission to subscribe from the third group type.
+    OgRole::getRole('node', $this->groupBundle3, OgRoleInterface::ANONYMOUS)
+      ->revokePermission('subscribe')
       ->save();
 
     // Create a new membership type.
@@ -222,6 +256,13 @@ class GroupSubscribeTest extends BrowserTestBase {
         'entity' => $this->group4,
         'code' => 403,
       ],
+
+      // A group which doesn't allow new subscriptions.
+      [
+        'entity' => $this->group5,
+        'code' => 403,
+      ],
+
       // A non existing entity type.
       [
         'entity_type_id' => mb_strtolower($this->randomMachineName()),


### PR DESCRIPTION
#694 

## Technical Details
The issue here is that in `SubscriptionController` there is an access check where the return value of `$this->ogAccess->userAccess()` is checked directly. This will always return `true` even for Forbidden access.
We should use `userAccess()->isAllowed()` or 'userAccess()->isForbidden()' inside the if conditions.
This PR fixes this issue. Tested locally for my case and it works as expected after this fix.