### PR TITLE
Fix up formatting of the Readme.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,13 +113,13 @@ provide a quick way to get started with Organic groups.
    'Subscribe' link. (Subscribing is the act of associating a user with a 
     group.)
    To show this subscribe link:
-   9.1 Make sure you have the Group UI module enabled
-   9.2 Go to admin/config/group/permissions and make sure that the "Subscribe 
+   1. Make sure you have the Group UI module enabled
+   2. Go to admin/config/group/permissions and make sure that the "Subscribe 
        user to group" permission is given to the appropriate user-roles.
-   9.3 Navigate to the "manage display" tab of your content type
+   3. Navigate to the "manage display" tab of your content type
       (admin/structure/types/manage/group/display)
        and choose the Group subscription format for the Group type field.
-   9.4 Back in the group view you will now notice a 'Subscribe' link (If you are 
+   4. Back in the group view you will now notice a 'Subscribe' link (If you are 
        the group administrator it will say "You are the group manager").
 10. In order to associate other entities with group or group content, navigate
     to Organic Groups field settings", in admin/config/group/fields.


### PR DESCRIPTION
Fix up formatting of the sub numbering in section 9 of the Installation.

The Markdown had not been formatted correctly which meant when it gets rendered it would just displays it as a long paragraph and is hard to read.