### PR TITLE
Fix machine name mismatch in OgMembershipType link template vs route

### DIFF
--- a/src/Entity/OgMembershipType.php
+++ b/src/Entity/OgMembershipType.php
@@ -46,8 +46,8 @@ use Drupal\og\OgMembershipTypeInterface;
  *     "description"
  *   },
  *   links = {
- *     "edit-form" = "/admin/structure/membership-types/manage/{membership_type}",
- *     "delete-form" = "/admin/structure/membership-types/manage/{membership_type}/delete",
+ *     "edit-form" = "/admin/structure/membership-types/manage/{og_membership_type}",
+ *     "delete-form" = "/admin/structure/membership-types/manage/{og_membership_type}/delete",
  *     "collection" = "/admin/structure/membership-types",
  *   }
  * )


### PR DESCRIPTION
The link template in OgMembershipType specifies {membership} as a placeholder, but the parameter name in og.routing.yml is {og_membership_type}. This cause issues when another module tries to add additional links, like in #744 and https://gitlab.com/drupalspoons/devel/-/issues/443

I prefer the more specific og_membership_type over membership_type, but an alternative fix would be to change the parameter names in og.routing.yml.