### PR TITLE
Pending and Blocked users are not removed on user delete.

### DIFF
--- a/plugins/entityreference/behavior/OgBehaviorHandler.class.php
+++ b/plugins/entityreference/behavior/OgBehaviorHandler.class.php
@@ -78,7 +78,8 @@ class OgBehaviorHandler extends EntityReference_BehaviorHandler_Abstract {
     if (!empty($entity->delete_og_membership)) {
       // Delete all OG memberships related to this entity.
       $og_memberships = array();
-      foreach (og_get_entity_groups($entity_type, $entity) as $group_type => $ids) {
+      $groups = og_get_entity_groups($entity_type, $entity, array(OG_STATE_ACTIVE, OG_STATE_PENDING, OG_STATE_BLOCKED));
+      foreach ($groups as $group_type => $ids) {
         $og_memberships = array_merge($og_memberships, array_keys($ids));
       }
       if ($og_memberships) {

--- a/plugins/entityreference/behavior/OgBehaviorHandler.class.php
+++ b/plugins/entityreference/behavior/OgBehaviorHandler.class.php
@@ -78,7 +78,7 @@ class OgBehaviorHandler extends EntityReference_BehaviorHandler_Abstract {
     if (!empty($entity->delete_og_membership)) {
       // Delete all OG memberships related to this entity.
       $og_memberships = array();
-      $groups = og_get_entity_groups($entity_type, $entity, array(OG_STATE_ACTIVE, OG_STATE_PENDING, OG_STATE_BLOCKED));
+      $groups = og_get_entity_groups($entity_type, $entity, [OG_STATE_ACTIVE, OG_STATE_PENDING, OG_STATE_BLOCKED]);
       foreach ($groups as $group_type => $ids) {
         $og_memberships = array_merge($og_memberships, array_keys($ids));
       }


### PR DESCRIPTION
STR:
1) add member
2) block member
3) delete user
RESULS: blocked/pending user still exist in table og_membership

The issue is in og_get_entity_groups() function which default parameter $state is OG_STATE_ACTIVE.

To fix all stalled blocked/pending users from database this script can be used:
to check what should be deleted:
select * from og_membership as om left join users as u ON u.uid = om.etid where (om.state=2 OR om.state=3) AND u.uid IS NULL;

to delete:
delete om from og_membership as om left join users as u ON u.uid = om.etid where (om.state=2 OR om.state=3) AND u.uid IS NULL;

