### PR TITLE
Remove any null values when building the list of target groups.

### DIFF
--- a/src/MembershipManager.php
+++ b/src/MembershipManager.php
@@ -306,7 +306,7 @@ class MembershipManager implements MembershipManagerInterface {
 
       // Compile a list of group target IDs.
       $target_ids = array_filter(array_map(function ($value) {
-        return isset($value['target_id']) ? $value['target_id'] : NULL;
+        return $value['target_id'] ?? NULL;
       }, $entity->get($field->getName())->getValue()));
 
       if (empty($target_ids)) {

--- a/src/MembershipManager.php
+++ b/src/MembershipManager.php
@@ -305,9 +305,9 @@ class MembershipManager implements MembershipManagerInterface {
       }
 
       // Compile a list of group target IDs.
-      $target_ids = array_map(function ($value) {
-        return $value['target_id'];
-      }, $entity->get($field->getName())->getValue());
+      $target_ids = array_filter(array_map(function ($value) {
+        return isset($value['target_id']) ? $value['target_id'] : NULL;
+      }, $entity->get($field->getName())->getValue()));
 
       if (empty($target_ids)) {
         continue;


### PR DESCRIPTION
During the building of the OgComplex widget (actually with any widget) a null item is appended to the og_audience field. This then causes a undefined index warning.

This fixes the warning and then strips out the NULL target ids.