### PR TITLE
Downgrade composer to version 1 for Drupal 8.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,8 @@ before_script:
 
   # Update PHPUnit.
   - test ${TEST_SUITE} == "PHP_CodeSniffer" || travis_retry composer update phpunit/phpunit symfony/phpunit-bridge phpspec/prophecy symfony/yaml --with-dependencies --working-dir=$DRUPAL_DIR
-
+  - test ${TEST_SUITE} == "PHP_CodeSniffer" || travis_retry composer drupal-phpunit-upgrade
+  
   # Start a web server on port 8888 in the background.
   - test ${TEST_SUITE} == "PHP_CodeSniffer" || nohup php -S localhost:8888 --docroot $DRUPAL_DIR > /dev/null 2>&1 &
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,9 @@ before_script:
   # Make sure Composer is up to date.
   - composer self-update
 
+  # Downgrade to composer version 1 to support Drupal 8.8.
+  - test ${TEST_SUITE} == "8.8.x" && composer self-update --1
+
   # Remember the current directory for later use in the Drupal installation.
   - MODULE_DIR=$(pwd)
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ before_script:
   - composer self-update
 
   # Downgrade to composer version 1 to support Drupal 8.8.
-  - test ${TEST_SUITE} == "8.8.x" && composer self-update --1
+  - test ${TEST_SUITE} != "8.8.x" || composer self-update --1
 
   # Remember the current directory for later use in the Drupal installation.
   - MODULE_DIR=$(pwd)

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,6 @@ before_script:
   - test ${TEST_SUITE} == "PHP_CodeSniffer" || composer install --working-dir=$DRUPAL_DIR
 
   # Update PHPUnit.
-  - test ${TEST_SUITE} == "PHP_CodeSniffer" || travis_retry composer update phpunit/phpunit symfony/phpunit-bridge phpspec/prophecy symfony/yaml --with-dependencies --working-dir=$DRUPAL_DIR
   - test ${TEST_SUITE} == "PHP_CodeSniffer" || travis_retry composer drupal-phpunit-upgrade
   
   # Start a web server on port 8888 in the background.

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,11 +66,11 @@ before_script:
   # Remember the Drupal installation path.
   - DRUPAL_DIR=$(pwd)/drupal
 
+  # Update PHPUnit.
+  - test ${TEST_SUITE} == "PHP_CodeSniffer" || travis_retry composer drupal-phpunit-upgrade --working-dir=$DRUPAL_DIR
+
   # Install Composer dependencies for core. Skip this for the coding standards test.
   - test ${TEST_SUITE} == "PHP_CodeSniffer" || composer install --working-dir=$DRUPAL_DIR
-
-  # Update PHPUnit.
-  - test ${TEST_SUITE} == "PHP_CodeSniffer" || travis_retry composer drupal-phpunit-upgrade
   
   # Start a web server on port 8888 in the background.
   - test ${TEST_SUITE} == "PHP_CodeSniffer" || nohup php -S localhost:8888 --docroot $DRUPAL_DIR > /dev/null 2>&1 &

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
     "require-dev": {
         "drupal/coder": "^8.2",
         "phpunit/phpunit": "^7 || ^8",
-        "phpspec/prophecy-phpunit": "^2",
         "slevomat/coding-standard": "~6.0"
     },
     "minimum-stability": "RC"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require-dev": {
         "drupal/coder": "^8.2",
         "phpunit/phpunit": "^7 || ^8",
-        "phpspec/prophecy-phpunit: ^2",
+        "phpspec/prophecy-phpunit": "^2",
         "slevomat/coding-standard": "~6.0"
     },
     "minimum-stability": "RC"

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "require-dev": {
         "drupal/coder": "^8.2",
         "phpunit/phpunit": "^7 || ^8",
+        "phpspec/prophecy-phpunit: ^2",
         "slevomat/coding-standard": "~6.0"
     },
     "minimum-stability": "RC"


### PR DESCRIPTION
Travis is now using composer 2 which requires some dependencies to be updated.
```
$ composer self-update
Updating to version 2.0.8 (stable channel).
   Downloading (100%)
```

```
You are using Composer 2, which some of your plugins seem to be incompatible with. Make sure you update your plugins or report a plugin-issue to ask them to support Composer 2.
Script @composer update phpunit/phpunit symfony/phpunit-bridge phpspec/prophecy symfony/yaml --with-dependencies --no-progress handling the drupal-phpunit-upgrade event returned with error code 2
```

PHP Fatal error:  Trait 'Prophecy\PhpUnit\ProphecyTrait' not found in /home/travis/build/Gizra/drupal/core/tests/Drupal/TestTools/PhpUnitCompatibility/PhpUnit9/TestCompatibilityTrait.php on line 12

See https://www.drupal.org/node/3176567

We should probably drop support for Drupal 8.8.x, it doesn't support composer 2.

```
    - drupal/core-vendor-hardening 8.8.x-dev requires composer-plugin-api ^1.1 -> found composer-plugin-api[2.0.0] but it does not match the constraint.
```