### PR TITLE
Remove config hash

### DIFF
--- a/config/optional/views.view.og_members_overview.yml
+++ b/config/optional/views.view.og_members_overview.yml
@@ -5,8 +5,6 @@ dependencies:
     - og
     - options
     - user
-_core:
-  default_config_hash: RnChWtrF4u0Q13iQMFypL0Uz6IsB4NY6ZTk_LorSbJg
 id: og_members_overview
 label: 'Members overview'
 module: views


### PR DESCRIPTION
We shouldn't store config hashes in the config/optional folder.