### PR TITLE
Fix GroupSubscribeTest::testSubscribeAccess

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
   global:
     - COMPOSER_MEMORY_LIMIT=2G
   matrix:
-    - TEST_SUITE=8.8.x
     - TEST_SUITE=8.9.x
     - TEST_SUITE=9.0.x
     - TEST_SUITE=9.1.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   global:
     - COMPOSER_MEMORY_LIMIT=2G
   matrix:
+    - TEST_SUITE=8.8.x
     - TEST_SUITE=8.9.x
     - TEST_SUITE=9.0.x
     - TEST_SUITE=9.1.x

--- a/tests/src/Functional/GroupSubscribeTest.php
+++ b/tests/src/Functional/GroupSubscribeTest.php
@@ -270,7 +270,7 @@ class GroupSubscribeTest extends BrowserTestBase {
         // @todo This currently returns a 500 error due to a bug in core. Change
         //   this to a 403 or 404 when the bug is fixed.
         // @see https://www.drupal.org/node/2786897
-        'code' => version_compare(\Drupal::VERSION, '9.1', '>=') ? 404 : 500,
+        'code' => version_compare(\Drupal::VERSION, '9.1.4', '>=') ? 404 : 500,
       ],
 
       // A non existing entity ID.

--- a/tests/src/Functional/GroupSubscribeTest.php
+++ b/tests/src/Functional/GroupSubscribeTest.php
@@ -270,7 +270,7 @@ class GroupSubscribeTest extends BrowserTestBase {
         // @todo This currently returns a 500 error due to a bug in core. Change
         //   this to a 403 or 404 when the bug is fixed.
         // @see https://www.drupal.org/node/2786897
-        'code' => 500,
+        'code' => version_compare(\Drupal::VERSION, '9.1', '>=') ? 404 : 500,
       ],
 
       // A non existing entity ID.


### PR DESCRIPTION
```
1) Drupal\Tests\og\Functional\GroupSubscribeTest::testSubscribeAccess
Behat\Mink\Exception\ExpectationException: Current response status code is 404, but 500 expected.
```

```
      // A non existing entity type.
      [
        'entity_type_id' => mb_strtolower($this->randomMachineName()),
        'entity_id' => 1,
        // @todo This currently returns a 500 error due to a bug in core. Change
        //   this to a 403 or 404 when the bug is fixed.
        // @see https://www.drupal.org/node/2786897
        'code' => 500,
      ],
```

@pfrenssen, it would seem that https://www.drupal.org/node/2786897 has been fixed in [9.1.4](https://www.drupal.org/node/3193771)?