### PR TITLE
[Drupal 10.2] Using a translatable string as a category for field type is deprecated

### DIFF
--- a/og.field_type_categories.yml
+++ b/og.field_type_categories.yml
@@ -1,3 +1,3 @@
 og:
   label: Organic groups
-  description: Organic group fields
+  description: Organic groups fields

--- a/og.field_type_categories.yml
+++ b/og.field_type_categories.yml
@@ -1,0 +1,3 @@
+og:
+  label: Organic groups
+  description: Organic group fields

--- a/src/Plugin/Field/FieldType/OgGroupItem.php
+++ b/src/Plugin/Field/FieldType/OgGroupItem.php
@@ -19,7 +19,7 @@ use Drupal\Core\TypedData\DataDefinition;
  *   id = "og_group",
  *   label = @Translation("OG Group"),
  *   description = @Translation("allow non-groups members, members, and group managers to join, request or leave a group"),
- *   category = @Translation("OG"),
+ *   category = "og",
  *   no_ui = TRUE,
  *   default_formatter = "og_group_subscribe",
  * )

--- a/src/Plugin/Field/FieldType/OgStandardReferenceItem.php
+++ b/src/Plugin/Field/FieldType/OgStandardReferenceItem.php
@@ -13,7 +13,7 @@ use Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem;
  *   id = "og_standard_reference",
  *   label = @Translation("OG membership reference"),
  *   description = @Translation("An entity field containing an OG membership reference for a non-user entity."),
- *   category = @Translation("Reference"),
+ *   category = "reference",
  *   no_ui = TRUE,
  *   default_widget = "og_complex",
  *   default_formatter = "entity_reference_label",


### PR DESCRIPTION
See https://www.drupal.org/node/3375748