### PR TITLE
ISSUE-742: Non-node permissions overrides one each other

### DIFF
--- a/src/EventSubscriber/OgEventSubscriber.php
+++ b/src/EventSubscriber/OgEventSubscriber.php
@@ -280,7 +280,7 @@ class OgEventSubscriber implements EventSubscriberInterface {
 
     foreach ($group_content_bundle_ids as $group_content_entity_type_id => $bundle_ids) {
       foreach ($bundle_ids as $bundle_id) {
-        $permissions += $this->generateEntityOperationPermissionList($group_content_entity_type_id, $bundle_id);
+        $permissions = array_merge($permissions, $this->generateEntityOperationPermissionList($group_content_entity_type_id, $bundle_id));
       }
     }
 

--- a/tests/src/Kernel/PermissionEventTest.php
+++ b/tests/src/Kernel/PermissionEventTest.php
@@ -26,6 +26,7 @@ class PermissionEventTest extends KernelTestBase {
    * {@inheritdoc}
    */
   public static $modules = [
+    'entity_test',
     'field',
     'node',
     'og',
@@ -61,6 +62,9 @@ class PermissionEventTest extends KernelTestBase {
       'type' => 'test_group_content',
       'name' => 'Test Group Content',
     ])->save();
+    // Create two entity_test bundles to test a mixed entity type case.
+    entity_test_create_bundle('a_bundle', 'A bundle');
+    entity_test_create_bundle('other_bundle', 'Other bundle');
   }
 
   /**
@@ -195,6 +199,37 @@ class PermissionEventTest extends KernelTestBase {
         // The list of permissions should contain both the group level
         // permission ('administer group') and the group content permission
         // ('create test_group_content node').
+        [
+          $group_level_permission,
+          $group_content_operation_permission,
+        ],
+      ],
+      // Test a combination of bundles comming from different entity types.
+      [
+        [
+          'node' => ['test_group_content'],
+          'entity_test' => ['a_bundle', 'other_bundle'],
+        ],
+        array_merge($default_permissions, [
+          // node:test_group_content
+          'create test_group_content content',
+          'delete any test_group_content content',
+          'delete own test_group_content content',
+          'edit any test_group_content content',
+          'edit own test_group_content content',
+          // entity_test:a_bundle
+          'create a_bundle entity_test',
+          'delete any a_bundle entity_test',
+          'delete own a_bundle entity_test',
+          'update any a_bundle entity_test',
+          'update own a_bundle entity_test',
+          // entity_test:other_bundle
+          'create other_bundle entity_test',
+          'delete any other_bundle entity_test',
+          'delete own other_bundle entity_test',
+          'update any other_bundle entity_test',
+          'update own other_bundle entity_test',
+        ]),
         [
           $group_level_permission,
           $group_content_operation_permission,

--- a/tests/src/Kernel/PermissionEventTest.php
+++ b/tests/src/Kernel/PermissionEventTest.php
@@ -204,7 +204,7 @@ class PermissionEventTest extends KernelTestBase {
           $group_content_operation_permission,
         ],
       ],
-      // Test a combination of bundles comming from different entity types.
+      // Test a combination of bundles coming from different entity types.
       [
         [
           'node' => ['test_group_content'],

--- a/tests/src/Kernel/PermissionEventTest.php
+++ b/tests/src/Kernel/PermissionEventTest.php
@@ -211,19 +211,19 @@ class PermissionEventTest extends KernelTestBase {
           'entity_test' => ['a_bundle', 'other_bundle'],
         ],
         array_merge($default_permissions, [
-          // node:test_group_content
+          // node:test_group_content.
           'create test_group_content content',
           'delete any test_group_content content',
           'delete own test_group_content content',
           'edit any test_group_content content',
           'edit own test_group_content content',
-          // entity_test:a_bundle
+          // entity_test:a_bundle.
           'create a_bundle entity_test',
           'delete any a_bundle entity_test',
           'delete own a_bundle entity_test',
           'update any a_bundle entity_test',
           'update own a_bundle entity_test',
-          // entity_test:other_bundle
+          // entity_test:other_bundle.
           'create other_bundle entity_test',
           'delete any other_bundle entity_test',
           'delete own other_bundle entity_test',


### PR DESCRIPTION
## Problem

In `OgEventSubscriber::getDefaultEntityOperationPermissions()` the `+=` operator is used to merge permissions coming from different entity types and bundles. But `OgEventSubscriber::generateEntityOperationPermissionList()` is returning an indexed array. It means only the first set returned by `OgEventSubscriber::generateEntityOperationPermissionList()` is retained at the end. All permissions for the previous bundles are discarded.

This is proved by the provided regression test.

## Proposal

Use `array_merge()` instead on `+=` operator.