### PR TITLE
Fix OgMembership::getCreatedTime

### DIFF
--- a/src/Entity/OgMembership.php
+++ b/src/Entity/OgMembership.php
@@ -108,7 +108,7 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
    * {@inheritdoc}
    */
   public function getCreatedTime(): int {
-    return $this->getFieldValue('created', 'value') ?: 0;
+    return (int) $this->getFieldValue('created', 'value') ?: 0;
   }
 
   /**


### PR DESCRIPTION
The return value from getFieldValue is not always an integer.