### PR TITLE
Avoid PHP 8.1 deprecation notices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ dist: bionic
 language: php
 
 php:
-  - 7.4
-  - 8.0
-  - 8.1
+  - '7.4'
+  - '8.0'
+  - nightly
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: php
 php:
   - 7.4
   - 8.0
+  - 8.1
 
 env:
   global:
@@ -18,6 +19,8 @@ env:
 matrix:
   exclude:
     - php: 7.4
+      env: TEST_SUITE=PHP_CodeSniffer
+    - php: 8.0
       env: TEST_SUITE=PHP_CodeSniffer
 
 mysql:
@@ -40,9 +43,6 @@ before_script:
 
   # Make sure Composer is up to date.
   - composer self-update
-
-  # Downgrade to composer version 1 to support Drupal 8.8.
-  - test ${TEST_SUITE} != "8.8.x" || composer self-update --1
 
   # Remember the current directory for later use in the Drupal installation.
   - MODULE_DIR=$(pwd)

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
             "drupal/coder": {
                 "https://www.drupal.org/project/coder/issues/3250986": "https://patch-diff.githubusercontent.com/raw/pfrenssen/coder/pull/157.diff"
             }
-        },
+        }
      },
     "minimum-stability": "RC"
 }

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     ],
     "require": {
         "php": "^7.4 || ^8",
+        "cweagans/composer-patches": "^1.7",
         "drupal/core": "^9.2"
     },
     "require-dev": {
@@ -33,5 +34,14 @@
         "phpunit/phpunit": "^7 || ^8",
         "slevomat/coding-standard": "~6.0"
     },
+     "extra": {
+        "composer-exit-on-patch-failure": true,
+        "enable-patching": true,
+        "patches": {
+            "drupal/coder": {
+                "https://www.drupal.org/project/coder/issues/3250986": "https://patch-diff.githubusercontent.com/raw/pfrenssen/coder/pull/157.diff"
+            }
+        },
+     },
     "minimum-stability": "RC"
 }

--- a/src/Event/PermissionEvent.php
+++ b/src/Event/PermissionEvent.php
@@ -212,6 +212,7 @@ class PermissionEvent extends Event implements PermissionEventInterface {
   /**
    * {@inheritdoc}
    */
+  #[\ReturnTypeWillChange]
   public function offsetGet($key) {
     return $this->getPermission($key);
   }
@@ -219,7 +220,7 @@ class PermissionEvent extends Event implements PermissionEventInterface {
   /**
    * {@inheritdoc}
    */
-  public function offsetSet($key, $value) {
+  public function offsetSet($key, $value): void {
     if (!$value instanceof PermissionInterface) {
       throw new \InvalidArgumentException('The value must be an object of type PermissionInterface.');
     }
@@ -232,7 +233,7 @@ class PermissionEvent extends Event implements PermissionEventInterface {
   /**
    * {@inheritdoc}
    */
-  public function offsetUnset($key) {
+  public function offsetUnset($key): void {
     if ($this->hasPermission($key)) {
       $this->deletePermission($key);
     }
@@ -241,14 +242,14 @@ class PermissionEvent extends Event implements PermissionEventInterface {
   /**
    * {@inheritdoc}
    */
-  public function offsetExists($key) {
+  public function offsetExists($key): bool {
     return $this->hasPermission($key);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function getIterator() {
+  public function getIterator(): \Traversable {
     return new \ArrayIterator($this->permissions);
   }
 


### PR DESCRIPTION
## Description

With PHP 8.1, we get this message:

> Return type of Drupal\og\Event\PermissionEvent::offsetGet() should either be compatible with IteratorAggregate::offsetGet(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice

This happens for all methods defined in `IteratorAggregate`.

## The fix

We add proper return strict typing for the methods except for `\Drupal\og\Event\PermissionEvent::offsetGet()` because we cannot type-hint to `mixed` as this return type has been introduced only in PHP 8.0 but we still keep the module compatible with PHP 7.4. In that case we use `#[\ReturnTypeWillChange]`