### PR TITLE
D10 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ matrix:
       env: TEST_SUITE=PHP_CodeSniffer
     - php: 8.0
       env: TEST_SUITE=10.0.x
+    - php: 8.1
+      env: TEST_SUITE=PHP_CodeSniffer
 
 mysql:
   database: og

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,6 @@ matrix:
       env: TEST_SUITE=PHP_CodeSniffer
     - php: 8.0
       env: TEST_SUITE=10.0.x
-    - php: 8.1
-      env: TEST_SUITE=PHP_CodeSniffer
 
 mysql:
   database: og

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,11 @@ php:
   - '7.4'
   - '8.0'
   - '8.1'
-  - nightly
 
 env:
   global:
     - COMPOSER_MEMORY_LIMIT=2G
   matrix:
-    - TEST_SUITE=9.3.x
     - TEST_SUITE=9.4.x
     - TEST_SUITE=10.0.x
     - TEST_SUITE=PHP_CodeSniffer

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: php
 php:
   - '7.4'
   - '8.0'
+  - '8.1'
   - nightly
 
 env:
@@ -13,6 +14,7 @@ env:
   matrix:
     - TEST_SUITE=9.3.x
     - TEST_SUITE=9.4.x
+    - TEST_SUITE=10.0.x
     - TEST_SUITE=PHP_CodeSniffer
 
 # Only run the coding standards check once.
@@ -20,8 +22,12 @@ matrix:
   exclude:
     - php: 7.4
       env: TEST_SUITE=PHP_CodeSniffer
+    - php: 7.4
+      env: TEST_SUITE=10.0.x
     - php: 8.0
       env: TEST_SUITE=PHP_CodeSniffer
+    - php: 8.0
+      env: TEST_SUITE=10.0.x
 
 mysql:
   database: og
@@ -65,7 +71,7 @@ before_script:
 
   # Install Composer dependencies for core. Skip this for the coding standards test.
   - test ${TEST_SUITE} == "PHP_CodeSniffer" || composer install --working-dir=$DRUPAL_DIR
-  
+
   # Start a web server on port 8888 in the background.
   - test ${TEST_SUITE} == "PHP_CodeSniffer" || nohup php -S localhost:8888 --docroot $DRUPAL_DIR > /dev/null 2>&1 &
 

--- a/composer.json
+++ b/composer.json
@@ -24,13 +24,9 @@
             "homepage": "https://www.drupal.org/u/pfrenssen"
         }
     ],
-    "require": {
-        "php": "^7.4 || ^8",
-        "drupal/core": "^9.3"
-    },
     "require-dev": {
         "drupal/coder": "^8.3.16",
-        "phpunit/phpunit": "^7 || ^8"
+        "phpunit/phpunit": "^7 || ^8 || ^9"
     },
     "minimum-stability": "RC",
     "config": {

--- a/og.info.yml
+++ b/og.info.yml
@@ -2,9 +2,8 @@ name: Organic Groups
 description: API to allow associating content with groups.
 package: Organic Groups
 
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 type: module
-php: 7.1
 
 dependencies:
   - drupal:options

--- a/og_ui/og_ui.info.yml
+++ b/og_ui/og_ui.info.yml
@@ -3,9 +3,9 @@ description: User interface for Organic Groups.
 package: Organic Groups
 
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 
 dependencies:
-  - og
+  - og:og
 
 configure: og_ui.admin_index

--- a/og_ui/src/BundleFormAlter.php
+++ b/og_ui/src/BundleFormAlter.php
@@ -95,7 +95,7 @@ class BundleFormAlter {
     // Example: article.
     $this->bundle = $this->entity->id();
     // Example: Article.
-    $this->bundleLabel = Unicode::lcfirst($this->entity->label());
+    $this->bundleLabel = Unicode::lcfirst((string) $this->entity->label());
     $this->definition = $this->entity->getEntityType();
     // Example: node.
     $this->entityTypeId = $this->definition->getBundleOf();

--- a/og_ui/tests/src/Functional/BundleFormAlterTest.php
+++ b/og_ui/tests/src/Functional/BundleFormAlterTest.php
@@ -21,7 +21,7 @@ class BundleFormAlterTest extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = ['block_content', 'entity_test', 'node', 'og_ui'];
+  protected static $modules = ['block_content', 'entity_test', 'node', 'og_ui'];
 
   /**
    * {@inheritdoc}

--- a/src/Controller/OgAdminRoutesController.php
+++ b/src/Controller/OgAdminRoutesController.php
@@ -76,7 +76,7 @@ class OgAdminRoutesController extends ControllerBase {
     $content = [];
 
     $event = new OgAdminRoutesEvent();
-    $event = $this->eventDispatcher->dispatch(OgAdminRoutesEventInterface::EVENT_NAME, $event);
+    $event = $this->eventDispatcher->dispatch($event, OgAdminRoutesEventInterface::EVENT_NAME);
 
     foreach ($event->getRoutes($entity_type_id) as $name => $info) {
       $route_name = "entity.$entity_type_id.og_admin_routes.$name";

--- a/src/Entity/OgMembership.php
+++ b/src/Entity/OgMembership.php
@@ -544,8 +544,8 @@ class OgMembership extends ContentEntityBase implements OgMembershipInterface {
     }
 
     // Check for an existing membership.
-    $query = \Drupal::entityQuery('og_membership');
-    $query
+    $query = \Drupal::entityQuery('og_membership')
+      ->accessCheck()
       ->condition('uid', $uid)
       ->condition('entity_id', $entity_id)
       ->condition('entity_type', $this->get('entity_type')->value);

--- a/src/Entity/OgRole.php
+++ b/src/Entity/OgRole.php
@@ -325,7 +325,7 @@ class OgRole extends Role implements OgRoleInterface {
   public function calculateDependencies() {
     // The parent method is checking for the existence of each role-assigned
     // permission. But in OG this isn't mandatory. Backup the permissions before
-    // calling the parent method and avoid preforming the check.
+    // calling the parent method and avoid performing the check.
     // @see https://www.drupal.org/node/3193348
     // @todo Consider decoupling 'og_role' from 'role' entity config and
     //   implementing the missing methods in 'og_role'.

--- a/src/Entity/OgRole.php
+++ b/src/Entity/OgRole.php
@@ -323,7 +323,16 @@ class OgRole extends Role implements OgRoleInterface {
    * {@inheritdoc}
    */
   public function calculateDependencies() {
+    // The parent method is checking for the existence of each role-assigned
+    // permission. But in OG this isn't mandatory. Backup the permissions before
+    // calling the parent method and avoid preforming the check.
+    // @see https://www.drupal.org/node/3193348
+    // @todo Consider decoupling 'og_role' from 'role' entity config and
+    //   implementing the missing methods in 'og_role'.
+    $permissions = $this->permissions;
+    $this->permissions = [];
     parent::calculateDependencies();
+    $this->permissions = $permissions;
 
     // Create a dependency on the group bundle.
     $bundle_config_dependency = \Drupal::entityTypeManager()->getDefinition($this->getGroupType())->getBundleConfigDependency($this->getGroupBundle());

--- a/src/Event/AccessEventBase.php
+++ b/src/Event/AccessEventBase.php
@@ -10,7 +10,7 @@ use Drupal\Core\Cache\RefinableCacheableDependencyInterface;
 use Drupal\Core\Cache\RefinableCacheableDependencyTrait;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Session\AccountInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Base class for OG access events.

--- a/src/Event/DefaultRoleEvent.php
+++ b/src/Event/DefaultRoleEvent.php
@@ -97,6 +97,7 @@ class DefaultRoleEvent extends Event implements DefaultRoleEventInterface {
   /**
    * {@inheritdoc}
    */
+  #[\ReturnTypeWillChange]
   public function offsetGet($key) {
     return $this->getRole($key);
   }
@@ -104,7 +105,7 @@ class DefaultRoleEvent extends Event implements DefaultRoleEventInterface {
   /**
    * {@inheritdoc}
    */
-  public function offsetSet($key, $role) {
+  public function offsetSet($key, $role): void {
     $this->validate($role);
     if ($role->getName() !== $key) {
       throw new \InvalidArgumentException('The key and the "name" property of the role should be identical.');
@@ -115,21 +116,21 @@ class DefaultRoleEvent extends Event implements DefaultRoleEventInterface {
   /**
    * {@inheritdoc}
    */
-  public function offsetUnset($key) {
+  public function offsetUnset($key): void {
     $this->deleteRole($key);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function offsetExists($key) {
+  public function offsetExists($key): bool {
     return $this->hasRole($key);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function getIterator() {
+  public function getIterator(): \Traversable {
     return new \ArrayIterator($this->roles);
   }
 

--- a/src/Event/DefaultRoleEvent.php
+++ b/src/Event/DefaultRoleEvent.php
@@ -5,7 +5,7 @@ declare(strict_types = 1);
 namespace Drupal\og\Event;
 
 use Drupal\og\Entity\OgRole;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Event that is fired when default roles are compiled.

--- a/src/Event/GroupCreationEvent.php
+++ b/src/Event/GroupCreationEvent.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Drupal\og\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * The group creation event.

--- a/src/Event/OgAdminRoutesEvent.php
+++ b/src/Event/OgAdminRoutesEvent.php
@@ -6,7 +6,7 @@ namespace Drupal\og\Event;
 
 use Drupal\Component\Utility\NestedArray;
 use Drupal\og\OgAccess;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Event that is fired when OG admin routes are being compiled.

--- a/src/Event/PermissionEvent.php
+++ b/src/Event/PermissionEvent.php
@@ -6,7 +6,7 @@ namespace Drupal\og\Event;
 
 use Drupal\og\GroupContentOperationPermission;
 use Drupal\og\PermissionInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Event that is fired when OG permissions are compiled.

--- a/src/GroupTypeManager.php
+++ b/src/GroupTypeManager.php
@@ -284,7 +284,7 @@ class GroupTypeManager implements GroupTypeManagerInterface {
 
     // Trigger an event upon the new group creation.
     $event = new GroupCreationEvent($entity_type_id, $bundle_id);
-    $this->eventDispatcher->dispatch(GroupCreationEventInterface::EVENT_NAME, $event);
+    $this->eventDispatcher->dispatch($event, GroupCreationEventInterface::EVENT_NAME);
 
     $this->ogRoleManager->createPerBundleRoles($entity_type_id, $bundle_id);
     $this->refreshGroupMap();

--- a/src/MembershipManager.php
+++ b/src/MembershipManager.php
@@ -113,6 +113,7 @@ class MembershipManager implements MembershipManagerInterface {
       $query = $this->entityTypeManager
         ->getStorage('og_membership')
         ->getQuery()
+        ->accessCheck()
         ->condition('uid', $user_id)
         ->condition('state', $states, 'IN');
 
@@ -185,6 +186,7 @@ class MembershipManager implements MembershipManagerInterface {
     $query = $this->entityTypeManager
       ->getStorage('og_membership')
       ->getQuery()
+      ->accessCheck()
       ->condition('entity_id', $group->id());
 
     if ($states) {
@@ -231,6 +233,7 @@ class MembershipManager implements MembershipManagerInterface {
       $query = $this->entityTypeManager
         ->getStorage('og_membership')
         ->getQuery()
+        ->accessCheck()
         ->condition('entity_type', $entity_type_id)
         ->condition('entity_id', $group->id())
         ->condition('state', $states, 'IN');
@@ -418,6 +421,7 @@ class MembershipManager implements MembershipManagerInterface {
       $results = $this->entityTypeManager
         ->getStorage($group_content_entity_type)
         ->getQuery()
+        ->accessCheck()
         ->condition($field->getName() . '.target_id', $entity->id())
         ->execute();
 

--- a/src/OgAccess.php
+++ b/src/OgAccess.php
@@ -323,7 +323,7 @@ class OgAccess implements OgAccessInterface {
       $event->addCacheContexts(['user']);
     }
 
-    $this->dispatcher->dispatch(GroupContentEntityOperationAccessEvent::EVENT_NAME, $event);
+    $this->dispatcher->dispatch($event, GroupContentEntityOperationAccessEvent::EVENT_NAME);
 
     return $event->getAccessResult();
   }

--- a/src/OgDeleteOrphansBase.php
+++ b/src/OgDeleteOrphansBase.php
@@ -120,6 +120,7 @@ abstract class OgDeleteOrphansBase extends PluginBase implements OgDeleteOrphans
     // Register orphaned user memberships.
     $membership_ids = $this->entityTypeManager->getStorage('og_membership')
       ->getQuery()
+      ->accessCheck()
       ->condition('entity_type', $entity->getEntityTypeId())
       ->condition('entity_id', $entity->id())
       ->execute();

--- a/src/OgRoleManager.php
+++ b/src/OgRoleManager.php
@@ -88,7 +88,7 @@ class OgRoleManager implements OgRoleManagerInterface {
     $roles = $this->getRequiredDefaultRoles();
 
     $event = new DefaultRoleEvent();
-    $this->eventDispatcher->dispatch(DefaultRoleEventInterface::EVENT_NAME, $event);
+    $this->eventDispatcher->dispatch($event, DefaultRoleEventInterface::EVENT_NAME);
 
     // Use the array union operator '+=' to ensure the default roles cannot be
     // altered by event subscribers.

--- a/src/PermissionManager.php
+++ b/src/PermissionManager.php
@@ -35,7 +35,7 @@ class PermissionManager implements PermissionManagerInterface {
    */
   public function getDefaultPermissions($group_entity_type_id, $group_bundle_id, array $group_content_bundle_ids, $role_name = NULL) {
     $event = new PermissionEvent($group_entity_type_id, $group_bundle_id, $group_content_bundle_ids);
-    $this->eventDispatcher->dispatch(PermissionEventInterface::EVENT_NAME, $event);
+    $this->eventDispatcher->dispatch($event, PermissionEventInterface::EVENT_NAME);
     return $event->getPermissions();
   }
 

--- a/src/Plugin/Validation/Constraint/UniqueOgMembershipConstraintValidator.php
+++ b/src/Plugin/Validation/Constraint/UniqueOgMembershipConstraintValidator.php
@@ -76,6 +76,7 @@ class UniqueOgMembershipConstraintValidator extends ConstraintValidator implemen
     $query = $this->entityTypeManager
       ->getStorage('og_membership')
       ->getQuery()
+      ->accessCheck()
       ->condition('entity_type', $entity->getGroupEntityType())
       ->condition('entity_id', $entity->getGroupId())
       ->condition('uid', $new_member_uid);

--- a/src/Routing/RouteSubscriber.php
+++ b/src/Routing/RouteSubscriber.php
@@ -120,7 +120,7 @@ class RouteSubscriber extends RouteSubscriberBase {
    */
   protected function createRoutesFromEventSubscribers($og_admin_path, $entity_type_id, RouteCollection $collection) {
     $event = new OgAdminRoutesEvent();
-    $this->eventDispatcher->dispatch(OgAdminRoutesEventInterface::EVENT_NAME, $event);
+    $this->eventDispatcher->dispatch($event, OgAdminRoutesEventInterface::EVENT_NAME);
 
     foreach ($event->getRoutes($entity_type_id) as $name => $route_info) {
       // Add the parent route.

--- a/src/Routing/RouteSubscriber.php
+++ b/src/Routing/RouteSubscriber.php
@@ -165,7 +165,7 @@ class RouteSubscriber extends RouteSubscriberBase {
    * We have such a case with the "members" OG admin route, that requires Views
    * module to be enabled.
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     $events[RoutingEvents::ALTER] = ['onAlterRoutes', 100];
     return $events;
   }

--- a/tests/modules/og_standard_reference_test_views/og_standard_reference_test_views.info.yml
+++ b/tests/modules/og_standard_reference_test_views/og_standard_reference_test_views.info.yml
@@ -2,6 +2,6 @@ name: 'OG standard reference test views'
 type: module
 description: 'Provides default views for views OG standard reference tests.'
 package: Testing
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
  - drupal:views

--- a/tests/modules/og_test/og_test.info.yml
+++ b/tests/modules/og_test/og_test.info.yml
@@ -2,6 +2,6 @@ name: 'Organic Groups test'
 type: module
 description: 'Support module for Organic Groups testing.'
 package: Testing
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - drupal:options

--- a/tests/src/Functional/GroupSubscribeFormatterTest.php
+++ b/tests/src/Functional/GroupSubscribeFormatterTest.php
@@ -21,7 +21,7 @@ class GroupSubscribeFormatterTest extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = ['node', 'og', 'options'];
+  protected static $modules = ['node', 'og', 'options'];
 
   /**
    * {@inheritdoc}

--- a/tests/src/Functional/GroupSubscribeTest.php
+++ b/tests/src/Functional/GroupSubscribeTest.php
@@ -27,7 +27,7 @@ class GroupSubscribeTest extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = ['node', 'og'];
+  protected static $modules = ['node', 'og'];
 
   /**
    * {@inheritdoc}

--- a/tests/src/Functional/GroupTabTest.php
+++ b/tests/src/Functional/GroupTabTest.php
@@ -220,12 +220,14 @@ class GroupTabTest extends BrowserTestBase {
         $value = $exiting_member->getDisplayName() . ' (' . $exiting_member->id() . ')';
         $this->submitForm(['Username' => $value], 'Save');
         $this->assertSession()->pageTextMatches('/The user .+ is already a member in this group/');
-        // Test entity query match.
-        $query = $entity_type_manger->getStorage('user')->getQuery();
-        $query->condition('uid', 0, '<>');
         $match = 'adminz';
-        $query->condition('name', $match, 'CONTAINS');
-        $found = $query->execute();
+        // Test entity query match.
+        $found = $entity_type_manger->getStorage('user')
+          ->getQuery()
+          ->accessCheck()
+          ->condition('uid', 0, '<>')
+          ->condition('name', $match, 'CONTAINS')
+          ->execute();
         $this->assertCount(3, $found, print_r($found, TRUE));
         // Two of the three possible matches are already members.
         $this->assertAutoCompleteMatches($group, $match, 1);

--- a/tests/src/Functional/GroupTabTest.php
+++ b/tests/src/Functional/GroupTabTest.php
@@ -364,6 +364,10 @@ class GroupTabTest extends BrowserTestBase {
     $page = $this->getSession()->getPage();
     $input = $page->findField('edit-uid-0-target-id');
     $path = $input->getAttribute('data-autocomplete-path');
+    // Remove potential base path when the site is  under a subdirectory.
+    if (str_starts_with($path, base_path())) {
+      $path = str_replace(base_path(), '', $path);
+    }
     $this->drupalGet($path, ['query' => ['q' => $match]]);
     $header = $this->getSession()->getResponseHeader('content-type');
     $this->assertSame('application/json', $header);

--- a/tests/src/Functional/GroupTabTest.php
+++ b/tests/src/Functional/GroupTabTest.php
@@ -29,7 +29,7 @@ class GroupTabTest extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = ['node', 'og', 'views', 'entity_test'];
+  protected static $modules = ['node', 'og', 'views', 'entity_test'];
 
   /**
    * {@inheritdoc}

--- a/tests/src/Functional/GroupTabTest.php
+++ b/tests/src/Functional/GroupTabTest.php
@@ -175,7 +175,7 @@ class GroupTabTest extends BrowserTestBase {
     $this->anotherNodeMembership = $this->createOgMembership($this->groupNode, $another_user);
 
     $this->groupTestEntity = EntityTest::create([
-      'title' => $this->randomString(),
+      'name' => $this->randomString(),
       'user_id' => $this->authorUser->id(),
     ]);
     $this->groupTestEntity->save();

--- a/tests/src/Functional/GroupTabTest.php
+++ b/tests/src/Functional/GroupTabTest.php
@@ -364,9 +364,10 @@ class GroupTabTest extends BrowserTestBase {
     $page = $this->getSession()->getPage();
     $input = $page->findField('edit-uid-0-target-id');
     $path = $input->getAttribute('data-autocomplete-path');
-    // Remove potential base path when the site is  under a subdirectory.
-    if (str_starts_with($path, base_path())) {
-      $path = str_replace(base_path(), '', $path);
+    // Remove potential base path when the site is under a subdirectory.
+    $base_path = rtrim(base_path(), '/');
+    if ($base_path && strpos($path, $base_path) === 0) {
+      $path = substr($path, strlen($base_path));
     }
     $this->drupalGet($path, ['query' => ['q' => $match]]);
     $header = $this->getSession()->getResponseHeader('content-type');

--- a/tests/src/Functional/OgComplexWidgetTest.php
+++ b/tests/src/Functional/OgComplexWidgetTest.php
@@ -26,7 +26,7 @@ class OgComplexWidgetTest extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = ['block_content', 'node', 'og'];
+  protected static $modules = ['block_content', 'node', 'og'];
 
   /**
    * {@inheritdoc}

--- a/tests/src/Functional/OgComplexWidgetTest.php
+++ b/tests/src/Functional/OgComplexWidgetTest.php
@@ -78,6 +78,7 @@ class OgComplexWidgetTest extends BrowserTestBase {
     $values = [
       'type' => 'group',
       'uid' => $group_owner->id(),
+      'info' => $this->randomString(),
     ];
     $group = BlockContent::create($values);
     $group->save();

--- a/tests/src/Functional/OgComplexWidgetTest.php
+++ b/tests/src/Functional/OgComplexWidgetTest.php
@@ -95,8 +95,9 @@ class OgComplexWidgetTest extends BrowserTestBase {
     $this->assertSession()->statusCodeEquals(200);
 
     // Retrieve the post that was created from the database.
-    $query = $this->container->get('entity_type.manager')->getStorage('node')->getQuery();
-    $result = $query
+    $result = $this->container->get('entity_type.manager')->getStorage('node')
+      ->getQuery()
+      ->accessCheck()
       ->condition('type', 'post')
       ->range(0, 1)
       ->sort('nid', 'DESC')

--- a/tests/src/Kernel/Access/AccessByOgMembershipTest.php
+++ b/tests/src/Kernel/Access/AccessByOgMembershipTest.php
@@ -34,7 +34,7 @@ class AccessByOgMembershipTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = [
+  protected static $modules = [
     'block_content',
     'field',
     'node',

--- a/tests/src/Kernel/Access/GroupContentOperationAccessAlterTest.php
+++ b/tests/src/Kernel/Access/GroupContentOperationAccessAlterTest.php
@@ -26,7 +26,7 @@ class GroupContentOperationAccessAlterTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = [
+  protected static $modules = [
     'comment',
     'entity_test',
     'field',

--- a/tests/src/Kernel/Access/GroupLevelAccessTest.php
+++ b/tests/src/Kernel/Access/GroupLevelAccessTest.php
@@ -25,7 +25,7 @@ class GroupLevelAccessTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = [
+  protected static $modules = [
     'system',
     'user',
     'field',

--- a/tests/src/Kernel/Access/OgAccessHookTest.php
+++ b/tests/src/Kernel/Access/OgAccessHookTest.php
@@ -30,7 +30,7 @@ class OgAccessHookTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = [
+  protected static $modules = [
     'block_content',
     'field',
     'node',

--- a/tests/src/Kernel/Access/OgGroupContentOperationAccessTest.php
+++ b/tests/src/Kernel/Access/OgGroupContentOperationAccessTest.php
@@ -28,7 +28,7 @@ class OgGroupContentOperationAccessTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = [
+  protected static $modules = [
     'comment',
     'entity_test',
     'field',

--- a/tests/src/Kernel/Action/ActionTestBase.php
+++ b/tests/src/Kernel/Action/ActionTestBase.php
@@ -205,6 +205,7 @@ abstract class ActionTestBase extends KernelTestBase {
    *
    * @covers ::execute
    * @dataProvider executeProvider
+   * @doesNotPerformAssertions
    */
   abstract public function testExecute($membership);
 

--- a/tests/src/Kernel/Action/ActionTestBase.php
+++ b/tests/src/Kernel/Action/ActionTestBase.php
@@ -33,7 +33,7 @@ abstract class ActionTestBase extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = ['node', 'og', 'system', 'user', 'options'];
+  protected static $modules = ['node', 'og', 'system', 'user', 'options'];
 
   /**
    * An array of test users.

--- a/tests/src/Kernel/Action/ChangeMultipleOgMembershipRolesActionTestBase.php
+++ b/tests/src/Kernel/Action/ChangeMultipleOgMembershipRolesActionTestBase.php
@@ -29,8 +29,6 @@ class ChangeMultipleOgMembershipRolesActionTestBase extends ChangeOgMembershipAc
   protected function setUp(): void {
     parent::setUp();
 
-    $this->installSchema('system', ['key_value_expire']);
-
     $this->tempStorageFactory = $this->container->get('tempstore.private');
 
     // Set up the group administrator as the user that will be logged in during

--- a/tests/src/Kernel/Cache/Context/OgRoleCacheContextTest.php
+++ b/tests/src/Kernel/Cache/Context/OgRoleCacheContextTest.php
@@ -32,7 +32,7 @@ class OgRoleCacheContextTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = [
+  protected static $modules = [
     'entity_test',
     'node',
     'og',

--- a/tests/src/Kernel/DefaultRoleEventIntegrationTest.php
+++ b/tests/src/Kernel/DefaultRoleEventIntegrationTest.php
@@ -20,7 +20,7 @@ class DefaultRoleEventIntegrationTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = ['entity_test', 'og', 'system', 'user', 'field'];
+  protected static $modules = ['entity_test', 'og', 'system', 'user', 'field'];
 
   /**
    * The Symfony event dispatcher.

--- a/tests/src/Kernel/DefaultRoleEventIntegrationTest.php
+++ b/tests/src/Kernel/DefaultRoleEventIntegrationTest.php
@@ -68,7 +68,7 @@ class DefaultRoleEventIntegrationTest extends KernelTestBase {
 
     // Query the event listener directly to see if the administrator role is
     // present.
-    $this->eventDispatcher->dispatch(DefaultRoleEventInterface::EVENT_NAME, $event);
+    $this->eventDispatcher->dispatch($event, DefaultRoleEventInterface::EVENT_NAME);
     $this->assertEquals([OgRoleInterface::ADMINISTRATOR], array_keys($event->getRoles()));
 
     // Check that the role was created with the correct values.

--- a/tests/src/Kernel/Entity/EntityCreateAccessTest.php
+++ b/tests/src/Kernel/Entity/EntityCreateAccessTest.php
@@ -29,7 +29,7 @@ class EntityCreateAccessTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = [
+  protected static $modules = [
     'field',
     'node',
     'og',

--- a/tests/src/Kernel/Entity/EntityCreateAccessTest.php
+++ b/tests/src/Kernel/Entity/EntityCreateAccessTest.php
@@ -4,6 +4,8 @@ declare(strict_types = 1);
 
 namespace Drupal\Tests\og\Kernel\Entity;
 
+use Drupal\Core\Access\AccessResultAllowed;
+use Drupal\Core\Url;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\Tests\node\Traits\ContentTypeCreationTrait;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
@@ -115,18 +117,15 @@ class EntityCreateAccessTest extends KernelTestBase {
 
     // Verify that the user does not have access to the entity create form of
     // the group content type.
-    /** @var \Drupal\node\Access\NodeAddAccessCheck $node_access_check */
-    $node_access_check = $this->container->get('access_check.node.add');
-    $result = $node_access_check->access(User::getAnonymousUser(), $this->groupContentType);
-    $this->assertNotInstanceOf('\Drupal\Core\Access\AccessResultAllowed', $result);
+    $url = Url::fromRoute('node.add_page');
+    $this->assertNotInstanceOf(AccessResultAllowed::class, $url->access(User::getAnonymousUser(), TRUE));
 
     // Test that the user can access the entity create form when the permission
     // to create group content is granted. Note that node access control is
     // cached, so we need to reset it when we change permissions.
     $this->container->get('entity_type.manager')->getAccessControlHandler('node')->resetCache();
     $role->grantPermission('create post content')->trustData()->save();
-    $result = $node_access_check->access(User::getAnonymousUser(), $this->groupContentType);
-    $this->assertInstanceOf('\Drupal\Core\Access\AccessResultAllowed', $result);
+    $this->assertInstanceOf('\Drupal\Core\Access\AccessResultAllowed', $url->access(User::getAnonymousUser(), TRUE));
   }
 
 }

--- a/tests/src/Kernel/Entity/FieldCreateTest.php
+++ b/tests/src/Kernel/Entity/FieldCreateTest.php
@@ -21,7 +21,7 @@ class FieldCreateTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = [
+  protected static $modules = [
     'user',
     'field',
     'node',

--- a/tests/src/Kernel/Entity/FieldCreateTest.php
+++ b/tests/src/Kernel/Entity/FieldCreateTest.php
@@ -97,6 +97,8 @@ class FieldCreateTest extends KernelTestBase {
 
   /**
    * Testing invalid field creation.
+   *
+   * @doesNotPerformAssertions
    */
   public function testInvalidFields() {
     // Unknown plugin.

--- a/tests/src/Kernel/Entity/GetBundleByBundleTest.php
+++ b/tests/src/Kernel/Entity/GetBundleByBundleTest.php
@@ -22,7 +22,7 @@ class GetBundleByBundleTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = [
+  protected static $modules = [
     'block_content',
     'field',
     'node',

--- a/tests/src/Kernel/Entity/GetGroupContentTest.php
+++ b/tests/src/Kernel/Entity/GetGroupContentTest.php
@@ -23,7 +23,7 @@ class GetGroupContentTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = [
+  protected static $modules = [
     'entity_test',
     'field',
     'node',

--- a/tests/src/Kernel/Entity/GetMembershipsTest.php
+++ b/tests/src/Kernel/Entity/GetMembershipsTest.php
@@ -25,7 +25,7 @@ class GetMembershipsTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = [
+  protected static $modules = [
     'entity_test',
     'field',
     'node',

--- a/tests/src/Kernel/Entity/GetMembershipsTest.php
+++ b/tests/src/Kernel/Entity/GetMembershipsTest.php
@@ -278,6 +278,7 @@ class GetMembershipsTest extends KernelTestBase {
       $memberships = $this->entityTypeManager
         ->getStorage('og_membership')
         ->getQuery()
+        ->accessCheck()
         ->condition('uid', $user_id)
         ->execute();
 

--- a/tests/src/Kernel/Entity/GetUserGroupsTest.php
+++ b/tests/src/Kernel/Entity/GetUserGroupsTest.php
@@ -26,7 +26,7 @@ class GetUserGroupsTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = [
+  protected static $modules = [
     'system',
     'user',
     'field',

--- a/tests/src/Kernel/Entity/GroupAudienceTest.php
+++ b/tests/src/Kernel/Entity/GroupAudienceTest.php
@@ -27,7 +27,6 @@ class GroupAudienceTest extends KernelTestBase {
    * {@inheritdoc}
    */
   protected static $modules = [
-    'entity_reference',
     'entity_test',
     'field',
     'og',

--- a/tests/src/Kernel/Entity/GroupAudienceTest.php
+++ b/tests/src/Kernel/Entity/GroupAudienceTest.php
@@ -26,7 +26,7 @@ class GroupAudienceTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = [
+  protected static $modules = [
     'entity_reference',
     'entity_test',
     'field',

--- a/tests/src/Kernel/Entity/GroupMembershipManagerTest.php
+++ b/tests/src/Kernel/Entity/GroupMembershipManagerTest.php
@@ -32,7 +32,7 @@ class GroupMembershipManagerTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = [
+  protected static $modules = [
     'entity_test',
     'field',
     'node',

--- a/tests/src/Kernel/Entity/GroupMembershipManagerTest.php
+++ b/tests/src/Kernel/Entity/GroupMembershipManagerTest.php
@@ -200,6 +200,7 @@ class GroupMembershipManagerTest extends KernelTestBase {
    *
    * @covers ::getGroupIds
    * @dataProvider groupContentProvider
+   * @doesNotPerformAssertions
    */
   public function testGetGroupIdsInvalidArguments() {
     /** @var \Drupal\og\MembershipManagerInterface $membership_manager */
@@ -381,6 +382,7 @@ class GroupMembershipManagerTest extends KernelTestBase {
    * Tests retrieval of group membership IDs filtered by role names.
    *
    * @covers ::getGroupMembershipIdsByRoleNames
+   * @doesNotPerformAssertions
    */
   public function testGetGroupMembershipIdsByRoleNames() {
     $membership_storage = $this->container->get('entity_type.manager')->getStorage('og_membership');

--- a/tests/src/Kernel/Entity/GroupTypeTest.php
+++ b/tests/src/Kernel/Entity/GroupTypeTest.php
@@ -17,7 +17,7 @@ class GroupTypeTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = ['field', 'node', 'og', 'options', 'system', 'user'];
+  protected static $modules = ['field', 'node', 'og', 'options', 'system', 'user'];
 
   /**
    * The group type manager.

--- a/tests/src/Kernel/Entity/GroupTypeTest.php
+++ b/tests/src/Kernel/Entity/GroupTypeTest.php
@@ -17,7 +17,14 @@ class GroupTypeTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected static $modules = ['field', 'node', 'og', 'options', 'system', 'user'];
+  protected static $modules = [
+    'field',
+    'node',
+    'og',
+    'options',
+    'system',
+    'user',
+  ];
 
   /**
    * The group type manager.

--- a/tests/src/Kernel/Entity/OgMembershipRoleReferenceTest.php
+++ b/tests/src/Kernel/Entity/OgMembershipRoleReferenceTest.php
@@ -22,7 +22,7 @@ class OgMembershipRoleReferenceTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = [
+  protected static $modules = [
     'field',
     'node',
     'og',

--- a/tests/src/Kernel/Entity/OgMembershipTest.php
+++ b/tests/src/Kernel/Entity/OgMembershipTest.php
@@ -258,6 +258,8 @@ class OgMembershipTest extends KernelTestBase {
    *
    * @todo This test is not related to the OgMembership entity. It should be
    *   moved to a more appropriate test class.
+   *
+   * @doesNotPerformAssertions
    */
   public function testNoOwnerException() {
     // Create a bundle and add as a group.
@@ -591,6 +593,7 @@ class OgMembershipTest extends KernelTestBase {
    * Tests re-saving a membership.
    *
    * @covers ::preSave
+   * @doesNotPerformAssertions
    */
   public function testSaveSameMembershipTwice() {
     $group = EntityTest::create([

--- a/tests/src/Kernel/Entity/OgMembershipTest.php
+++ b/tests/src/Kernel/Entity/OgMembershipTest.php
@@ -29,7 +29,7 @@ class OgMembershipTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = [
+  protected static $modules = [
     'entity_test',
     'field',
     'node',

--- a/tests/src/Kernel/Entity/OgRoleTest.php
+++ b/tests/src/Kernel/Entity/OgRoleTest.php
@@ -22,7 +22,7 @@ class OgRoleTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = [
+  protected static $modules = [
     'entity_test',
     'field',
     'node',

--- a/tests/src/Kernel/Entity/OgStandardReferenceItemTest.php
+++ b/tests/src/Kernel/Entity/OgStandardReferenceItemTest.php
@@ -90,7 +90,9 @@ class OgStandardReferenceItemTest extends KernelTestBase {
    */
   public function testStandardReference() {
     $groups_query = function ($gid) {
-      return $this->container->get('entity_type.manager')->getStorage('entity_test')->getQuery()
+      return $this->container->get('entity_type.manager')->getStorage('entity_test')
+        ->getQuery()
+        ->accessCheck()
         ->condition($this->fieldName, $gid)
         ->execute();
     };

--- a/tests/src/Kernel/Entity/OgStandardReferenceItemTest.php
+++ b/tests/src/Kernel/Entity/OgStandardReferenceItemTest.php
@@ -20,7 +20,7 @@ class OgStandardReferenceItemTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = [
+  protected static $modules = [
     'user',
     'entity_test',
     'field',

--- a/tests/src/Kernel/Entity/ReferenceStringIdTest.php
+++ b/tests/src/Kernel/Entity/ReferenceStringIdTest.php
@@ -106,7 +106,9 @@ class ReferenceStringIdTest extends KernelTestBase {
     $entity->save();
 
     // Check that the group content entity is referenced.
-    $references = $this->container->get('entity_type.manager')->getStorage('entity_test_string_id')->getQuery()
+    $references = $this->container->get('entity_type.manager')->getStorage('entity_test_string_id')
+      ->getQuery()
+      ->accessCheck()
       ->condition($this->fieldName, $this->group->id())
       ->execute();
     $this->assertEquals([$entity->id()], array_keys($references), 'The correct group is referenced.');

--- a/tests/src/Kernel/Entity/ReferenceStringIdTest.php
+++ b/tests/src/Kernel/Entity/ReferenceStringIdTest.php
@@ -19,7 +19,7 @@ class ReferenceStringIdTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = [
+  protected static $modules = [
     'user',
     'entity_test',
     'field',

--- a/tests/src/Kernel/Entity/SelectionHandlerTest.php
+++ b/tests/src/Kernel/Entity/SelectionHandlerTest.php
@@ -29,7 +29,7 @@ class SelectionHandlerTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = [
+  protected static $modules = [
     'system',
     'user',
     'field',

--- a/tests/src/Kernel/Entity/SelectionHandlerTest.php
+++ b/tests/src/Kernel/Entity/SelectionHandlerTest.php
@@ -33,7 +33,6 @@ class SelectionHandlerTest extends KernelTestBase {
     'system',
     'user',
     'field',
-    'entity_reference',
     'node',
     'og',
     'options',

--- a/tests/src/Kernel/EntityReference/Views/OgStandardReferenceRelationshipTest.php
+++ b/tests/src/Kernel/EntityReference/Views/OgStandardReferenceRelationshipTest.php
@@ -102,37 +102,37 @@ class OgStandardReferenceRelationshipTest extends ViewsKernelTestBase {
     $entity = EntityTest::create();
     $entity->field_test_data->target_id = $referenced_entity->id();
     $entity->save();
-    $this->assertEquals($entity->field_test_data[0]->entity->id(), $referenced_entity->id());
+    $this->assertEquals($referenced_entity->id(), $entity->field_test_data[0]->entity->id());
     $this->entities[] = $entity;
 
     $entity = EntityTest::create();
     $entity->field_test_data->target_id = $referenced_entity->id();
     $entity->save();
-    $this->assertEquals($entity->field_test_data[0]->entity->id(), $referenced_entity->id());
+    $this->assertEquals($referenced_entity->id(), $entity->field_test_data[0]->entity->id());
     $this->entities[] = $entity;
 
     Views::viewsData()->clear();
 
     // Check the generated views data.
     $views_data = Views::viewsData()->get('entity_test__field_test_data');
-    $this->assertEquals($views_data['field_test_data']['relationship']['id'], 'standard');
-    $this->assertEquals($views_data['field_test_data']['relationship']['base'], 'entity_test_mul_property_data');
-    $this->assertEquals($views_data['field_test_data']['relationship']['base field'], 'id');
-    $this->assertEquals($views_data['field_test_data']['relationship']['relationship field'], 'field_test_data_target_id');
-    $this->assertEquals($views_data['field_test_data']['relationship']['entity type'], 'entity_test_mul');
+    $this->assertEquals('standard', $views_data['field_test_data']['relationship']['id']);
+    $this->assertEquals('entity_test_mul_property_data', $views_data['field_test_data']['relationship']['base']);
+    $this->assertEquals('id', $views_data['field_test_data']['relationship']['base field']);
+    $this->assertEquals('field_test_data_target_id', $views_data['field_test_data']['relationship']['relationship field']);
+    $this->assertEquals('entity_test_mul', $views_data['field_test_data']['relationship']['entity type']);
 
     // Check the backwards reference.
     $views_data = Views::viewsData()->get('entity_test_mul_property_data');
-    $this->assertEquals($views_data['reverse__entity_test__field_test_data']['relationship']['id'], 'entity_reverse');
-    $this->assertEquals($views_data['reverse__entity_test__field_test_data']['relationship']['base'], 'entity_test');
-    $this->assertEquals($views_data['reverse__entity_test__field_test_data']['relationship']['base field'], 'id');
-    $this->assertEquals($views_data['reverse__entity_test__field_test_data']['relationship']['field table'], 'entity_test__field_test_data');
-    $this->assertEquals($views_data['reverse__entity_test__field_test_data']['relationship']['field field'], 'field_test_data_target_id');
-    $this->assertEquals($views_data['reverse__entity_test__field_test_data']['relationship']['field_name'], 'field_test_data');
-    $this->assertEquals($views_data['reverse__entity_test__field_test_data']['relationship']['entity_type'], 'entity_test');
+    $this->assertEquals('entity_reverse', $views_data['reverse__entity_test__field_test_data']['relationship']['id']);
+    $this->assertEquals('entity_test', $views_data['reverse__entity_test__field_test_data']['relationship']['base']);
+    $this->assertEquals('id', $views_data['reverse__entity_test__field_test_data']['relationship']['base field']);
+    $this->assertEquals('entity_test__field_test_data', $views_data['reverse__entity_test__field_test_data']['relationship']['field table']);
+    $this->assertEquals('field_test_data_target_id', $views_data['reverse__entity_test__field_test_data']['relationship']['field field']);
+    $this->assertEquals('field_test_data', $views_data['reverse__entity_test__field_test_data']['relationship']['field_name']);
+    $this->assertEquals('entity_test', $views_data['reverse__entity_test__field_test_data']['relationship']['entity_type']);
 
     $values = ['field' => 'deleted', 'value' => 0, 'numeric' => TRUE];
-    $this->assertEquals($views_data['reverse__entity_test__field_test_data']['relationship']['join_extra'][0], $values);
+    $this->assertEquals($values, $views_data['reverse__entity_test__field_test_data']['relationship']['join_extra'][0]);
 
     // Check an actual test view.
     $view = Views::getView('test_og_standard_reference_entity_test_view');
@@ -140,18 +140,17 @@ class OgStandardReferenceRelationshipTest extends ViewsKernelTestBase {
     /** @var \Drupal\views\ResultRow $row */
     foreach ($view->result as $index => $row) {
       // Check that the actual ID of the entity is the expected one.
-      $this->assertEquals($row->id, $this->entities[$index]->id());
+      $this->assertEquals($this->entities[$index]->id(), $row->id);
 
       // Also check that we have the correct result entity.
-      $this->assertEquals($row->_entity->id(), $this->entities[$index]->id());
+      $this->assertEquals($this->entities[$index]->id(), $row->_entity->id());
 
       // Test the forward relationship.
-      $this->assertEquals($row->entity_test_mul_property_data_entity_test__field_test_data_i, 1);
+      $this->assertEquals(1, $row->entity_test_mul_property_data_entity_test__field_test_data_i);
 
       // Test that the correct relationship entity is on the row.
-      $this->assertEquals($row->_relationship_entities['field_test_data']->id(), 1);
-      $this->assertEquals($row->_relationship_entities['field_test_data']->bundle(), 'entity_test_mul');
-
+      $this->assertEquals(1, $row->_relationship_entities['field_test_data']->id());
+      $this->assertEquals('entity_test_mul', $row->_relationship_entities['field_test_data']->bundle());
     }
 
     // Check the backwards reference view.
@@ -185,37 +184,37 @@ class OgStandardReferenceRelationshipTest extends ViewsKernelTestBase {
     $entity = EntityTestMul::create();
     $entity->field_data_test->target_id = $referenced_entity->id();
     $entity->save();
-    $this->assertEquals($entity->field_data_test[0]->entity->id(), $referenced_entity->id());
+    $this->assertEquals($referenced_entity->id(), $entity->field_data_test[0]->entity->id());
     $this->entities[] = $entity;
 
     $entity = EntityTestMul::create();
     $entity->field_data_test->target_id = $referenced_entity->id();
     $entity->save();
-    $this->assertEquals($entity->field_data_test[0]->entity->id(), $referenced_entity->id());
+    $this->assertEquals($referenced_entity->id(), $entity->field_data_test[0]->entity->id());
     $this->entities[] = $entity;
 
     Views::viewsData()->clear();
 
     // Check the generated views data.
     $views_data = Views::viewsData()->get('entity_test_mul__field_data_test');
-    $this->assertEquals($views_data['field_data_test']['relationship']['id'], 'standard');
-    $this->assertEquals($views_data['field_data_test']['relationship']['base'], 'entity_test');
-    $this->assertEquals($views_data['field_data_test']['relationship']['base field'], 'id');
-    $this->assertEquals($views_data['field_data_test']['relationship']['relationship field'], 'field_data_test_target_id');
-    $this->assertEquals($views_data['field_data_test']['relationship']['entity type'], 'entity_test');
+    $this->assertEquals('standard', $views_data['field_data_test']['relationship']['id']);
+    $this->assertEquals('entity_test', $views_data['field_data_test']['relationship']['base']);
+    $this->assertEquals('id', $views_data['field_data_test']['relationship']['base field']);
+    $this->assertEquals('field_data_test_target_id', $views_data['field_data_test']['relationship']['relationship field']);
+    $this->assertEquals('entity_test', $views_data['field_data_test']['relationship']['entity type']);
 
     // Check the backwards reference.
     $views_data = Views::viewsData()->get('entity_test');
-    $this->assertEquals($views_data['reverse__entity_test_mul__field_data_test']['relationship']['id'], 'entity_reverse');
-    $this->assertEquals($views_data['reverse__entity_test_mul__field_data_test']['relationship']['base'], 'entity_test_mul_property_data');
-    $this->assertEquals($views_data['reverse__entity_test_mul__field_data_test']['relationship']['base field'], 'id');
-    $this->assertEquals($views_data['reverse__entity_test_mul__field_data_test']['relationship']['field table'], 'entity_test_mul__field_data_test');
-    $this->assertEquals($views_data['reverse__entity_test_mul__field_data_test']['relationship']['field field'], 'field_data_test_target_id');
-    $this->assertEquals($views_data['reverse__entity_test_mul__field_data_test']['relationship']['field_name'], 'field_data_test');
-    $this->assertEquals($views_data['reverse__entity_test_mul__field_data_test']['relationship']['entity_type'], 'entity_test_mul');
+    $this->assertEquals('entity_reverse', $views_data['reverse__entity_test_mul__field_data_test']['relationship']['id']);
+    $this->assertEquals('entity_test_mul_property_data', $views_data['reverse__entity_test_mul__field_data_test']['relationship']['base']);
+    $this->assertEquals('id', $views_data['reverse__entity_test_mul__field_data_test']['relationship']['base field']);
+    $this->assertEquals('entity_test_mul__field_data_test', $views_data['reverse__entity_test_mul__field_data_test']['relationship']['field table']);
+    $this->assertEquals('field_data_test_target_id', $views_data['reverse__entity_test_mul__field_data_test']['relationship']['field field']);
+    $this->assertEquals('field_data_test', $views_data['reverse__entity_test_mul__field_data_test']['relationship']['field_name']);
+    $this->assertEquals('entity_test_mul', $views_data['reverse__entity_test_mul__field_data_test']['relationship']['entity_type']);
 
     $values = ['field' => 'deleted', 'value' => 0, 'numeric' => TRUE];
-    $this->assertEquals($views_data['reverse__entity_test_mul__field_data_test']['relationship']['join_extra'][0], $values);
+    $this->assertEquals($values, $views_data['reverse__entity_test_mul__field_data_test']['relationship']['join_extra'][0]);
 
     // Check an actual test view.
     $view = Views::getView('test_og_standard_reference_entity_test_mul_view');
@@ -223,17 +222,17 @@ class OgStandardReferenceRelationshipTest extends ViewsKernelTestBase {
     /** @var \Drupal\views\ResultRow $row */
     foreach ($view->result as $index => $row) {
       // Check that the actual ID of the entity is the expected one.
-      $this->assertEquals($row->id, $this->entities[$index]->id());
+      $this->assertEquals($this->entities[$index]->id(), $row->id);
 
       // Also check that we have the correct result entity.
-      $this->assertEquals($row->_entity->id(), $this->entities[$index]->id());
+      $this->assertEquals($this->entities[$index]->id(), $row->_entity->id());
 
       // Test the forward relationship.
-      $this->assertEquals($row->entity_test_entity_test_mul__field_data_test_id, 1);
+      $this->assertEquals(1, $row->entity_test_entity_test_mul__field_data_test_id);
 
       // Test that the correct relationship entity is on the row.
-      $this->assertEquals($row->_relationship_entities['field_data_test']->id(), 1);
-      $this->assertEquals($row->_relationship_entities['field_data_test']->bundle(), 'entity_test');
+      $this->assertEquals(1, $row->_relationship_entities['field_data_test']->id());
+      $this->assertEquals('entity_test', $row->_relationship_entities['field_data_test']->bundle());
 
     }
 
@@ -242,15 +241,15 @@ class OgStandardReferenceRelationshipTest extends ViewsKernelTestBase {
     $this->executeView($view);
     /** @var \Drupal\views\ResultRow $row */
     foreach ($view->result as $index => $row) {
-      $this->assertEquals($row->id, 1);
-      $this->assertEquals($row->_entity->id(), 1);
+      $this->assertEquals(1, $row->id);
+      $this->assertEquals(1, $row->_entity->id());
 
       // Test the backwards relationship.
-      $this->assertEquals($row->field_data_test_entity_test_id, $this->entities[$index]->id());
+      $this->assertEquals($this->entities[$index]->id(), $row->field_data_test_entity_test_id);
 
       // Test that the correct relationship entity is on the row.
-      $this->assertEquals($row->_relationship_entities['reverse__entity_test_mul__field_data_test']->id(), $this->entities[$index]->id());
-      $this->assertEquals($row->_relationship_entities['reverse__entity_test_mul__field_data_test']->bundle(), 'entity_test_mul');
+      $this->assertEquals($this->entities[$index]->id(), $row->_relationship_entities['reverse__entity_test_mul__field_data_test']->id());
+      $this->assertEquals('entity_test_mul', $row->_relationship_entities['reverse__entity_test_mul__field_data_test']->bundle());
     }
   }
 

--- a/tests/src/Kernel/EntityReference/Views/OgStandardReferenceRelationshipTest.php
+++ b/tests/src/Kernel/EntityReference/Views/OgStandardReferenceRelationshipTest.php
@@ -38,7 +38,7 @@ class OgStandardReferenceRelationshipTest extends ViewsKernelTestBase {
    *
    * @var array
    */
-  public static $modules = [
+  protected static $modules = [
     'user',
     'field',
     'entity_test',

--- a/tests/src/Kernel/EntityReference/Views/OgStandardReferenceRelationshipTest.php
+++ b/tests/src/Kernel/EntityReference/Views/OgStandardReferenceRelationshipTest.php
@@ -102,37 +102,37 @@ class OgStandardReferenceRelationshipTest extends ViewsKernelTestBase {
     $entity = EntityTest::create();
     $entity->field_test_data->target_id = $referenced_entity->id();
     $entity->save();
-    $this->assertEqual($entity->field_test_data[0]->entity->id(), $referenced_entity->id());
+    $this->assertEquals($entity->field_test_data[0]->entity->id(), $referenced_entity->id());
     $this->entities[] = $entity;
 
     $entity = EntityTest::create();
     $entity->field_test_data->target_id = $referenced_entity->id();
     $entity->save();
-    $this->assertEqual($entity->field_test_data[0]->entity->id(), $referenced_entity->id());
+    $this->assertEquals($entity->field_test_data[0]->entity->id(), $referenced_entity->id());
     $this->entities[] = $entity;
 
     Views::viewsData()->clear();
 
     // Check the generated views data.
     $views_data = Views::viewsData()->get('entity_test__field_test_data');
-    $this->assertEqual($views_data['field_test_data']['relationship']['id'], 'standard');
-    $this->assertEqual($views_data['field_test_data']['relationship']['base'], 'entity_test_mul_property_data');
-    $this->assertEqual($views_data['field_test_data']['relationship']['base field'], 'id');
-    $this->assertEqual($views_data['field_test_data']['relationship']['relationship field'], 'field_test_data_target_id');
-    $this->assertEqual($views_data['field_test_data']['relationship']['entity type'], 'entity_test_mul');
+    $this->assertEquals($views_data['field_test_data']['relationship']['id'], 'standard');
+    $this->assertEquals($views_data['field_test_data']['relationship']['base'], 'entity_test_mul_property_data');
+    $this->assertEquals($views_data['field_test_data']['relationship']['base field'], 'id');
+    $this->assertEquals($views_data['field_test_data']['relationship']['relationship field'], 'field_test_data_target_id');
+    $this->assertEquals($views_data['field_test_data']['relationship']['entity type'], 'entity_test_mul');
 
     // Check the backwards reference.
     $views_data = Views::viewsData()->get('entity_test_mul_property_data');
-    $this->assertEqual($views_data['reverse__entity_test__field_test_data']['relationship']['id'], 'entity_reverse');
-    $this->assertEqual($views_data['reverse__entity_test__field_test_data']['relationship']['base'], 'entity_test');
-    $this->assertEqual($views_data['reverse__entity_test__field_test_data']['relationship']['base field'], 'id');
-    $this->assertEqual($views_data['reverse__entity_test__field_test_data']['relationship']['field table'], 'entity_test__field_test_data');
-    $this->assertEqual($views_data['reverse__entity_test__field_test_data']['relationship']['field field'], 'field_test_data_target_id');
-    $this->assertEqual($views_data['reverse__entity_test__field_test_data']['relationship']['field_name'], 'field_test_data');
-    $this->assertEqual($views_data['reverse__entity_test__field_test_data']['relationship']['entity_type'], 'entity_test');
+    $this->assertEquals($views_data['reverse__entity_test__field_test_data']['relationship']['id'], 'entity_reverse');
+    $this->assertEquals($views_data['reverse__entity_test__field_test_data']['relationship']['base'], 'entity_test');
+    $this->assertEquals($views_data['reverse__entity_test__field_test_data']['relationship']['base field'], 'id');
+    $this->assertEquals($views_data['reverse__entity_test__field_test_data']['relationship']['field table'], 'entity_test__field_test_data');
+    $this->assertEquals($views_data['reverse__entity_test__field_test_data']['relationship']['field field'], 'field_test_data_target_id');
+    $this->assertEquals($views_data['reverse__entity_test__field_test_data']['relationship']['field_name'], 'field_test_data');
+    $this->assertEquals($views_data['reverse__entity_test__field_test_data']['relationship']['entity_type'], 'entity_test');
 
     $values = ['field' => 'deleted', 'value' => 0, 'numeric' => TRUE];
-    $this->assertEqual($views_data['reverse__entity_test__field_test_data']['relationship']['join_extra'][0], $values);
+    $this->assertEquals($views_data['reverse__entity_test__field_test_data']['relationship']['join_extra'][0], $values);
 
     // Check an actual test view.
     $view = Views::getView('test_og_standard_reference_entity_test_view');
@@ -140,17 +140,17 @@ class OgStandardReferenceRelationshipTest extends ViewsKernelTestBase {
     /** @var \Drupal\views\ResultRow $row */
     foreach ($view->result as $index => $row) {
       // Check that the actual ID of the entity is the expected one.
-      $this->assertEqual($row->id, $this->entities[$index]->id());
+      $this->assertEquals($row->id, $this->entities[$index]->id());
 
       // Also check that we have the correct result entity.
-      $this->assertEqual($row->_entity->id(), $this->entities[$index]->id());
+      $this->assertEquals($row->_entity->id(), $this->entities[$index]->id());
 
       // Test the forward relationship.
-      $this->assertEqual($row->entity_test_mul_property_data_entity_test__field_test_data_i, 1);
+      $this->assertEquals($row->entity_test_mul_property_data_entity_test__field_test_data_i, 1);
 
       // Test that the correct relationship entity is on the row.
-      $this->assertEqual($row->_relationship_entities['field_test_data']->id(), 1);
-      $this->assertEqual($row->_relationship_entities['field_test_data']->bundle(), 'entity_test_mul');
+      $this->assertEquals($row->_relationship_entities['field_test_data']->id(), 1);
+      $this->assertEquals($row->_relationship_entities['field_test_data']->bundle(), 'entity_test_mul');
 
     }
 
@@ -159,15 +159,15 @@ class OgStandardReferenceRelationshipTest extends ViewsKernelTestBase {
     $this->executeView($view);
     /** @var \Drupal\views\ResultRow $row */
     foreach ($view->result as $index => $row) {
-      $this->assertEqual($row->id, 1);
-      $this->assertEqual($row->_entity->id(), 1);
+      $this->assertEquals($row->id, 1);
+      $this->assertEquals($row->_entity->id(), 1);
 
       // Test the backwards relationship.
-      $this->assertEqual($row->field_test_data_entity_test_mul_property_data_id, $this->entities[$index]->id());
+      $this->assertEquals($row->field_test_data_entity_test_mul_property_data_id, $this->entities[$index]->id());
 
       // Test that the correct relationship entity is on the row.
-      $this->assertEqual($row->_relationship_entities['reverse__entity_test__field_test_data']->id(), $this->entities[$index]->id());
-      $this->assertEqual($row->_relationship_entities['reverse__entity_test__field_test_data']->bundle(), 'entity_test');
+      $this->assertEquals($row->_relationship_entities['reverse__entity_test__field_test_data']->id(), $this->entities[$index]->id());
+      $this->assertEquals($row->_relationship_entities['reverse__entity_test__field_test_data']->bundle(), 'entity_test');
     }
   }
 
@@ -185,37 +185,37 @@ class OgStandardReferenceRelationshipTest extends ViewsKernelTestBase {
     $entity = EntityTestMul::create();
     $entity->field_data_test->target_id = $referenced_entity->id();
     $entity->save();
-    $this->assertEqual($entity->field_data_test[0]->entity->id(), $referenced_entity->id());
+    $this->assertEquals($entity->field_data_test[0]->entity->id(), $referenced_entity->id());
     $this->entities[] = $entity;
 
     $entity = EntityTestMul::create();
     $entity->field_data_test->target_id = $referenced_entity->id();
     $entity->save();
-    $this->assertEqual($entity->field_data_test[0]->entity->id(), $referenced_entity->id());
+    $this->assertEquals($entity->field_data_test[0]->entity->id(), $referenced_entity->id());
     $this->entities[] = $entity;
 
     Views::viewsData()->clear();
 
     // Check the generated views data.
     $views_data = Views::viewsData()->get('entity_test_mul__field_data_test');
-    $this->assertEqual($views_data['field_data_test']['relationship']['id'], 'standard');
-    $this->assertEqual($views_data['field_data_test']['relationship']['base'], 'entity_test');
-    $this->assertEqual($views_data['field_data_test']['relationship']['base field'], 'id');
-    $this->assertEqual($views_data['field_data_test']['relationship']['relationship field'], 'field_data_test_target_id');
-    $this->assertEqual($views_data['field_data_test']['relationship']['entity type'], 'entity_test');
+    $this->assertEquals($views_data['field_data_test']['relationship']['id'], 'standard');
+    $this->assertEquals($views_data['field_data_test']['relationship']['base'], 'entity_test');
+    $this->assertEquals($views_data['field_data_test']['relationship']['base field'], 'id');
+    $this->assertEquals($views_data['field_data_test']['relationship']['relationship field'], 'field_data_test_target_id');
+    $this->assertEquals($views_data['field_data_test']['relationship']['entity type'], 'entity_test');
 
     // Check the backwards reference.
     $views_data = Views::viewsData()->get('entity_test');
-    $this->assertEqual($views_data['reverse__entity_test_mul__field_data_test']['relationship']['id'], 'entity_reverse');
-    $this->assertEqual($views_data['reverse__entity_test_mul__field_data_test']['relationship']['base'], 'entity_test_mul_property_data');
-    $this->assertEqual($views_data['reverse__entity_test_mul__field_data_test']['relationship']['base field'], 'id');
-    $this->assertEqual($views_data['reverse__entity_test_mul__field_data_test']['relationship']['field table'], 'entity_test_mul__field_data_test');
-    $this->assertEqual($views_data['reverse__entity_test_mul__field_data_test']['relationship']['field field'], 'field_data_test_target_id');
-    $this->assertEqual($views_data['reverse__entity_test_mul__field_data_test']['relationship']['field_name'], 'field_data_test');
-    $this->assertEqual($views_data['reverse__entity_test_mul__field_data_test']['relationship']['entity_type'], 'entity_test_mul');
+    $this->assertEquals($views_data['reverse__entity_test_mul__field_data_test']['relationship']['id'], 'entity_reverse');
+    $this->assertEquals($views_data['reverse__entity_test_mul__field_data_test']['relationship']['base'], 'entity_test_mul_property_data');
+    $this->assertEquals($views_data['reverse__entity_test_mul__field_data_test']['relationship']['base field'], 'id');
+    $this->assertEquals($views_data['reverse__entity_test_mul__field_data_test']['relationship']['field table'], 'entity_test_mul__field_data_test');
+    $this->assertEquals($views_data['reverse__entity_test_mul__field_data_test']['relationship']['field field'], 'field_data_test_target_id');
+    $this->assertEquals($views_data['reverse__entity_test_mul__field_data_test']['relationship']['field_name'], 'field_data_test');
+    $this->assertEquals($views_data['reverse__entity_test_mul__field_data_test']['relationship']['entity_type'], 'entity_test_mul');
 
     $values = ['field' => 'deleted', 'value' => 0, 'numeric' => TRUE];
-    $this->assertEqual($views_data['reverse__entity_test_mul__field_data_test']['relationship']['join_extra'][0], $values);
+    $this->assertEquals($views_data['reverse__entity_test_mul__field_data_test']['relationship']['join_extra'][0], $values);
 
     // Check an actual test view.
     $view = Views::getView('test_og_standard_reference_entity_test_mul_view');
@@ -223,17 +223,17 @@ class OgStandardReferenceRelationshipTest extends ViewsKernelTestBase {
     /** @var \Drupal\views\ResultRow $row */
     foreach ($view->result as $index => $row) {
       // Check that the actual ID of the entity is the expected one.
-      $this->assertEqual($row->id, $this->entities[$index]->id());
+      $this->assertEquals($row->id, $this->entities[$index]->id());
 
       // Also check that we have the correct result entity.
-      $this->assertEqual($row->_entity->id(), $this->entities[$index]->id());
+      $this->assertEquals($row->_entity->id(), $this->entities[$index]->id());
 
       // Test the forward relationship.
-      $this->assertEqual($row->entity_test_entity_test_mul__field_data_test_id, 1);
+      $this->assertEquals($row->entity_test_entity_test_mul__field_data_test_id, 1);
 
       // Test that the correct relationship entity is on the row.
-      $this->assertEqual($row->_relationship_entities['field_data_test']->id(), 1);
-      $this->assertEqual($row->_relationship_entities['field_data_test']->bundle(), 'entity_test');
+      $this->assertEquals($row->_relationship_entities['field_data_test']->id(), 1);
+      $this->assertEquals($row->_relationship_entities['field_data_test']->bundle(), 'entity_test');
 
     }
 
@@ -242,15 +242,15 @@ class OgStandardReferenceRelationshipTest extends ViewsKernelTestBase {
     $this->executeView($view);
     /** @var \Drupal\views\ResultRow $row */
     foreach ($view->result as $index => $row) {
-      $this->assertEqual($row->id, 1);
-      $this->assertEqual($row->_entity->id(), 1);
+      $this->assertEquals($row->id, 1);
+      $this->assertEquals($row->_entity->id(), 1);
 
       // Test the backwards relationship.
-      $this->assertEqual($row->field_data_test_entity_test_id, $this->entities[$index]->id());
+      $this->assertEquals($row->field_data_test_entity_test_id, $this->entities[$index]->id());
 
       // Test that the correct relationship entity is on the row.
-      $this->assertEqual($row->_relationship_entities['reverse__entity_test_mul__field_data_test']->id(), $this->entities[$index]->id());
-      $this->assertEqual($row->_relationship_entities['reverse__entity_test_mul__field_data_test']->bundle(), 'entity_test_mul');
+      $this->assertEquals($row->_relationship_entities['reverse__entity_test_mul__field_data_test']->id(), $this->entities[$index]->id());
+      $this->assertEquals($row->_relationship_entities['reverse__entity_test_mul__field_data_test']->bundle(), 'entity_test_mul');
     }
   }
 

--- a/tests/src/Kernel/Field/AudienceFieldFormatterTest.php
+++ b/tests/src/Kernel/Field/AudienceFieldFormatterTest.php
@@ -17,7 +17,7 @@ class AudienceFieldFormatterTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = ['field', 'og'];
+  protected static $modules = ['field', 'og'];
 
   /**
    * Testing og_field_formatter_info_alter().

--- a/tests/src/Kernel/Form/GroupSubscribeFormTest.php
+++ b/tests/src/Kernel/Form/GroupSubscribeFormTest.php
@@ -26,7 +26,7 @@ class GroupSubscribeFormTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = [
+  protected static $modules = [
     'system',
     'user',
     'field',

--- a/tests/src/Kernel/GroupManagerSubscriptionTest.php
+++ b/tests/src/Kernel/GroupManagerSubscriptionTest.php
@@ -21,7 +21,7 @@ class GroupManagerSubscriptionTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = [
+  protected static $modules = [
     'field',
     'node',
     'og',

--- a/tests/src/Kernel/GroupTypeConditionTest.php
+++ b/tests/src/Kernel/GroupTypeConditionTest.php
@@ -19,7 +19,7 @@ class GroupTypeConditionTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = [
+  protected static $modules = [
     'entity_test',
     'field',
     'node',

--- a/tests/src/Kernel/OgDeleteOrphansTest.php
+++ b/tests/src/Kernel/OgDeleteOrphansTest.php
@@ -21,7 +21,7 @@ class OgDeleteOrphansTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = [
+  protected static $modules = [
     'system',
     'user',
     'field',

--- a/tests/src/Kernel/OgDeleteOrphansTest.php
+++ b/tests/src/Kernel/OgDeleteOrphansTest.php
@@ -25,7 +25,6 @@ class OgDeleteOrphansTest extends KernelTestBase {
     'system',
     'user',
     'field',
-    'entity_reference',
     'node',
     'og',
     'options',
@@ -256,7 +255,7 @@ class OgDeleteOrphansTest extends KernelTestBase {
    *   The expected number of user memberships.
    */
   protected function assertUserMembershipCount($expected) {
-    $count = \Drupal::entityQuery('og_membership')->count()->execute();
+    $count = \Drupal::entityQuery('og_membership')->accessCheck()->count()->execute();
     $this->assertEquals($expected, $count);
   }
 

--- a/tests/src/Kernel/OgRoleManagerTest.php
+++ b/tests/src/Kernel/OgRoleManagerTest.php
@@ -21,7 +21,7 @@ class OgRoleManagerTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = [
+  protected static $modules = [
     'entity_test',
     'field',
     'node',

--- a/tests/src/Kernel/PermissionEventTest.php
+++ b/tests/src/Kernel/PermissionEventTest.php
@@ -25,7 +25,7 @@ class PermissionEventTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = [
+  protected static $modules = [
     'entity_test',
     'field',
     'node',

--- a/tests/src/Kernel/PermissionEventTest.php
+++ b/tests/src/Kernel/PermissionEventTest.php
@@ -98,7 +98,7 @@ class PermissionEventTest extends KernelTestBase {
     // Retrieve the permissions from the listeners.
     /** @var \Drupal\og\Event\PermissionEvent $permission_event */
     $event = new PermissionEvent($this->randomMachineName(), $this->randomMachineName(), $group_content_bundle_ids);
-    $permission_event = $this->eventDispatcher->dispatch(PermissionEventInterface::EVENT_NAME, $event);
+    $permission_event = $this->eventDispatcher->dispatch($event, PermissionEventInterface::EVENT_NAME);
     $actual_permissions = array_keys($permission_event->getPermissions());
 
     // Sort the permission arrays so they can be compared.

--- a/tests/src/Kernel/Plugin/Block/MemberCountBlockTest.php
+++ b/tests/src/Kernel/Plugin/Block/MemberCountBlockTest.php
@@ -21,6 +21,7 @@ use Prophecy\Promise\CallbackPromise;
  */
 class MemberCountBlockTest extends KernelTestBase {
 
+  use \Prophecy\PhpUnit\ProphecyTrait;
   use OgMembershipCreationTrait;
   use StringTranslationTrait;
   use UserCreationTrait;

--- a/tests/src/Kernel/Plugin/Block/MemberCountBlockTest.php
+++ b/tests/src/Kernel/Plugin/Block/MemberCountBlockTest.php
@@ -12,6 +12,7 @@ use Drupal\og\OgContextInterface;
 use Drupal\og\OgMembershipInterface;
 use Drupal\Tests\og\Traits\OgMembershipCreationTrait;
 use Drupal\Tests\user\Traits\UserCreationTrait;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Promise\CallbackPromise;
 
 /**
@@ -21,8 +22,8 @@ use Prophecy\Promise\CallbackPromise;
  */
 class MemberCountBlockTest extends KernelTestBase {
 
-  use \Prophecy\PhpUnit\ProphecyTrait;
   use OgMembershipCreationTrait;
+  use ProphecyTrait;
   use StringTranslationTrait;
   use UserCreationTrait;
 

--- a/tests/src/Kernel/Views/OgAdminMembersViewTest.php
+++ b/tests/src/Kernel/Views/OgAdminMembersViewTest.php
@@ -23,7 +23,7 @@ class OgAdminMembersViewTest extends ViewsKernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = [
+  protected static $modules = [
     'system',
     'user',
     'field',

--- a/tests/src/Unit/Cache/Context/OgContextCacheContextTestBase.php
+++ b/tests/src/Unit/Cache/Context/OgContextCacheContextTestBase.php
@@ -17,6 +17,8 @@ use Drupal\og\OgContextInterface;
  */
 abstract class OgContextCacheContextTestBase extends OgCacheContextTestBase {
 
+  use \Prophecy\PhpUnit\ProphecyTrait;
+
   /**
    * The mocked OG context service.
    *
@@ -69,6 +71,7 @@ abstract class OgContextCacheContextTestBase extends OgCacheContextTestBase {
    * Tests the result of the cache context service without active context.
    *
    * @covers ::getContext
+   * @doesNotPerformAssertions
    */
   abstract public function testWithoutContext();
 

--- a/tests/src/Unit/Cache/Context/OgContextCacheContextTestBase.php
+++ b/tests/src/Unit/Cache/Context/OgContextCacheContextTestBase.php
@@ -6,6 +6,7 @@ namespace Drupal\Tests\og\Unit\Cache\Context;
 
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\og\OgContextInterface;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * Base class for testing cache contexts that rely on OgContext.
@@ -17,7 +18,7 @@ use Drupal\og\OgContextInterface;
  */
 abstract class OgContextCacheContextTestBase extends OgCacheContextTestBase {
 
-  use \Prophecy\PhpUnit\ProphecyTrait;
+  use ProphecyTrait;
 
   /**
    * The mocked OG context service.

--- a/tests/src/Unit/Cache/Context/OgMembershipStateCacheContextTest.php
+++ b/tests/src/Unit/Cache/Context/OgMembershipStateCacheContextTest.php
@@ -17,6 +17,8 @@ use Drupal\og\OgMembershipInterface;
  */
 class OgMembershipStateCacheContextTest extends OgContextCacheContextTestBase {
 
+  use \Prophecy\PhpUnit\ProphecyTrait;
+
   /**
    * The OG membership entity.
    *

--- a/tests/src/Unit/Cache/Context/OgMembershipStateCacheContextTest.php
+++ b/tests/src/Unit/Cache/Context/OgMembershipStateCacheContextTest.php
@@ -8,6 +8,7 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\og\Cache\Context\OgMembershipStateCacheContext;
 use Drupal\og\MembershipManagerInterface;
 use Drupal\og\OgMembershipInterface;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * Tests OG membership state cache context.
@@ -17,7 +18,7 @@ use Drupal\og\OgMembershipInterface;
  */
 class OgMembershipStateCacheContextTest extends OgContextCacheContextTestBase {
 
-  use \Prophecy\PhpUnit\ProphecyTrait;
+  use ProphecyTrait;
 
   /**
    * The OG membership entity.

--- a/tests/src/Unit/Cache/Context/OgRoleCacheContextTest.php
+++ b/tests/src/Unit/Cache/Context/OgRoleCacheContextTest.php
@@ -14,6 +14,7 @@ use Drupal\Tests\og\Traits\OgRoleCacheContextTestTrait;
 use Drupal\og\Cache\Context\OgRoleCacheContext;
 use Drupal\og\MembershipManagerInterface;
 use Drupal\og\OgMembershipInterface;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * Tests the OG role cache context.
@@ -23,9 +24,8 @@ use Drupal\og\OgMembershipInterface;
  */
 class OgRoleCacheContextTest extends OgCacheContextTestBase {
 
-  use \Prophecy\PhpUnit\ProphecyTrait;
-
   use OgRoleCacheContextTestTrait;
+  use ProphecyTrait;
 
   /**
    * The mocked entity type manager.

--- a/tests/src/Unit/Cache/Context/OgRoleCacheContextTest.php
+++ b/tests/src/Unit/Cache/Context/OgRoleCacheContextTest.php
@@ -23,6 +23,8 @@ use Drupal\og\OgMembershipInterface;
  */
 class OgRoleCacheContextTest extends OgCacheContextTestBase {
 
+  use \Prophecy\PhpUnit\ProphecyTrait;
+
   use OgRoleCacheContextTestTrait;
 
   /**

--- a/tests/src/Unit/CreateMembershipTest.php
+++ b/tests/src/Unit/CreateMembershipTest.php
@@ -25,6 +25,8 @@ use Prophecy\Argument;
  */
 class CreateMembershipTest extends UnitTestCase {
 
+  use \Prophecy\PhpUnit\ProphecyTrait;
+
   /**
    * The entity type manager.
    *

--- a/tests/src/Unit/CreateMembershipTest.php
+++ b/tests/src/Unit/CreateMembershipTest.php
@@ -16,6 +16,7 @@ use Drupal\og\OgGroupAudienceHelperInterface;
 use Drupal\og\OgMembershipInterface;
 use Drupal\user\UserInterface;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * Tests create membership helper function.
@@ -25,7 +26,7 @@ use Prophecy\Argument;
  */
 class CreateMembershipTest extends UnitTestCase {
 
-  use \Prophecy\PhpUnit\ProphecyTrait;
+  use ProphecyTrait;
 
   /**
    * The entity type manager.

--- a/tests/src/Unit/DefaultRoleEventTest.php
+++ b/tests/src/Unit/DefaultRoleEventTest.php
@@ -10,6 +10,7 @@ use Drupal\Tests\UnitTestCase;
 use Drupal\og\Entity\OgRole;
 use Drupal\og\Event\DefaultRoleEvent;
 use Drupal\og\OgRoleInterface;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * Tests default role events.
@@ -19,7 +20,7 @@ use Drupal\og\OgRoleInterface;
  */
 class DefaultRoleEventTest extends UnitTestCase {
 
-  use \Prophecy\PhpUnit\ProphecyTrait;
+  use ProphecyTrait;
 
   /**
    * The DefaultRoleEvent class, which is the system under test.

--- a/tests/src/Unit/DefaultRoleEventTest.php
+++ b/tests/src/Unit/DefaultRoleEventTest.php
@@ -19,6 +19,8 @@ use Drupal\og\OgRoleInterface;
  */
 class DefaultRoleEventTest extends UnitTestCase {
 
+  use \Prophecy\PhpUnit\ProphecyTrait;
+
   /**
    * The DefaultRoleEvent class, which is the system under test.
    *

--- a/tests/src/Unit/GroupCheckTest.php
+++ b/tests/src/Unit/GroupCheckTest.php
@@ -25,6 +25,8 @@ use Symfony\Component\Routing\Route;
  */
 class GroupCheckTest extends UnitTestCase {
 
+  use \Prophecy\PhpUnit\ProphecyTrait;
+
   /**
    * The entity type manager prophecy used in the test.
    *

--- a/tests/src/Unit/GroupCheckTest.php
+++ b/tests/src/Unit/GroupCheckTest.php
@@ -15,6 +15,7 @@ use Drupal\Tests\UnitTestCase;
 use Drupal\og\Access\GroupCheck;
 use Drupal\og\GroupTypeManagerInterface;
 use Drupal\og\OgAccessInterface;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Symfony\Component\Routing\Route;
 
 /**
@@ -25,7 +26,7 @@ use Symfony\Component\Routing\Route;
  */
 class GroupCheckTest extends UnitTestCase {
 
-  use \Prophecy\PhpUnit\ProphecyTrait;
+  use ProphecyTrait;
 
   /**
    * The entity type manager prophecy used in the test.

--- a/tests/src/Unit/GroupTypeManagerTest.php
+++ b/tests/src/Unit/GroupTypeManagerTest.php
@@ -267,7 +267,7 @@ class GroupTypeManagerTest extends UnitTestCase {
 
     $this->ogRoleManager->createPerBundleRoles('test_entity_new', 'a');
 
-    $this->eventDispatcher->dispatch(GroupCreationEventInterface::EVENT_NAME, Argument::type(GroupCreationEvent::class))
+    $this->eventDispatcher->dispatch(Argument::type(GroupCreationEvent::class), GroupCreationEventInterface::EVENT_NAME)
       ->shouldBeCalled();
 
     // Add a new entity type.

--- a/tests/src/Unit/GroupTypeManagerTest.php
+++ b/tests/src/Unit/GroupTypeManagerTest.php
@@ -32,6 +32,8 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  */
 class GroupTypeManagerTest extends UnitTestCase {
 
+  use \Prophecy\PhpUnit\ProphecyTrait;
+
   /**
    * The config prophecy used in the test.
    *

--- a/tests/src/Unit/GroupTypeManagerTest.php
+++ b/tests/src/Unit/GroupTypeManagerTest.php
@@ -22,6 +22,7 @@ use Drupal\og\OgGroupAudienceHelperInterface;
 use Drupal\og\OgRoleManagerInterface;
 use Drupal\og\PermissionManagerInterface;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -32,7 +33,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  */
 class GroupTypeManagerTest extends UnitTestCase {
 
-  use \Prophecy\PhpUnit\ProphecyTrait;
+  use ProphecyTrait;
 
   /**
    * The config prophecy used in the test.

--- a/tests/src/Unit/OgAccessEntityTestBase.php
+++ b/tests/src/Unit/OgAccessEntityTestBase.php
@@ -19,6 +19,8 @@ use Drupal\og\OgGroupAudienceHelperInterface;
  */
 abstract class OgAccessEntityTestBase extends OgAccessTestBase {
 
+  use \Prophecy\PhpUnit\ProphecyTrait;
+
   /**
    * A test group content entity.
    *

--- a/tests/src/Unit/OgAccessEntityTestBase.php
+++ b/tests/src/Unit/OgAccessEntityTestBase.php
@@ -13,13 +13,14 @@ use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\og\OgGroupAudienceHelperInterface;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * OG access entity base class.
  */
 abstract class OgAccessEntityTestBase extends OgAccessTestBase {
 
-  use \Prophecy\PhpUnit\ProphecyTrait;
+  use ProphecyTrait;
 
   /**
    * A test group content entity.

--- a/tests/src/Unit/OgAccessHookTest.php
+++ b/tests/src/Unit/OgAccessHookTest.php
@@ -13,6 +13,7 @@ use Drupal\Core\Entity\EntityInterface;
  */
 class OgAccessHookTest extends OgAccessEntityTestBase {
 
+  use \Prophecy\PhpUnit\ProphecyTrait;
   /**
    * {@inheritdoc}
    */

--- a/tests/src/Unit/OgAccessHookTest.php
+++ b/tests/src/Unit/OgAccessHookTest.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Drupal\Tests\og\Unit;
 
 use Drupal\Core\Entity\EntityInterface;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * Tests hook implementation of OG related access.
@@ -13,7 +14,8 @@ use Drupal\Core\Entity\EntityInterface;
  */
 class OgAccessHookTest extends OgAccessEntityTestBase {
 
-  use \Prophecy\PhpUnit\ProphecyTrait;
+  use ProphecyTrait;
+
   /**
    * {@inheritdoc}
    */

--- a/tests/src/Unit/OgAccessTestBase.php
+++ b/tests/src/Unit/OgAccessTestBase.php
@@ -23,6 +23,7 @@ use Drupal\og\PermissionManager;
 use Drupal\user\EntityOwnerInterface;
 use Drupal\user\RoleInterface;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -30,7 +31,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  */
 class OgAccessTestBase extends UnitTestCase {
 
-  use \Prophecy\PhpUnit\ProphecyTrait;
+  use ProphecyTrait;
 
   /**
    * The mocked config handler.

--- a/tests/src/Unit/OgAccessTestBase.php
+++ b/tests/src/Unit/OgAccessTestBase.php
@@ -30,6 +30,8 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  */
 class OgAccessTestBase extends UnitTestCase {
 
+  use \Prophecy\PhpUnit\ProphecyTrait;
+
   /**
    * The mocked config handler.
    *

--- a/tests/src/Unit/OgAdminRoutesControllerTest.php
+++ b/tests/src/Unit/OgAdminRoutesControllerTest.php
@@ -25,6 +25,8 @@ use Symfony\Component\Routing\Route;
  */
 class OgAdminRoutesControllerTest extends UnitTestCase {
 
+  use \Prophecy\PhpUnit\ProphecyTrait;
+
   /**
    * The access manager service.
    *

--- a/tests/src/Unit/OgAdminRoutesControllerTest.php
+++ b/tests/src/Unit/OgAdminRoutesControllerTest.php
@@ -161,7 +161,7 @@ class OgAdminRoutesControllerTest extends UnitTestCase {
 
     $this
       ->eventDispatcher
-      ->dispatch(OgAdminRoutesEventInterface::EVENT_NAME, Argument::type(OgAdminRoutesEvent::class))
+      ->dispatch(Argument::type(OgAdminRoutesEvent::class), OgAdminRoutesEventInterface::EVENT_NAME)
       ->willReturn($this->event->reveal())
       ->shouldBeCalled();
 

--- a/tests/src/Unit/OgAdminRoutesControllerTest.php
+++ b/tests/src/Unit/OgAdminRoutesControllerTest.php
@@ -15,6 +15,7 @@ use Drupal\og\Controller\OgAdminRoutesController;
 use Drupal\og\Event\OgAdminRoutesEvent;
 use Drupal\og\Event\OgAdminRoutesEventInterface;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Symfony\Component\Routing\Route;
 
 /**
@@ -25,7 +26,7 @@ use Symfony\Component\Routing\Route;
  */
 class OgAdminRoutesControllerTest extends UnitTestCase {
 
-  use \Prophecy\PhpUnit\ProphecyTrait;
+  use ProphecyTrait;
 
   /**
    * The access manager service.

--- a/tests/src/Unit/OgContextTest.php
+++ b/tests/src/Unit/OgContextTest.php
@@ -16,6 +16,7 @@ use Drupal\og\ContextProvider\OgContext;
 use Drupal\og\OgGroupResolverInterface;
 use Drupal\og\OgResolvedGroupCollectionInterface;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Symfony\Component\DependencyInjection\Container;
 
 /**
@@ -26,7 +27,7 @@ use Symfony\Component\DependencyInjection\Container;
  */
 class OgContextTest extends UnitTestCase {
 
-  use \Prophecy\PhpUnit\ProphecyTrait;
+  use ProphecyTrait;
 
   /**
    * A mocked plugin manager.

--- a/tests/src/Unit/OgContextTest.php
+++ b/tests/src/Unit/OgContextTest.php
@@ -26,6 +26,8 @@ use Symfony\Component\DependencyInjection\Container;
  */
 class OgContextTest extends UnitTestCase {
 
+  use \Prophecy\PhpUnit\ProphecyTrait;
+
   /**
    * A mocked plugin manager.
    *

--- a/tests/src/Unit/OgLocalTaskTest.php
+++ b/tests/src/Unit/OgLocalTaskTest.php
@@ -9,6 +9,7 @@ use Drupal\Core\Routing\RouteProvider;
 use Drupal\Tests\UnitTestCase;
 use Drupal\og\GroupTypeManagerInterface;
 use Drupal\og\Plugin\Derivative\OgLocalTask;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Symfony\Component\Routing\Route;
 
 /**
@@ -21,7 +22,7 @@ use Symfony\Component\Routing\Route;
  */
 class OgLocalTaskTest extends UnitTestCase {
 
-  use \Prophecy\PhpUnit\ProphecyTrait;
+  use ProphecyTrait;
 
   /**
    * The group type manager.

--- a/tests/src/Unit/OgLocalTaskTest.php
+++ b/tests/src/Unit/OgLocalTaskTest.php
@@ -21,6 +21,8 @@ use Symfony\Component\Routing\Route;
  */
 class OgLocalTaskTest extends UnitTestCase {
 
+  use \Prophecy\PhpUnit\ProphecyTrait;
+
   /**
    * The group type manager.
    *

--- a/tests/src/Unit/OgResolvedGroupCollectionTest.php
+++ b/tests/src/Unit/OgResolvedGroupCollectionTest.php
@@ -16,6 +16,8 @@ use Drupal\og\OgResolvedGroupCollection;
  */
 class OgResolvedGroupCollectionTest extends UnitTestCase {
 
+  use \Prophecy\PhpUnit\ProphecyTrait;
+
   /**
    * An array of mocked test groups, keyed by entity type ID and entity ID.
    *

--- a/tests/src/Unit/OgResolvedGroupCollectionTest.php
+++ b/tests/src/Unit/OgResolvedGroupCollectionTest.php
@@ -7,6 +7,7 @@ namespace Drupal\Tests\og\Unit;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Tests\UnitTestCase;
 use Drupal\og\OgResolvedGroupCollection;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * Tests the collecting of resolved groups to pass as a route context.
@@ -16,7 +17,7 @@ use Drupal\og\OgResolvedGroupCollection;
  */
 class OgResolvedGroupCollectionTest extends UnitTestCase {
 
-  use \Prophecy\PhpUnit\ProphecyTrait;
+  use ProphecyTrait;
 
   /**
    * An array of mocked test groups, keyed by entity type ID and entity ID.

--- a/tests/src/Unit/OgRoleManagerTest.php
+++ b/tests/src/Unit/OgRoleManagerTest.php
@@ -21,6 +21,8 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  */
 class OgRoleManagerTest extends UnitTestCase {
 
+  use \Prophecy\PhpUnit\ProphecyTrait;
+
   /**
    * The entity type ID of the test group.
    *

--- a/tests/src/Unit/OgRoleManagerTest.php
+++ b/tests/src/Unit/OgRoleManagerTest.php
@@ -6,11 +6,14 @@ namespace Drupal\Tests\og\Unit;
 
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\og\Event\DefaultRoleEvent;
+use Drupal\og\Event\DefaultRoleEventInterface;
 use Drupal\Tests\UnitTestCase;
 use Drupal\og\Entity\OgRole;
 use Drupal\og\OgRoleInterface;
 use Drupal\og\OgRoleManager;
 use Drupal\og\PermissionManagerInterface;
+use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -231,6 +234,11 @@ class OgRoleManagerTest extends UnitTestCase {
    *   The initialized OG role manager.
    */
   protected function getOgRoleManager() {
+    $this->eventDispatcher
+      ->dispatch(
+        Argument::type(DefaultRoleEvent::class),
+        DefaultRoleEventInterface::EVENT_NAME,
+      )->willReturnArgument();
     return new OgRoleManager(
       $this->entityTypeManager->reveal(),
       $this->eventDispatcher->reveal(),

--- a/tests/src/Unit/OgRoleManagerTest.php
+++ b/tests/src/Unit/OgRoleManagerTest.php
@@ -11,6 +11,7 @@ use Drupal\og\Entity\OgRole;
 use Drupal\og\OgRoleInterface;
 use Drupal\og\OgRoleManager;
 use Drupal\og\PermissionManagerInterface;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -21,7 +22,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  */
 class OgRoleManagerTest extends UnitTestCase {
 
-  use \Prophecy\PhpUnit\ProphecyTrait;
+  use ProphecyTrait;
 
   /**
    * The entity type ID of the test group.

--- a/tests/src/Unit/Plugin/OgGroupResolver/OgGroupResolverTestBase.php
+++ b/tests/src/Unit/Plugin/OgGroupResolver/OgGroupResolverTestBase.php
@@ -10,6 +10,7 @@ use Drupal\Tests\UnitTestCase;
 use Drupal\og\GroupTypeManagerInterface;
 use Drupal\og\MembershipManagerInterface;
 use Drupal\og\OgGroupAudienceHelperInterface;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * Base class for testing OgGroupResolver plugins.
@@ -18,7 +19,7 @@ use Drupal\og\OgGroupAudienceHelperInterface;
  */
 abstract class OgGroupResolverTestBase extends UnitTestCase {
 
-  use \Prophecy\PhpUnit\ProphecyTrait;
+  use ProphecyTrait;
 
   /**
    * The fully qualified class name of the plugin under test.

--- a/tests/src/Unit/Plugin/OgGroupResolver/OgGroupResolverTestBase.php
+++ b/tests/src/Unit/Plugin/OgGroupResolver/OgGroupResolverTestBase.php
@@ -18,6 +18,8 @@ use Drupal\og\OgGroupAudienceHelperInterface;
  */
 abstract class OgGroupResolverTestBase extends UnitTestCase {
 
+  use \Prophecy\PhpUnit\ProphecyTrait;
+
   /**
    * The fully qualified class name of the plugin under test.
    *
@@ -118,6 +120,7 @@ abstract class OgGroupResolverTestBase extends UnitTestCase {
    *
    * @dataProvider resolveProvider
    * @covers ::resolve()
+   * @doesNotPerformAssertions
    */
   abstract public function testResolve();
 

--- a/tests/src/Unit/Plugin/OgGroupResolver/OgRouteGroupResolverTestBase.php
+++ b/tests/src/Unit/Plugin/OgGroupResolver/OgRouteGroupResolverTestBase.php
@@ -15,6 +15,8 @@ use Symfony\Component\Routing\Route;
  */
 abstract class OgRouteGroupResolverTestBase extends OgGroupResolverTestBase {
 
+  use \Prophecy\PhpUnit\ProphecyTrait;
+
   /**
    * A list of link templates that belong to entity types used in the tests.
    *

--- a/tests/src/Unit/Plugin/OgGroupResolver/OgRouteGroupResolverTestBase.php
+++ b/tests/src/Unit/Plugin/OgGroupResolver/OgRouteGroupResolverTestBase.php
@@ -8,6 +8,7 @@ use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\og\OgResolvedGroupCollectionInterface;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Symfony\Component\Routing\Route;
 
 /**
@@ -15,7 +16,7 @@ use Symfony\Component\Routing\Route;
  */
 abstract class OgRouteGroupResolverTestBase extends OgGroupResolverTestBase {
 
-  use \Prophecy\PhpUnit\ProphecyTrait;
+  use ProphecyTrait;
 
   /**
    * A list of link templates that belong to entity types used in the tests.

--- a/tests/src/Unit/Plugin/OgGroupResolver/RequestQueryArgumentResolverTest.php
+++ b/tests/src/Unit/Plugin/OgGroupResolver/RequestQueryArgumentResolverTest.php
@@ -7,6 +7,7 @@ namespace Drupal\Tests\og\Unit\Plugin\OgGroupResolver;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\og\OgResolvedGroupCollectionInterface;
 use Drupal\og\Plugin\OgGroupResolver\RequestQueryArgumentResolver;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -19,7 +20,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
  */
 class RequestQueryArgumentResolverTest extends OgGroupResolverTestBase {
 
-  use \Prophecy\PhpUnit\ProphecyTrait;
+  use ProphecyTrait;
 
   /**
    * {@inheritdoc}

--- a/tests/src/Unit/Plugin/OgGroupResolver/RequestQueryArgumentResolverTest.php
+++ b/tests/src/Unit/Plugin/OgGroupResolver/RequestQueryArgumentResolverTest.php
@@ -19,6 +19,8 @@ use Symfony\Component\HttpFoundation\RequestStack;
  */
 class RequestQueryArgumentResolverTest extends OgGroupResolverTestBase {
 
+  use \Prophecy\PhpUnit\ProphecyTrait;
+
   /**
    * {@inheritdoc}
    */

--- a/tests/src/Unit/Plugin/OgGroupResolver/RouteGroupResolverTest.php
+++ b/tests/src/Unit/Plugin/OgGroupResolver/RouteGroupResolverTest.php
@@ -6,6 +6,7 @@ namespace Drupal\Tests\og\Unit\Plugin\OgGroupResolver;
 
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\og\Plugin\OgGroupResolver\RouteGroupResolver;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * Tests the RouteGroupResolver plugin.
@@ -15,7 +16,7 @@ use Drupal\og\Plugin\OgGroupResolver\RouteGroupResolver;
  */
 class RouteGroupResolverTest extends OgRouteGroupResolverTestBase {
 
-  use \Prophecy\PhpUnit\ProphecyTrait;
+  use ProphecyTrait;
 
   /**
    * {@inheritdoc}

--- a/tests/src/Unit/Plugin/OgGroupResolver/RouteGroupResolverTest.php
+++ b/tests/src/Unit/Plugin/OgGroupResolver/RouteGroupResolverTest.php
@@ -15,6 +15,8 @@ use Drupal\og\Plugin\OgGroupResolver\RouteGroupResolver;
  */
 class RouteGroupResolverTest extends OgRouteGroupResolverTestBase {
 
+  use \Prophecy\PhpUnit\ProphecyTrait;
+
   /**
    * {@inheritdoc}
    */

--- a/tests/src/Unit/Plugin/OgGroupResolver/UserGroupAccessResolverTest.php
+++ b/tests/src/Unit/Plugin/OgGroupResolver/UserGroupAccessResolverTest.php
@@ -6,6 +6,7 @@ namespace Drupal\Tests\og\Unit\Plugin\OgGroupResolver;
 
 use Drupal\og\OgResolvedGroupCollectionInterface;
 use Drupal\og\Plugin\OgGroupResolver\UserGroupAccessResolver;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * Tests the UserGroupAccessResolver plugin.
@@ -15,7 +16,7 @@ use Drupal\og\Plugin\OgGroupResolver\UserGroupAccessResolver;
  */
 class UserGroupAccessResolverTest extends OgGroupResolverTestBase {
 
-  use \Prophecy\PhpUnit\ProphecyTrait;
+  use ProphecyTrait;
 
   /**
    * {@inheritdoc}

--- a/tests/src/Unit/Plugin/OgGroupResolver/UserGroupAccessResolverTest.php
+++ b/tests/src/Unit/Plugin/OgGroupResolver/UserGroupAccessResolverTest.php
@@ -15,6 +15,8 @@ use Drupal\og\Plugin\OgGroupResolver\UserGroupAccessResolver;
  */
 class UserGroupAccessResolverTest extends OgGroupResolverTestBase {
 
+  use \Prophecy\PhpUnit\ProphecyTrait;
+
   /**
    * {@inheritdoc}
    */

--- a/tests/src/Unit/SubscriptionControllerTest.php
+++ b/tests/src/Unit/SubscriptionControllerTest.php
@@ -27,6 +27,8 @@ use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
  */
 class SubscriptionControllerTest extends UnitTestCase {
 
+  use \Prophecy\PhpUnit\ProphecyTrait;
+
   /**
    * The entity for builder object.
    *

--- a/tests/src/Unit/SubscriptionControllerTest.php
+++ b/tests/src/Unit/SubscriptionControllerTest.php
@@ -17,6 +17,7 @@ use Drupal\og\MembershipManagerInterface;
 use Drupal\og\OgAccessInterface;
 use Drupal\og\OgMembershipInterface;
 use Drupal\user\EntityOwnerInterface;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 /**
@@ -27,7 +28,7 @@ use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
  */
 class SubscriptionControllerTest extends UnitTestCase {
 
-  use \Prophecy\PhpUnit\ProphecyTrait;
+  use ProphecyTrait;
 
   /**
    * The entity for builder object.


### PR DESCRIPTION
## Review notes

* I've added `::accessCheck()` to all entity queries (see https://www.drupal.org/node/3201242) without any argument, meaning the _access is checked_. I did this in order to preserve the current code behavior. However, I'm not sure that this is correct for all the cases. It's not in the scope of this PR to fix potential cases where the entity query should bypass the current user access constraint. The module maintainer should carefully review each case and fix potential cases in a followup.
* See the hack and the comment I've added in `OgRole::calculateDependencies()`. The module maintainer should weight on the `@todo` and, potentially, handle that in a followup.